### PR TITLE
feat: improve generator imports

### DIFF
--- a/src/generation/generators/daoGenerator.ts
+++ b/src/generation/generators/daoGenerator.ts
@@ -12,21 +12,11 @@ export class TsTypettaDAOGenerator extends TsTypettaAbstractGenerator {
     const mongoSources = [...new Set([...typesMap.values()].flatMap((type) => (type.entity?.type === 'mongo' ? [type.entity.source] : [])))]
     const hasMongoDBEntites = mongoSources.length > 0
 
-    const knexImports = [`import { KnexJsDAOGenerics, KnexJsDAOParams, AbstractKnexJsDAO } from '${this._config.typettaImport || '@twinlogix/typetta'}'`, "import { Knex } from 'knex'"]
+    const knexImports = "import { Knex } from 'knex'"
+    const mongodbImports = "import * as M from 'mongodb'"
+    const commonImports = [`import * as T from '${this._config.typettaImport || '@twinlogix/typetta'}'`, `import * as types from '${this._config.tsTypesImport || '@twinlogix/typetta'}'`]
 
-    const mongodbImports = [
-      `import { MongoDBDAOGenerics, MongoDBDAOParams, AbstractMongoDBDAO } from '${this._config.typettaImport || '@twinlogix/typetta'}'`,
-      "import { Collection, Db, Filter, Sort, UpdateFilter, Document } from 'mongodb'",
-    ]
-
-    const commonImports = [
-      `import { DAOMiddleware, Coordinates, UserInputDriverDataTypeAdapterMap, Schema, AbstractDAOContext, LogicalOperators, QuantityOperators, EqualityOperators, StringOperators, ElementOperators, OneKey, SortDirection, overrideRelations, userInputDataTypeAdapterToDataTypeAdapter, LogFunction, LogInput, logInputToLogger, ParamProjection, DAOGenerics, CRUDPermission, DAOContextSecurtyPolicy, createSecurityPolicyMiddlewares, SelectProjection, mergeProjections, AbstractInMemoryDAO, InMemoryDAOGenerics, InMemoryDAOParams } from '${
-        this._config.typettaImport || '@twinlogix/typetta'
-      }'`,
-      `import * as types from '${this._config.tsTypesImport || '@twinlogix/typetta'}'`,
-    ]
-
-    return [...commonImports, ...(hasSQLEntities ? knexImports : []), ...(hasMongoDBEntites ? mongodbImports : [])]
+    return [...commonImports, ...(hasSQLEntities ? [knexImports] : []), ...(hasMongoDBEntites ? [mongodbImports] : [])]
   }
 
   public generateDefinition(node: TsTypettaGeneratorNode, typesMap: Map<string, TsTypettaGeneratorNode>, customScalarsMap: Map<string, TsTypettaGeneratorScalar>): string {
@@ -58,7 +48,7 @@ export class TsTypettaDAOGenerator extends TsTypettaAbstractGenerator {
     const sqlSourcesLiteral = sqlSources.map((v) => `'${v}'`).join(' | ')
     const mongoSourcesLiteral = mongoSources.map((v) => `'${v}'`).join(' | ')
     const sqlSourcesType = `Record<${sqlSourcesLiteral}, Knex | 'mock'>`
-    const mongoSourcesType = `Record<${mongoSourcesLiteral}, Db | 'mock'>`
+    const mongoSourcesType = `Record<${mongoSourcesLiteral}, M.Db | 'mock'>`
     const daoNamesType = Array.from(typesMap.values())
       .filter((node) => node.entity)
       .map((node) => `'${toFirstLower(node.name)}'`)
@@ -77,9 +67,9 @@ export class TsTypettaDAOGenerator extends TsTypettaAbstractGenerator {
     const overrides = `\noverrides?: { \n${indentMultiline(contextDAOParamsDeclarations)}\n}`
     const mongoDBParams = hasMongoDBEntites ? `,\nmongodb: ${mongoSourcesType}` : ''
     const knexJsParams = hasSQLEntities ? `,\nknex: ${sqlSourcesType}` : ''
-    const adaptersParams = `,\nscalars?: UserInputDriverDataTypeAdapterMap<types.Scalars, '${hasMongoDBEntites && hasSQLEntities ? 'both' : hasMongoDBEntites ? 'mongo' : 'knex'}'>`
-    const loggerParams = `,\nlog?: LogInput<${daoNamesType}>`
-    const securityPolicyParam = ',\nsecurity?: DAOContextSecurtyPolicy<DAOGenericsMap<MetadataType, OperationMetadataType>, OperationMetadataType, Permissions, SecurityDomain>'
+    const adaptersParams = `,\nscalars?: T.UserInputDriverDataTypeAdapterMap<types.Scalars, '${hasMongoDBEntites && hasSQLEntities ? 'both' : hasMongoDBEntites ? 'mongo' : 'knex'}'>`
+    const loggerParams = `,\nlog?: T.LogInput<${daoNamesType}>`
+    const securityPolicyParam = ',\nsecurity?: T.DAOContextSecurtyPolicy<DAOGenericsMap<MetadataType, OperationMetadataType>, OperationMetadataType, Permissions, SecurityDomain>'
     const dbsInputParam =
       hasMongoDBEntites && hasSQLEntities
         ? `mongodb: ${mongoSourcesType}, knex: ${sqlSourcesType}`
@@ -92,7 +82,7 @@ export class TsTypettaDAOGenerator extends TsTypettaAbstractGenerator {
     const entitiesInputParam = Array.from(typesMap.values())
       .flatMap((node) => {
         return node.entity?.type === 'mongo'
-          ? [`${toFirstLower(node.name)}: Collection<Document> | null`]
+          ? [`${toFirstLower(node.name)}: M.Collection<M.Document> | null`]
           : node.entity?.type === 'sql'
           ? [`${toFirstLower(node.name)}: Knex.QueryBuilder<any, unknown[]> | null`]
           : []
@@ -138,7 +128,7 @@ export type DAOContextParams<MetadataType, OperationMetadataType, Permissions ex
     const knexJsFields = hasSQLEntities ? `\nprivate knex: ${sqlSourcesType}` : ''
     const overridesDeclaration = `private overrides: DAOContextParams<MetadataType, OperationMetadataType, Permissions, SecurityDomain>['overrides']${mongoDBFields}${knexJsFields}`
     const middlewareDeclaration = 'private middlewares: (DAOContextMiddleware<MetadataType, OperationMetadataType> | GroupMiddleware<any, MetadataType, OperationMetadataType>)[]'
-    const loggerDeclaration = `private logger?: LogFunction<${daoNamesType}>`
+    const loggerDeclaration = `private logger?: T.LogFunction<${daoNamesType}>`
     const paramsDeclaration = `private params: DAOContextParams<MetadataType, OperationMetadataType, Permissions, SecurityDomain>`
 
     const daoGetters = Array.from(typesMap.values())
@@ -149,7 +139,7 @@ export type DAOContextParams<MetadataType, OperationMetadataType, Permissions ex
           node.entity?.type === 'sql' ? `, knex: db, tableName: '${node.entity?.table}'` : node.entity?.type === 'mongo' ? `, collection: db.collection('${node.entity?.collection}')` : ''
         const daoMiddlewareInit = `, middlewares: [...(this.overrides?.${toFirstLower(node.name)}?.middlewares || []), ...selectMiddleware('${toFirstLower(
           node.name,
-        )}', this.middlewares) as DAOMiddleware<${node.name}DAOGenerics<MetadataType, OperationMetadataType>>[]]`
+        )}', this.middlewares) as T.DAOMiddleware<${node.name}DAOGenerics<MetadataType, OperationMetadataType>>[]]`
         const normalDaoInstance = `new ${node.name}DAO({ daoContext: this, datasource: ${datasource}, metadata: this.metadata, ...this.overrides?.${toFirstLower(
           node.name,
         )}${daoImplementationInit}${daoMiddlewareInit}, name: '${toFirstLower(node.name)}', logger: this.logger })`
@@ -172,11 +162,11 @@ export type DAOContextParams<MetadataType, OperationMetadataType, Permissions ex
     const daoConstructor =
       'constructor(params: DAOContextParams<MetadataType, OperationMetadataType, Permissions, SecurityDomain>) {\n' +
       indentMultiline(
-        `super({\n  ...params,\n  scalars: params.scalars ? userInputDataTypeAdapterToDataTypeAdapter(params.scalars, [${scalarsNameList.map((v) => `'${v}'`).join(', ')}]) : undefined\n})
+        `super({\n  ...params,\n  scalars: params.scalars ? T.userInputDataTypeAdapterToDataTypeAdapter(params.scalars, [${scalarsNameList.map((v) => `'${v}'`).join(', ')}]) : undefined\n})
 this.overrides = params.overrides${mongoDBConstructor}${knexJsContsructor}\nthis.middlewares = params.middlewares || []
-this.logger = logInputToLogger(params.log)
+this.logger = T.logInputToLogger(params.log)
 if(params.security && params.security.applySecurity !== false) {
-  const securityMiddlewares = createSecurityPolicyMiddlewares(params.security)
+  const securityMiddlewares = T.createSecurityPolicyMiddlewares(params.security)
   const defaultMiddleware = securityMiddlewares.others ? [groupMiddleware.excludes(Object.fromEntries(Object.keys(securityMiddlewares.middlewares).map(k => [k, true])) as any, securityMiddlewares.others as any)] : []
   this.middlewares = [...(params.middlewares ?? []), ...defaultMiddleware, ...Object.entries(securityMiddlewares.middlewares).map(([name, middleware]) => groupMiddleware.includes({[name]: true} as any, middleware as any))]
 }
@@ -187,13 +177,13 @@ this.params = params`,
     const declarations = [daoDeclarations, paramsDeclaration, overridesDeclaration, middlewareDeclaration, loggerDeclaration, daoGetters, daoConstructor, execQueryF, cloneF, createTableF].join('\n\n')
 
     const daoExport =
-      `export class DAOContext<MetadataType = never, OperationMetadataType = never, Permissions extends string = never, SecurityDomain extends object = never> extends AbstractDAOContext<${
+      `export class DAOContext<MetadataType = never, OperationMetadataType = never, Permissions extends string = never, SecurityDomain extends object = never> extends T.AbstractDAOContext<${
         mongoSourcesLiteral || 'never'
       }, ${sqlSourcesLiteral || 'never'}, types.Scalars, MetadataType>  {\n\n` +
       indentMultiline(declarations) +
       '\n\n}'
 
-    const daoContextMiddleware = `type DAOContextMiddleware<MetadataType = never, OperationMetadataType = never> = DAOMiddleware<DAOGenericsUnion<MetadataType, OperationMetadataType>>`
+    const daoContextMiddleware = `type DAOContextMiddleware<MetadataType = never, OperationMetadataType = never> = T.DAOMiddleware<DAOGenericsUnion<MetadataType, OperationMetadataType>>`
 
     const utilsCode = `
 //--------------------------------------------------------------------------------
@@ -213,16 +203,16 @@ type GroupMiddleware<N extends DAOName, MetadataType, OperationMetadataType> =
   | ExcludeGroupMiddleware<N, MetadataType, OperationMetadataType>
 type IncludeGroupMiddleware<N extends DAOName, MetadataType, OperationMetadataType> = {
   include: { [K in N]: true }
-  middleware: DAOMiddleware<DAOGenericsMap<MetadataType, OperationMetadataType>[N]>
+  middleware: T.DAOMiddleware<DAOGenericsMap<MetadataType, OperationMetadataType>[N]>
 }
 type ExcludeGroupMiddleware<N extends DAOName, MetadataType, OperationMetadataType> = {
   exclude: { [K in N]: true }
-  middleware: DAOMiddleware<DAOGenericsMap<MetadataType, OperationMetadataType>[Exclude<DAOName, N>]>
+  middleware: T.DAOMiddleware<DAOGenericsMap<MetadataType, OperationMetadataType>[Exclude<DAOName, N>]>
 }
 export const groupMiddleware = {
   includes<N extends DAOName, MetadataType, OperationMetadataType>(
     include: { [K in N]: true },
-    middleware: DAOMiddleware<DAOGenericsMap<MetadataType, OperationMetadataType>[N]>,
+    middleware: T.DAOMiddleware<DAOGenericsMap<MetadataType, OperationMetadataType>[N]>,
   ): IncludeGroupMiddleware<N, MetadataType, OperationMetadataType> {
     return { include, middleware }
   },
@@ -277,7 +267,7 @@ function selectMiddleware<MetadataType, OperationMetadataType>(
 
   public _generateDAOSchema(node: TsTypettaGeneratorNode, typesMap: Map<string, TsTypettaGeneratorNode>): string {
     const daoSchemaBody = indentMultiline(this._generateDAOSchemaFields(node, typesMap).join(',\n'))
-    const daoSchema = `export function ${toFirstLower(node.name)}Schema(): Schema<types.Scalars> {\n  return {\n` + daoSchemaBody + `\n  }\n}`
+    const daoSchema = `export function ${toFirstLower(node.name)}Schema(): T.Schema<types.Scalars> {\n  return {\n` + daoSchemaBody + `\n  }\n}`
     return daoSchema
   }
 
@@ -306,9 +296,9 @@ function selectMiddleware<MetadataType, OperationMetadataType>(
     const daoFilterFieldsBody = indentMultiline(this._generateDAOFilterFields(node, typesMap, customScalarsMap).join(',\n'))
     const daoFilterFields = `type ${node.name}FilterFields = {\n` + daoFilterFieldsBody + `\n}`
     const daoRawFilter = `export type ${node.name}RawFilter = ${
-      node.entity?.type === 'mongo' ? '() => Filter<Document>' : node.entity?.type === 'sql' ? '(builder: Knex.QueryBuilder<any, any>) => Knex.QueryBuilder<any, any>' : 'never'
+      node.entity?.type === 'mongo' ? '() => M.Filter<M.Document>' : node.entity?.type === 'sql' ? '(builder: Knex.QueryBuilder<any, any>) => Knex.QueryBuilder<any, any>' : 'never'
     }`
-    const daoFilter = `export type ${node.name}Filter = ${node.name}FilterFields & LogicalOperators<${node.name}FilterFields | ${node.name}RawFilter>`
+    const daoFilter = `export type ${node.name}Filter = ${node.name}FilterFields & T.LogicalOperators<${node.name}FilterFields | ${node.name}RawFilter>`
 
     return [daoFilterFields, daoFilter, daoRawFilter].join('\n')
   }
@@ -322,9 +312,9 @@ function selectMiddleware<MetadataType, OperationMetadataType>(
           fieldName += field.name
           const baseType = field.isEnum ? `types.${field.graphqlType}` : `types.Scalars['${field.graphqlType}']`
           const fieldType = field.isList ? `${baseType}[]` : baseType
-          const quantityOperators = field.graphqlType === 'Int' || field.graphqlType === 'Float' || customScalarsMap.get(field.graphqlType)?.isQuantity ? ` | QuantityOperators<${fieldType}>` : ''
-          const stringOperators = field.graphqlType === 'String' || customScalarsMap.get(field.graphqlType)?.isString || field.isEnum ? ` | StringOperators` : ''
-          return [`'${fieldName}'?: ${fieldType} | null | EqualityOperators<${fieldType}> | ElementOperators` + stringOperators + quantityOperators]
+          const quantityOperators = field.graphqlType === 'Int' || field.graphqlType === 'Float' || customScalarsMap.get(field.graphqlType)?.isQuantity ? ` | T.QuantityOperators<${fieldType}>` : ''
+          const stringOperators = field.graphqlType === 'String' || customScalarsMap.get(field.graphqlType)?.isString || field.isEnum ? ` | T.StringOperators` : ''
+          return [`'${fieldName}'?: ${fieldType} | null | T.EqualityOperators<${fieldType}> | T.ElementOperators` + stringOperators + quantityOperators]
         } else if (field.type.kind === 'embedded') {
           const embeddedType = getNode(field.type.embed, typesMap)
           return this._generateDAOFilterFields(embeddedType, typesMap, customScalarsMap, path + field.name + '.')
@@ -360,7 +350,7 @@ function selectMiddleware<MetadataType, OperationMetadataType>(
   public _generateDAOProjection(node: TsTypettaGeneratorNode, typesMap: Map<string, TsTypettaGeneratorNode>): string {
     const daoProjectionBody = indentMultiline(this._generateDAOProjectionFields(node, typesMap))
     const daoProjection = `export type ${node.name}Projection = {\n` + daoProjectionBody + `\n}`
-    const daoParams = `export type ${node.name}Param<P extends ${node.name}Projection> = ParamProjection<types.${node.name}, ${node.name}Projection, P>`
+    const daoParams = `export type ${node.name}Param<P extends ${node.name}Projection> = T.ParamProjection<types.${node.name}, ${node.name}Projection, P>`
     return [daoProjection, daoParams].join('\n')
   }
 
@@ -393,9 +383,9 @@ function selectMiddleware<MetadataType, OperationMetadataType>(
   public _generateDAOSort(node: TsTypettaGeneratorNode, typesMap: Map<string, TsTypettaGeneratorNode>): string {
     const daoSortFields = this._generateDAOSortFields(node, typesMap).join(' | ')
     const daoSortKeys = `export type ${node.name}SortKeys = ${daoSortFields}`
-    const daoSort = `export type ${node.name}Sort = OneKey<${node.name}SortKeys, SortDirection>`
+    const daoSort = `export type ${node.name}Sort = T.OneKey<${node.name}SortKeys, T.SortDirection>`
     const daoRawSort = `export type ${node.name}RawSort = ${
-      node.entity?.type === 'mongo' ? '() => Sort' : node.entity?.type === 'sql' ? '(builder: Knex.QueryBuilder<any, any>) => Knex.QueryBuilder<any, any>' : 'never'
+      node.entity?.type === 'mongo' ? '() => M.Sort' : node.entity?.type === 'sql' ? '(builder: Knex.QueryBuilder<any, any>) => Knex.QueryBuilder<any, any>' : 'never'
     }`
     return `${daoSortKeys}\n${daoSort}\n${daoRawSort}`
   }
@@ -424,7 +414,7 @@ function selectMiddleware<MetadataType, OperationMetadataType>(
   public _generateDAOUpdate(node: TsTypettaGeneratorNode, typesMap: Map<string, TsTypettaGeneratorNode>): string {
     const daoUpdateFieldsBody = indentMultiline(this._generateDAOUpdateFields(node, typesMap).join(',\n'))
     const daoRawUpdate = `export type ${node.name}RawUpdate = ${
-      node.entity?.type === 'mongo' ? '() => UpdateFilter<Document>' : node.entity?.type === 'sql' ? '(builder: Knex.QueryBuilder<any, any>) => Knex.QueryBuilder<any, any>' : 'never'
+      node.entity?.type === 'mongo' ? '() => M.UpdateFilter<M.Document>' : node.entity?.type === 'sql' ? '(builder: Knex.QueryBuilder<any, any>) => Knex.QueryBuilder<any, any>' : 'never'
     }`
     const daoUpdate = `export type ${node.name}Update = {\n` + daoUpdateFieldsBody + `\n}`
     return [daoUpdate, daoRawUpdate].join('\n')
@@ -491,8 +481,9 @@ function selectMiddleware<MetadataType, OperationMetadataType>(
   public _generateDAOParams(node: TsTypettaGeneratorNode): string {
     const idField = getID(node)
     const dbDAOGenerics =
-      node.entity?.type === 'sql' ? 'KnexJsDAOGenerics' : node.entity?.type === 'mongo' ? 'MongoDBDAOGenerics' : node.entity?.type === 'memory' ? 'InMemoryDAOGenerics' : 'DAOGenerics'
-    const dbDAOParams = node.entity?.type === 'sql' ? 'KnexJsDAOParams' : node.entity?.type === 'mongo' ? 'MongoDBDAOParams' : node.entity?.type === 'memory' ? 'InMemoryDAOParams' : 'DAOParams'
+      node.entity?.type === 'sql' ? 'T.KnexJsDAOGenerics' : node.entity?.type === 'mongo' ? 'T.MongoDBDAOGenerics' : node.entity?.type === 'memory' ? 'T.InMemoryDAOGenerics' : 'T.DAOGenerics'
+    const dbDAOParams =
+      node.entity?.type === 'sql' ? 'T.KnexJsDAOParams' : node.entity?.type === 'mongo' ? 'T.MongoDBDAOParams' : node.entity?.type === 'memory' ? 'T.InMemoryDAOParams' : 'T.DAOParams'
     const daoGenerics = `type ${node.name}DAOGenerics<MetadataType, OperationMetadataType> = ${dbDAOGenerics}<types.${node.name}, '${idField.name}', '${
       idField.isEnum ? 'String' : idField.graphqlType
     }', ${node.name}Filter, ${node.name}RawFilter, ${node.name}Relations, ${node.name}Projection, ${node.name}Sort, ${node.name}RawSort, ${node.name}Insert, ${node.name}Update, ${
@@ -503,7 +494,9 @@ function selectMiddleware<MetadataType, OperationMetadataType>(
     const daoParams = `export type ${node.name}DAOParams<MetadataType, OperationMetadataType> = Omit<${dbDAOParams}<${node.name}DAOGenerics<MetadataType, OperationMetadataType>>, ${
       node.fields.find((f) => f.isID)?.idGenerationStrategy !== 'generator' ? "'idGenerator' | " : ''
     }'idField' | 'schema' | 'idScalar' | 'idGeneration'>`
-    const inMemoryDaoParams = `export type InMemory${node.name}DAOParams<MetadataType, OperationMetadataType> = Omit<InMemoryDAOParams<${node.name}DAOGenerics<MetadataType, OperationMetadataType>>, ${
+    const inMemoryDaoParams = `export type InMemory${node.name}DAOParams<MetadataType, OperationMetadataType> = Omit<T.InMemoryDAOParams<${
+      node.name
+    }DAOGenerics<MetadataType, OperationMetadataType>>, ${
       node.fields.find((f) => f.isID)?.idGenerationStrategy !== 'generator' ? "'idGenerator' | " : ''
     }'idField' | 'schema' | 'idScalar' | 'idGeneration'>`
     return [daoGenerics, daoParams, inMemoryDaoParams].join('\n')
@@ -514,19 +507,20 @@ function selectMiddleware<MetadataType, OperationMetadataType>(
   // ---------------------------------------------------------------------------------------------------------
 
   public _generateDAO(node: TsTypettaGeneratorNode, typesMap: Map<string, TsTypettaGeneratorNode>): string {
-    const daoName = node.entity?.type === 'sql' ? 'AbstractKnexJsDAO' : node.entity?.type === 'mongo' ? 'AbstractMongoDBDAO' : node.entity?.type === 'memory' ? 'AbstractInMemoryDAO' : 'AbstractDAO'
+    const daoName =
+      node.entity?.type === 'sql' ? 'T.AbstractKnexJsDAO' : node.entity?.type === 'mongo' ? 'T.AbstractMongoDBDAO' : node.entity?.type === 'memory' ? 'T.AbstractInMemoryDAO' : 'AbstractDAO'
     const daoBody = indentMultiline('\n' + this._generateConstructorMethod(node, typesMap, `${node.name}DAOParams`) + '\n')
     const daoBodyInMemory = indentMultiline('\n' + this._generateConstructorMethod(node, typesMap, `InMemory${node.name}DAOParams`) + '\n')
     return [
       `export class ${node.name}DAO<MetadataType, OperationMetadataType> extends ${daoName}<${node.name}DAOGenerics<MetadataType, OperationMetadataType>> {${daoBody}}`,
-      `export class InMemory${node.name}DAO<MetadataType, OperationMetadataType> extends AbstractInMemoryDAO<${node.name}DAOGenerics<MetadataType, OperationMetadataType>> {${daoBodyInMemory}}`,
+      `export class InMemory${node.name}DAO<MetadataType, OperationMetadataType> extends T.AbstractInMemoryDAO<${node.name}DAOGenerics<MetadataType, OperationMetadataType>> {${daoBodyInMemory}}`,
     ].join('\n\n')
   }
 
   private _generateConstructorMethod(node: TsTypettaGeneratorNode, typesMap: Map<string, TsTypettaGeneratorNode>, daoParams: string): string {
     const idField = getID(node)
     const generatedRelations = `[\n${indentMultiline(this._generateRelations(node, typesMap).join(',\n'))}\n]`
-    const relations = `relations: overrideRelations(\n${indentMultiline(`${generatedRelations}`)}\n)`
+    const relations = `relations: T.overrideRelations(\n${indentMultiline(`${generatedRelations}`)}\n)`
     const idGenerator = `idGeneration: '${idField.idGenerationStrategy || this._config.defaultIdGenerationStrategy || 'generator'}'`
     const idScalar = `idScalar: '${idField.isEnum ? 'String' : idField.graphqlType}'`
     const constructorBody = `super({ ${indentMultiline(
@@ -537,8 +531,8 @@ function selectMiddleware<MetadataType, OperationMetadataType>(
 public static projection<P extends ${node.name}Projection>(p: P) {
   return p
 }
-public static mergeProjection<P1 extends ${node.name}Projection, P2 extends ${node.name}Projection>(p1: P1, p2: P2): SelectProjection<${node.name}Projection, P1, P2> {
-  return mergeProjections(p1, p2) as SelectProjection<${node.name}Projection, P1, P2>
+public static mergeProjection<P1 extends ${node.name}Projection, P2 extends ${node.name}Projection>(p1: P1, p2: P2): T.SelectProjection<${node.name}Projection, P1, P2> {
+  return T.mergeProjections(p1, p2) as T.SelectProjection<${node.name}Projection, P1, P2>
 }
 
 public constructor(params: ${daoParams}<MetadataType, OperationMetadataType>){\n` +

--- a/tests/demo/dao.mock.ts
+++ b/tests/demo/dao.mock.ts
@@ -1,13 +1,12 @@
-import { DAOMiddleware, Coordinates, UserInputDriverDataTypeAdapterMap, Schema, AbstractDAOContext, LogicalOperators, QuantityOperators, EqualityOperators, StringOperators, ElementOperators, OneKey, SortDirection, overrideRelations, userInputDataTypeAdapterToDataTypeAdapter, LogFunction, LogInput, logInputToLogger, ParamProjection, DAOGenerics, CRUDPermission, DAOContextSecurtyPolicy, createSecurityPolicyMiddlewares, SelectProjection, mergeProjections, AbstractInMemoryDAO, InMemoryDAOGenerics, InMemoryDAOParams } from '../../src'
+import * as T from '../../src'
 import * as types from './models.mock'
-import { KnexJsDAOGenerics, KnexJsDAOParams, AbstractKnexJsDAO } from '../../src'
 import { Knex } from 'knex'
 
 //--------------------------------------------------------------------------------
 //--------------------------------- CREDENTIALS ----------------------------------
 //--------------------------------------------------------------------------------
 
-export function credentialsSchema(): Schema<types.Scalars> {
+export function credentialsSchema(): T.Schema<types.Scalars> {
   return {
     'password': {
       scalar: 'Password'
@@ -22,7 +21,7 @@ export type CredentialsProjection = {
   password?: boolean,
   username?: boolean,
 }
-export type CredentialsParam<P extends CredentialsProjection> = ParamProjection<types.Credentials, CredentialsProjection, P>
+export type CredentialsParam<P extends CredentialsProjection> = T.ParamProjection<types.Credentials, CredentialsProjection, P>
 
 export type CredentialsInsert = {
   password?: null | types.Scalars['Password'],
@@ -38,7 +37,7 @@ export type CredentialsInsert = {
 export type PostExcludedFields = never
 export type PostRelationFields = 'author' | 'tags'
 
-export function postSchema(): Schema<types.Scalars> {
+export function postSchema(): T.Schema<types.Scalars> {
   return {
     'authorId': {
       scalar: 'ID', 
@@ -72,18 +71,18 @@ export function postSchema(): Schema<types.Scalars> {
 }
 
 type PostFilterFields = {
-  'authorId'?: types.Scalars['ID'] | null | EqualityOperators<types.Scalars['ID']> | ElementOperators,
-  'body'?: types.Scalars['String'] | null | EqualityOperators<types.Scalars['String']> | ElementOperators | StringOperators,
-  'clicks'?: types.Scalars['Int'] | null | EqualityOperators<types.Scalars['Int']> | ElementOperators | QuantityOperators<types.Scalars['Int']>,
-  'createdAt'?: types.Scalars['DateTime'] | null | EqualityOperators<types.Scalars['DateTime']> | ElementOperators | QuantityOperators<types.Scalars['DateTime']>,
-  'id'?: types.Scalars['ID'] | null | EqualityOperators<types.Scalars['ID']> | ElementOperators,
-  'metadata.region'?: types.Scalars['String'] | null | EqualityOperators<types.Scalars['String']> | ElementOperators | StringOperators,
-  'metadata.typeId'?: types.Scalars['ID'] | null | EqualityOperators<types.Scalars['ID']> | ElementOperators,
-  'metadata.visible'?: types.Scalars['Boolean'] | null | EqualityOperators<types.Scalars['Boolean']> | ElementOperators,
-  'title'?: types.Scalars['String'] | null | EqualityOperators<types.Scalars['String']> | ElementOperators | StringOperators,
-  'views'?: types.Scalars['Int'] | null | EqualityOperators<types.Scalars['Int']> | ElementOperators | QuantityOperators<types.Scalars['Int']>
+  'authorId'?: types.Scalars['ID'] | null | T.EqualityOperators<types.Scalars['ID']> | T.ElementOperators,
+  'body'?: types.Scalars['String'] | null | T.EqualityOperators<types.Scalars['String']> | T.ElementOperators | T.StringOperators,
+  'clicks'?: types.Scalars['Int'] | null | T.EqualityOperators<types.Scalars['Int']> | T.ElementOperators | T.QuantityOperators<types.Scalars['Int']>,
+  'createdAt'?: types.Scalars['DateTime'] | null | T.EqualityOperators<types.Scalars['DateTime']> | T.ElementOperators | T.QuantityOperators<types.Scalars['DateTime']>,
+  'id'?: types.Scalars['ID'] | null | T.EqualityOperators<types.Scalars['ID']> | T.ElementOperators,
+  'metadata.region'?: types.Scalars['String'] | null | T.EqualityOperators<types.Scalars['String']> | T.ElementOperators | T.StringOperators,
+  'metadata.typeId'?: types.Scalars['ID'] | null | T.EqualityOperators<types.Scalars['ID']> | T.ElementOperators,
+  'metadata.visible'?: types.Scalars['Boolean'] | null | T.EqualityOperators<types.Scalars['Boolean']> | T.ElementOperators,
+  'title'?: types.Scalars['String'] | null | T.EqualityOperators<types.Scalars['String']> | T.ElementOperators | T.StringOperators,
+  'views'?: types.Scalars['Int'] | null | T.EqualityOperators<types.Scalars['Int']> | T.ElementOperators | T.QuantityOperators<types.Scalars['Int']>
 }
-export type PostFilter = PostFilterFields & LogicalOperators<PostFilterFields | PostRawFilter>
+export type PostFilter = PostFilterFields & T.LogicalOperators<PostFilterFields | PostRawFilter>
 export type PostRawFilter = (builder: Knex.QueryBuilder<any, any>) => Knex.QueryBuilder<any, any>
 
 export type PostRelations = {
@@ -113,10 +112,10 @@ export type PostProjection = {
   title?: boolean,
   views?: boolean,
 }
-export type PostParam<P extends PostProjection> = ParamProjection<types.Post, PostProjection, P>
+export type PostParam<P extends PostProjection> = T.ParamProjection<types.Post, PostProjection, P>
 
 export type PostSortKeys = 'authorId' | 'body' | 'clicks' | 'createdAt' | 'id' | 'metadata.region' | 'metadata.typeId' | 'metadata.visible' | 'title' | 'views'
-export type PostSort = OneKey<PostSortKeys, SortDirection>
+export type PostSort = T.OneKey<PostSortKeys, T.SortDirection>
 export type PostRawSort = (builder: Knex.QueryBuilder<any, any>) => Knex.QueryBuilder<any, any>
 
 export type PostUpdate = {
@@ -145,17 +144,17 @@ export type PostInsert = {
   views: types.Scalars['Int'],
 }
 
-type PostDAOGenerics<MetadataType, OperationMetadataType> = KnexJsDAOGenerics<types.Post, 'id', 'ID', PostFilter, PostRawFilter, PostRelations, PostProjection, PostSort, PostRawSort, PostInsert, PostUpdate, PostRawUpdate, PostExcludedFields, PostRelationFields, MetadataType, OperationMetadataType, types.Scalars, 'post', DAOContext<MetadataType, OperationMetadataType>>
-export type PostDAOParams<MetadataType, OperationMetadataType> = Omit<KnexJsDAOParams<PostDAOGenerics<MetadataType, OperationMetadataType>>, 'idField' | 'schema' | 'idScalar' | 'idGeneration'>
-export type InMemoryPostDAOParams<MetadataType, OperationMetadataType> = Omit<InMemoryDAOParams<PostDAOGenerics<MetadataType, OperationMetadataType>>, 'idField' | 'schema' | 'idScalar' | 'idGeneration'>
+type PostDAOGenerics<MetadataType, OperationMetadataType> = T.KnexJsDAOGenerics<types.Post, 'id', 'ID', PostFilter, PostRawFilter, PostRelations, PostProjection, PostSort, PostRawSort, PostInsert, PostUpdate, PostRawUpdate, PostExcludedFields, PostRelationFields, MetadataType, OperationMetadataType, types.Scalars, 'post', DAOContext<MetadataType, OperationMetadataType>>
+export type PostDAOParams<MetadataType, OperationMetadataType> = Omit<T.KnexJsDAOParams<PostDAOGenerics<MetadataType, OperationMetadataType>>, 'idField' | 'schema' | 'idScalar' | 'idGeneration'>
+export type InMemoryPostDAOParams<MetadataType, OperationMetadataType> = Omit<T.InMemoryDAOParams<PostDAOGenerics<MetadataType, OperationMetadataType>>, 'idField' | 'schema' | 'idScalar' | 'idGeneration'>
 
-export class PostDAO<MetadataType, OperationMetadataType> extends AbstractKnexJsDAO<PostDAOGenerics<MetadataType, OperationMetadataType>> {  
+export class PostDAO<MetadataType, OperationMetadataType> extends T.AbstractKnexJsDAO<PostDAOGenerics<MetadataType, OperationMetadataType>> {  
   
   public static projection<P extends PostProjection>(p: P) {
     return p
   }
-  public static mergeProjection<P1 extends PostProjection, P2 extends PostProjection>(p1: P1, p2: P2): SelectProjection<PostProjection, P1, P2> {
-    return mergeProjections(p1, p2) as SelectProjection<PostProjection, P1, P2>
+  public static mergeProjection<P1 extends PostProjection, P2 extends PostProjection>(p1: P1, p2: P2): T.SelectProjection<PostProjection, P1, P2> {
+    return T.mergeProjections(p1, p2) as T.SelectProjection<PostProjection, P1, P2>
   }
   
   public constructor(params: PostDAOParams<MetadataType, OperationMetadataType>){
@@ -163,7 +162,7 @@ export class PostDAO<MetadataType, OperationMetadataType> extends AbstractKnexJs
       ...params, 
       idField: 'id', 
       schema: postSchema(), 
-      relations: overrideRelations(
+      relations: T.overrideRelations(
         [
           { type: '1-1', reference: 'inner', field: 'author', refFrom: 'authorId', refTo: 'id', dao: 'user', required: false },
           { type: '1-1', reference: 'inner', field: 'metadata.type', refFrom: 'metadata.typeId', refTo: 'id', dao: 'postType', required: false },
@@ -176,13 +175,13 @@ export class PostDAO<MetadataType, OperationMetadataType> extends AbstractKnexJs
   }
   }
 
-export class InMemoryPostDAO<MetadataType, OperationMetadataType> extends AbstractInMemoryDAO<PostDAOGenerics<MetadataType, OperationMetadataType>> {  
+export class InMemoryPostDAO<MetadataType, OperationMetadataType> extends T.AbstractInMemoryDAO<PostDAOGenerics<MetadataType, OperationMetadataType>> {  
   
   public static projection<P extends PostProjection>(p: P) {
     return p
   }
-  public static mergeProjection<P1 extends PostProjection, P2 extends PostProjection>(p1: P1, p2: P2): SelectProjection<PostProjection, P1, P2> {
-    return mergeProjections(p1, p2) as SelectProjection<PostProjection, P1, P2>
+  public static mergeProjection<P1 extends PostProjection, P2 extends PostProjection>(p1: P1, p2: P2): T.SelectProjection<PostProjection, P1, P2> {
+    return T.mergeProjections(p1, p2) as T.SelectProjection<PostProjection, P1, P2>
   }
   
   public constructor(params: InMemoryPostDAOParams<MetadataType, OperationMetadataType>){
@@ -190,7 +189,7 @@ export class InMemoryPostDAO<MetadataType, OperationMetadataType> extends Abstra
       ...params, 
       idField: 'id', 
       schema: postSchema(), 
-      relations: overrideRelations(
+      relations: T.overrideRelations(
         [
           { type: '1-1', reference: 'inner', field: 'author', refFrom: 'authorId', refTo: 'id', dao: 'user', required: false },
           { type: '1-1', reference: 'inner', field: 'metadata.type', refFrom: 'metadata.typeId', refTo: 'id', dao: 'postType', required: false },
@@ -209,7 +208,7 @@ export class InMemoryPostDAO<MetadataType, OperationMetadataType> extends Abstra
 //--------------------------------- POSTMETADATA ---------------------------------
 //--------------------------------------------------------------------------------
 
-export function postMetadataSchema(): Schema<types.Scalars> {
+export function postMetadataSchema(): T.Schema<types.Scalars> {
   return {
     'region': {
       scalar: 'String', 
@@ -232,7 +231,7 @@ export type PostMetadataProjection = {
   typeId?: boolean,
   visible?: boolean,
 }
-export type PostMetadataParam<P extends PostMetadataProjection> = ParamProjection<types.PostMetadata, PostMetadataProjection, P>
+export type PostMetadataParam<P extends PostMetadataProjection> = T.ParamProjection<types.PostMetadata, PostMetadataProjection, P>
 
 export type PostMetadataInsert = {
   region: types.Scalars['String'],
@@ -249,7 +248,7 @@ export type PostMetadataInsert = {
 export type PostTypeExcludedFields = never
 export type PostTypeRelationFields = never
 
-export function postTypeSchema(): Schema<types.Scalars> {
+export function postTypeSchema(): T.Schema<types.Scalars> {
   return {
     'id': {
       scalar: 'ID', 
@@ -263,10 +262,10 @@ export function postTypeSchema(): Schema<types.Scalars> {
 }
 
 type PostTypeFilterFields = {
-  'id'?: types.Scalars['ID'] | null | EqualityOperators<types.Scalars['ID']> | ElementOperators,
-  'name'?: types.Scalars['String'] | null | EqualityOperators<types.Scalars['String']> | ElementOperators | StringOperators
+  'id'?: types.Scalars['ID'] | null | T.EqualityOperators<types.Scalars['ID']> | T.ElementOperators,
+  'name'?: types.Scalars['String'] | null | T.EqualityOperators<types.Scalars['String']> | T.ElementOperators | T.StringOperators
 }
-export type PostTypeFilter = PostTypeFilterFields & LogicalOperators<PostTypeFilterFields | PostTypeRawFilter>
+export type PostTypeFilter = PostTypeFilterFields & T.LogicalOperators<PostTypeFilterFields | PostTypeRawFilter>
 export type PostTypeRawFilter = (builder: Knex.QueryBuilder<any, any>) => Knex.QueryBuilder<any, any>
 
 export type PostTypeRelations = Record<never, string>
@@ -275,10 +274,10 @@ export type PostTypeProjection = {
   id?: boolean,
   name?: boolean,
 }
-export type PostTypeParam<P extends PostTypeProjection> = ParamProjection<types.PostType, PostTypeProjection, P>
+export type PostTypeParam<P extends PostTypeProjection> = T.ParamProjection<types.PostType, PostTypeProjection, P>
 
 export type PostTypeSortKeys = 'id' | 'name'
-export type PostTypeSort = OneKey<PostTypeSortKeys, SortDirection>
+export type PostTypeSort = T.OneKey<PostTypeSortKeys, T.SortDirection>
 export type PostTypeRawSort = (builder: Knex.QueryBuilder<any, any>) => Knex.QueryBuilder<any, any>
 
 export type PostTypeUpdate = {
@@ -292,17 +291,17 @@ export type PostTypeInsert = {
   name: types.Scalars['String'],
 }
 
-type PostTypeDAOGenerics<MetadataType, OperationMetadataType> = KnexJsDAOGenerics<types.PostType, 'id', 'ID', PostTypeFilter, PostTypeRawFilter, PostTypeRelations, PostTypeProjection, PostTypeSort, PostTypeRawSort, PostTypeInsert, PostTypeUpdate, PostTypeRawUpdate, PostTypeExcludedFields, PostTypeRelationFields, MetadataType, OperationMetadataType, types.Scalars, 'postType', DAOContext<MetadataType, OperationMetadataType>>
-export type PostTypeDAOParams<MetadataType, OperationMetadataType> = Omit<KnexJsDAOParams<PostTypeDAOGenerics<MetadataType, OperationMetadataType>>, 'idGenerator' | 'idField' | 'schema' | 'idScalar' | 'idGeneration'>
-export type InMemoryPostTypeDAOParams<MetadataType, OperationMetadataType> = Omit<InMemoryDAOParams<PostTypeDAOGenerics<MetadataType, OperationMetadataType>>, 'idGenerator' | 'idField' | 'schema' | 'idScalar' | 'idGeneration'>
+type PostTypeDAOGenerics<MetadataType, OperationMetadataType> = T.KnexJsDAOGenerics<types.PostType, 'id', 'ID', PostTypeFilter, PostTypeRawFilter, PostTypeRelations, PostTypeProjection, PostTypeSort, PostTypeRawSort, PostTypeInsert, PostTypeUpdate, PostTypeRawUpdate, PostTypeExcludedFields, PostTypeRelationFields, MetadataType, OperationMetadataType, types.Scalars, 'postType', DAOContext<MetadataType, OperationMetadataType>>
+export type PostTypeDAOParams<MetadataType, OperationMetadataType> = Omit<T.KnexJsDAOParams<PostTypeDAOGenerics<MetadataType, OperationMetadataType>>, 'idGenerator' | 'idField' | 'schema' | 'idScalar' | 'idGeneration'>
+export type InMemoryPostTypeDAOParams<MetadataType, OperationMetadataType> = Omit<T.InMemoryDAOParams<PostTypeDAOGenerics<MetadataType, OperationMetadataType>>, 'idGenerator' | 'idField' | 'schema' | 'idScalar' | 'idGeneration'>
 
-export class PostTypeDAO<MetadataType, OperationMetadataType> extends AbstractKnexJsDAO<PostTypeDAOGenerics<MetadataType, OperationMetadataType>> {  
+export class PostTypeDAO<MetadataType, OperationMetadataType> extends T.AbstractKnexJsDAO<PostTypeDAOGenerics<MetadataType, OperationMetadataType>> {  
   
   public static projection<P extends PostTypeProjection>(p: P) {
     return p
   }
-  public static mergeProjection<P1 extends PostTypeProjection, P2 extends PostTypeProjection>(p1: P1, p2: P2): SelectProjection<PostTypeProjection, P1, P2> {
-    return mergeProjections(p1, p2) as SelectProjection<PostTypeProjection, P1, P2>
+  public static mergeProjection<P1 extends PostTypeProjection, P2 extends PostTypeProjection>(p1: P1, p2: P2): T.SelectProjection<PostTypeProjection, P1, P2> {
+    return T.mergeProjections(p1, p2) as T.SelectProjection<PostTypeProjection, P1, P2>
   }
   
   public constructor(params: PostTypeDAOParams<MetadataType, OperationMetadataType>){
@@ -310,7 +309,7 @@ export class PostTypeDAO<MetadataType, OperationMetadataType> extends AbstractKn
       ...params, 
       idField: 'id', 
       schema: postTypeSchema(), 
-      relations: overrideRelations(
+      relations: T.overrideRelations(
         [
           
         ]
@@ -321,13 +320,13 @@ export class PostTypeDAO<MetadataType, OperationMetadataType> extends AbstractKn
   }
   }
 
-export class InMemoryPostTypeDAO<MetadataType, OperationMetadataType> extends AbstractInMemoryDAO<PostTypeDAOGenerics<MetadataType, OperationMetadataType>> {  
+export class InMemoryPostTypeDAO<MetadataType, OperationMetadataType> extends T.AbstractInMemoryDAO<PostTypeDAOGenerics<MetadataType, OperationMetadataType>> {  
   
   public static projection<P extends PostTypeProjection>(p: P) {
     return p
   }
-  public static mergeProjection<P1 extends PostTypeProjection, P2 extends PostTypeProjection>(p1: P1, p2: P2): SelectProjection<PostTypeProjection, P1, P2> {
-    return mergeProjections(p1, p2) as SelectProjection<PostTypeProjection, P1, P2>
+  public static mergeProjection<P1 extends PostTypeProjection, P2 extends PostTypeProjection>(p1: P1, p2: P2): T.SelectProjection<PostTypeProjection, P1, P2> {
+    return T.mergeProjections(p1, p2) as T.SelectProjection<PostTypeProjection, P1, P2>
   }
   
   public constructor(params: InMemoryPostTypeDAOParams<MetadataType, OperationMetadataType>){
@@ -335,7 +334,7 @@ export class InMemoryPostTypeDAO<MetadataType, OperationMetadataType> extends Ab
       ...params, 
       idField: 'id', 
       schema: postTypeSchema(), 
-      relations: overrideRelations(
+      relations: T.overrideRelations(
         [
           
         ]
@@ -355,7 +354,7 @@ export class InMemoryPostTypeDAO<MetadataType, OperationMetadataType> extends Ab
 export type TagExcludedFields = never
 export type TagRelationFields = never
 
-export function tagSchema(): Schema<types.Scalars> {
+export function tagSchema(): T.Schema<types.Scalars> {
   return {
     'id': {
       scalar: 'ID', 
@@ -372,11 +371,11 @@ export function tagSchema(): Schema<types.Scalars> {
 }
 
 type TagFilterFields = {
-  'id'?: types.Scalars['ID'] | null | EqualityOperators<types.Scalars['ID']> | ElementOperators,
-  'name'?: types.Scalars['String'] | null | EqualityOperators<types.Scalars['String']> | ElementOperators | StringOperators,
-  'postId'?: types.Scalars['ID'] | null | EqualityOperators<types.Scalars['ID']> | ElementOperators
+  'id'?: types.Scalars['ID'] | null | T.EqualityOperators<types.Scalars['ID']> | T.ElementOperators,
+  'name'?: types.Scalars['String'] | null | T.EqualityOperators<types.Scalars['String']> | T.ElementOperators | T.StringOperators,
+  'postId'?: types.Scalars['ID'] | null | T.EqualityOperators<types.Scalars['ID']> | T.ElementOperators
 }
-export type TagFilter = TagFilterFields & LogicalOperators<TagFilterFields | TagRawFilter>
+export type TagFilter = TagFilterFields & T.LogicalOperators<TagFilterFields | TagRawFilter>
 export type TagRawFilter = (builder: Knex.QueryBuilder<any, any>) => Knex.QueryBuilder<any, any>
 
 export type TagRelations = Record<never, string>
@@ -386,10 +385,10 @@ export type TagProjection = {
   name?: boolean,
   postId?: boolean,
 }
-export type TagParam<P extends TagProjection> = ParamProjection<types.Tag, TagProjection, P>
+export type TagParam<P extends TagProjection> = T.ParamProjection<types.Tag, TagProjection, P>
 
 export type TagSortKeys = 'id' | 'name' | 'postId'
-export type TagSort = OneKey<TagSortKeys, SortDirection>
+export type TagSort = T.OneKey<TagSortKeys, T.SortDirection>
 export type TagRawSort = (builder: Knex.QueryBuilder<any, any>) => Knex.QueryBuilder<any, any>
 
 export type TagUpdate = {
@@ -405,17 +404,17 @@ export type TagInsert = {
   postId: types.Scalars['ID'],
 }
 
-type TagDAOGenerics<MetadataType, OperationMetadataType> = KnexJsDAOGenerics<types.Tag, 'id', 'ID', TagFilter, TagRawFilter, TagRelations, TagProjection, TagSort, TagRawSort, TagInsert, TagUpdate, TagRawUpdate, TagExcludedFields, TagRelationFields, MetadataType, OperationMetadataType, types.Scalars, 'tag', DAOContext<MetadataType, OperationMetadataType>>
-export type TagDAOParams<MetadataType, OperationMetadataType> = Omit<KnexJsDAOParams<TagDAOGenerics<MetadataType, OperationMetadataType>>, 'idField' | 'schema' | 'idScalar' | 'idGeneration'>
-export type InMemoryTagDAOParams<MetadataType, OperationMetadataType> = Omit<InMemoryDAOParams<TagDAOGenerics<MetadataType, OperationMetadataType>>, 'idField' | 'schema' | 'idScalar' | 'idGeneration'>
+type TagDAOGenerics<MetadataType, OperationMetadataType> = T.KnexJsDAOGenerics<types.Tag, 'id', 'ID', TagFilter, TagRawFilter, TagRelations, TagProjection, TagSort, TagRawSort, TagInsert, TagUpdate, TagRawUpdate, TagExcludedFields, TagRelationFields, MetadataType, OperationMetadataType, types.Scalars, 'tag', DAOContext<MetadataType, OperationMetadataType>>
+export type TagDAOParams<MetadataType, OperationMetadataType> = Omit<T.KnexJsDAOParams<TagDAOGenerics<MetadataType, OperationMetadataType>>, 'idField' | 'schema' | 'idScalar' | 'idGeneration'>
+export type InMemoryTagDAOParams<MetadataType, OperationMetadataType> = Omit<T.InMemoryDAOParams<TagDAOGenerics<MetadataType, OperationMetadataType>>, 'idField' | 'schema' | 'idScalar' | 'idGeneration'>
 
-export class TagDAO<MetadataType, OperationMetadataType> extends AbstractKnexJsDAO<TagDAOGenerics<MetadataType, OperationMetadataType>> {  
+export class TagDAO<MetadataType, OperationMetadataType> extends T.AbstractKnexJsDAO<TagDAOGenerics<MetadataType, OperationMetadataType>> {  
   
   public static projection<P extends TagProjection>(p: P) {
     return p
   }
-  public static mergeProjection<P1 extends TagProjection, P2 extends TagProjection>(p1: P1, p2: P2): SelectProjection<TagProjection, P1, P2> {
-    return mergeProjections(p1, p2) as SelectProjection<TagProjection, P1, P2>
+  public static mergeProjection<P1 extends TagProjection, P2 extends TagProjection>(p1: P1, p2: P2): T.SelectProjection<TagProjection, P1, P2> {
+    return T.mergeProjections(p1, p2) as T.SelectProjection<TagProjection, P1, P2>
   }
   
   public constructor(params: TagDAOParams<MetadataType, OperationMetadataType>){
@@ -423,7 +422,7 @@ export class TagDAO<MetadataType, OperationMetadataType> extends AbstractKnexJsD
       ...params, 
       idField: 'id', 
       schema: tagSchema(), 
-      relations: overrideRelations(
+      relations: T.overrideRelations(
         [
           
         ]
@@ -434,13 +433,13 @@ export class TagDAO<MetadataType, OperationMetadataType> extends AbstractKnexJsD
   }
   }
 
-export class InMemoryTagDAO<MetadataType, OperationMetadataType> extends AbstractInMemoryDAO<TagDAOGenerics<MetadataType, OperationMetadataType>> {  
+export class InMemoryTagDAO<MetadataType, OperationMetadataType> extends T.AbstractInMemoryDAO<TagDAOGenerics<MetadataType, OperationMetadataType>> {  
   
   public static projection<P extends TagProjection>(p: P) {
     return p
   }
-  public static mergeProjection<P1 extends TagProjection, P2 extends TagProjection>(p1: P1, p2: P2): SelectProjection<TagProjection, P1, P2> {
-    return mergeProjections(p1, p2) as SelectProjection<TagProjection, P1, P2>
+  public static mergeProjection<P1 extends TagProjection, P2 extends TagProjection>(p1: P1, p2: P2): T.SelectProjection<TagProjection, P1, P2> {
+    return T.mergeProjections(p1, p2) as T.SelectProjection<TagProjection, P1, P2>
   }
   
   public constructor(params: InMemoryTagDAOParams<MetadataType, OperationMetadataType>){
@@ -448,7 +447,7 @@ export class InMemoryTagDAO<MetadataType, OperationMetadataType> extends Abstrac
       ...params, 
       idField: 'id', 
       schema: tagSchema(), 
-      relations: overrideRelations(
+      relations: T.overrideRelations(
         [
           
         ]
@@ -468,7 +467,7 @@ export class InMemoryTagDAO<MetadataType, OperationMetadataType> extends Abstrac
 export type UserExcludedFields = 'averageViewsPerPost' | 'totalPostsViews'
 export type UserRelationFields = 'posts'
 
-export function userSchema(): Schema<types.Scalars> {
+export function userSchema(): T.Schema<types.Scalars> {
   return {
     'createdAt': {
       scalar: 'DateTime', 
@@ -492,15 +491,15 @@ export function userSchema(): Schema<types.Scalars> {
 }
 
 type UserFilterFields = {
-  'createdAt'?: types.Scalars['DateTime'] | null | EqualityOperators<types.Scalars['DateTime']> | ElementOperators | QuantityOperators<types.Scalars['DateTime']>,
-  'credentials.password'?: types.Scalars['Password'] | null | EqualityOperators<types.Scalars['Password']> | ElementOperators | StringOperators,
-  'credentials.username'?: types.Scalars['String'] | null | EqualityOperators<types.Scalars['String']> | ElementOperators | StringOperators,
-  'email'?: types.Scalars['String'] | null | EqualityOperators<types.Scalars['String']> | ElementOperators | StringOperators,
-  'firstName'?: types.Scalars['String'] | null | EqualityOperators<types.Scalars['String']> | ElementOperators | StringOperators,
-  'id'?: types.Scalars['ID'] | null | EqualityOperators<types.Scalars['ID']> | ElementOperators,
-  'lastName'?: types.Scalars['String'] | null | EqualityOperators<types.Scalars['String']> | ElementOperators | StringOperators
+  'createdAt'?: types.Scalars['DateTime'] | null | T.EqualityOperators<types.Scalars['DateTime']> | T.ElementOperators | T.QuantityOperators<types.Scalars['DateTime']>,
+  'credentials.password'?: types.Scalars['Password'] | null | T.EqualityOperators<types.Scalars['Password']> | T.ElementOperators | T.StringOperators,
+  'credentials.username'?: types.Scalars['String'] | null | T.EqualityOperators<types.Scalars['String']> | T.ElementOperators | T.StringOperators,
+  'email'?: types.Scalars['String'] | null | T.EqualityOperators<types.Scalars['String']> | T.ElementOperators | T.StringOperators,
+  'firstName'?: types.Scalars['String'] | null | T.EqualityOperators<types.Scalars['String']> | T.ElementOperators | T.StringOperators,
+  'id'?: types.Scalars['ID'] | null | T.EqualityOperators<types.Scalars['ID']> | T.ElementOperators,
+  'lastName'?: types.Scalars['String'] | null | T.EqualityOperators<types.Scalars['String']> | T.ElementOperators | T.StringOperators
 }
-export type UserFilter = UserFilterFields & LogicalOperators<UserFilterFields | UserRawFilter>
+export type UserFilter = UserFilterFields & T.LogicalOperators<UserFilterFields | UserRawFilter>
 export type UserRawFilter = (builder: Knex.QueryBuilder<any, any>) => Knex.QueryBuilder<any, any>
 
 export type UserRelations = {
@@ -527,10 +526,10 @@ export type UserProjection = {
   posts?: PostProjection | boolean,
   totalPostsViews?: boolean,
 }
-export type UserParam<P extends UserProjection> = ParamProjection<types.User, UserProjection, P>
+export type UserParam<P extends UserProjection> = T.ParamProjection<types.User, UserProjection, P>
 
 export type UserSortKeys = 'createdAt' | 'credentials.password' | 'credentials.username' | 'email' | 'firstName' | 'id' | 'lastName'
-export type UserSort = OneKey<UserSortKeys, SortDirection>
+export type UserSort = T.OneKey<UserSortKeys, T.SortDirection>
 export type UserRawSort = (builder: Knex.QueryBuilder<any, any>) => Knex.QueryBuilder<any, any>
 
 export type UserUpdate = {
@@ -554,17 +553,17 @@ export type UserInsert = {
   lastName?: null | types.Scalars['String'],
 }
 
-type UserDAOGenerics<MetadataType, OperationMetadataType> = KnexJsDAOGenerics<types.User, 'id', 'ID', UserFilter, UserRawFilter, UserRelations, UserProjection, UserSort, UserRawSort, UserInsert, UserUpdate, UserRawUpdate, UserExcludedFields, UserRelationFields, MetadataType, OperationMetadataType, types.Scalars, 'user', DAOContext<MetadataType, OperationMetadataType>>
-export type UserDAOParams<MetadataType, OperationMetadataType> = Omit<KnexJsDAOParams<UserDAOGenerics<MetadataType, OperationMetadataType>>, 'idField' | 'schema' | 'idScalar' | 'idGeneration'>
-export type InMemoryUserDAOParams<MetadataType, OperationMetadataType> = Omit<InMemoryDAOParams<UserDAOGenerics<MetadataType, OperationMetadataType>>, 'idField' | 'schema' | 'idScalar' | 'idGeneration'>
+type UserDAOGenerics<MetadataType, OperationMetadataType> = T.KnexJsDAOGenerics<types.User, 'id', 'ID', UserFilter, UserRawFilter, UserRelations, UserProjection, UserSort, UserRawSort, UserInsert, UserUpdate, UserRawUpdate, UserExcludedFields, UserRelationFields, MetadataType, OperationMetadataType, types.Scalars, 'user', DAOContext<MetadataType, OperationMetadataType>>
+export type UserDAOParams<MetadataType, OperationMetadataType> = Omit<T.KnexJsDAOParams<UserDAOGenerics<MetadataType, OperationMetadataType>>, 'idField' | 'schema' | 'idScalar' | 'idGeneration'>
+export type InMemoryUserDAOParams<MetadataType, OperationMetadataType> = Omit<T.InMemoryDAOParams<UserDAOGenerics<MetadataType, OperationMetadataType>>, 'idField' | 'schema' | 'idScalar' | 'idGeneration'>
 
-export class UserDAO<MetadataType, OperationMetadataType> extends AbstractKnexJsDAO<UserDAOGenerics<MetadataType, OperationMetadataType>> {  
+export class UserDAO<MetadataType, OperationMetadataType> extends T.AbstractKnexJsDAO<UserDAOGenerics<MetadataType, OperationMetadataType>> {  
   
   public static projection<P extends UserProjection>(p: P) {
     return p
   }
-  public static mergeProjection<P1 extends UserProjection, P2 extends UserProjection>(p1: P1, p2: P2): SelectProjection<UserProjection, P1, P2> {
-    return mergeProjections(p1, p2) as SelectProjection<UserProjection, P1, P2>
+  public static mergeProjection<P1 extends UserProjection, P2 extends UserProjection>(p1: P1, p2: P2): T.SelectProjection<UserProjection, P1, P2> {
+    return T.mergeProjections(p1, p2) as T.SelectProjection<UserProjection, P1, P2>
   }
   
   public constructor(params: UserDAOParams<MetadataType, OperationMetadataType>){
@@ -572,7 +571,7 @@ export class UserDAO<MetadataType, OperationMetadataType> extends AbstractKnexJs
       ...params, 
       idField: 'id', 
       schema: userSchema(), 
-      relations: overrideRelations(
+      relations: T.overrideRelations(
         [
           { type: '1-n', reference: 'foreign', field: 'posts', refFrom: 'authorId', refTo: 'id', dao: 'post', required: false }
         ]
@@ -583,13 +582,13 @@ export class UserDAO<MetadataType, OperationMetadataType> extends AbstractKnexJs
   }
   }
 
-export class InMemoryUserDAO<MetadataType, OperationMetadataType> extends AbstractInMemoryDAO<UserDAOGenerics<MetadataType, OperationMetadataType>> {  
+export class InMemoryUserDAO<MetadataType, OperationMetadataType> extends T.AbstractInMemoryDAO<UserDAOGenerics<MetadataType, OperationMetadataType>> {  
   
   public static projection<P extends UserProjection>(p: P) {
     return p
   }
-  public static mergeProjection<P1 extends UserProjection, P2 extends UserProjection>(p1: P1, p2: P2): SelectProjection<UserProjection, P1, P2> {
-    return mergeProjections(p1, p2) as SelectProjection<UserProjection, P1, P2>
+  public static mergeProjection<P1 extends UserProjection, P2 extends UserProjection>(p1: P1, p2: P2): T.SelectProjection<UserProjection, P1, P2> {
+    return T.mergeProjections(p1, p2) as T.SelectProjection<UserProjection, P1, P2>
   }
   
   public constructor(params: InMemoryUserDAOParams<MetadataType, OperationMetadataType>){
@@ -597,7 +596,7 @@ export class InMemoryUserDAO<MetadataType, OperationMetadataType> extends Abstra
       ...params, 
       idField: 'id', 
       schema: userSchema(), 
-      relations: overrideRelations(
+      relations: T.overrideRelations(
         [
           { type: '1-n', reference: 'foreign', field: 'posts', refFrom: 'authorId', refTo: 'id', dao: 'post', required: false }
         ]
@@ -619,14 +618,14 @@ export type DAOContextParams<MetadataType, OperationMetadataType, Permissions ex
     user?: Pick<Partial<UserDAOParams<MetadataType, OperationMetadataType>>, 'idGenerator' | 'middlewares' | 'metadata'>
   },
   knex: Record<'default', Knex | 'mock'>,
-  scalars?: UserInputDriverDataTypeAdapterMap<types.Scalars, 'knex'>,
-  log?: LogInput<'post' | 'postType' | 'tag' | 'user'>,
-  security?: DAOContextSecurtyPolicy<DAOGenericsMap<MetadataType, OperationMetadataType>, OperationMetadataType, Permissions, SecurityDomain>
+  scalars?: T.UserInputDriverDataTypeAdapterMap<types.Scalars, 'knex'>,
+  log?: T.LogInput<'post' | 'postType' | 'tag' | 'user'>,
+  security?: T.DAOContextSecurtyPolicy<DAOGenericsMap<MetadataType, OperationMetadataType>, OperationMetadataType, Permissions, SecurityDomain>
 }
 
-type DAOContextMiddleware<MetadataType = never, OperationMetadataType = never> = DAOMiddleware<DAOGenericsUnion<MetadataType, OperationMetadataType>>
+type DAOContextMiddleware<MetadataType = never, OperationMetadataType = never> = T.DAOMiddleware<DAOGenericsUnion<MetadataType, OperationMetadataType>>
 
-export class DAOContext<MetadataType = never, OperationMetadataType = never, Permissions extends string = never, SecurityDomain extends object = never> extends AbstractDAOContext<never, 'default', types.Scalars, MetadataType>  {
+export class DAOContext<MetadataType = never, OperationMetadataType = never, Permissions extends string = never, SecurityDomain extends object = never> extends T.AbstractDAOContext<never, 'default', types.Scalars, MetadataType>  {
 
   private _post: PostDAO<MetadataType, OperationMetadataType> | undefined
   private _postType: PostTypeDAO<MetadataType, OperationMetadataType> | undefined
@@ -640,33 +639,33 @@ export class DAOContext<MetadataType = never, OperationMetadataType = never, Per
   
   private middlewares: (DAOContextMiddleware<MetadataType, OperationMetadataType> | GroupMiddleware<any, MetadataType, OperationMetadataType>)[]
   
-  private logger?: LogFunction<'post' | 'postType' | 'tag' | 'user'>
+  private logger?: T.LogFunction<'post' | 'postType' | 'tag' | 'user'>
   
   get post(): PostDAO<MetadataType, OperationMetadataType> {
     if(!this._post) {
       const db = this.knex.default
-      this._post = db === 'mock' ? (new InMemoryPostDAO({ daoContext: this, datasource: null, metadata: this.metadata, ...this.overrides?.post, middlewares: [...(this.overrides?.post?.middlewares || []), ...selectMiddleware('post', this.middlewares) as DAOMiddleware<PostDAOGenerics<MetadataType, OperationMetadataType>>[]], name: 'post', logger: this.logger }) as unknown as PostDAO<MetadataType, OperationMetadataType>) : new PostDAO({ daoContext: this, datasource: 'default', metadata: this.metadata, ...this.overrides?.post, knex: db, tableName: 'posts', middlewares: [...(this.overrides?.post?.middlewares || []), ...selectMiddleware('post', this.middlewares) as DAOMiddleware<PostDAOGenerics<MetadataType, OperationMetadataType>>[]], name: 'post', logger: this.logger })
+      this._post = db === 'mock' ? (new InMemoryPostDAO({ daoContext: this, datasource: null, metadata: this.metadata, ...this.overrides?.post, middlewares: [...(this.overrides?.post?.middlewares || []), ...selectMiddleware('post', this.middlewares) as T.DAOMiddleware<PostDAOGenerics<MetadataType, OperationMetadataType>>[]], name: 'post', logger: this.logger }) as unknown as PostDAO<MetadataType, OperationMetadataType>) : new PostDAO({ daoContext: this, datasource: 'default', metadata: this.metadata, ...this.overrides?.post, knex: db, tableName: 'posts', middlewares: [...(this.overrides?.post?.middlewares || []), ...selectMiddleware('post', this.middlewares) as T.DAOMiddleware<PostDAOGenerics<MetadataType, OperationMetadataType>>[]], name: 'post', logger: this.logger })
     }
     return this._post
   }
   get postType(): PostTypeDAO<MetadataType, OperationMetadataType> {
     if(!this._postType) {
       const db = this.knex.default
-      this._postType = db === 'mock' ? (new InMemoryPostTypeDAO({ daoContext: this, datasource: null, metadata: this.metadata, ...this.overrides?.postType, middlewares: [...(this.overrides?.postType?.middlewares || []), ...selectMiddleware('postType', this.middlewares) as DAOMiddleware<PostTypeDAOGenerics<MetadataType, OperationMetadataType>>[]], name: 'postType', logger: this.logger }) as unknown as PostTypeDAO<MetadataType, OperationMetadataType>) : new PostTypeDAO({ daoContext: this, datasource: 'default', metadata: this.metadata, ...this.overrides?.postType, knex: db, tableName: 'postTypes', middlewares: [...(this.overrides?.postType?.middlewares || []), ...selectMiddleware('postType', this.middlewares) as DAOMiddleware<PostTypeDAOGenerics<MetadataType, OperationMetadataType>>[]], name: 'postType', logger: this.logger })
+      this._postType = db === 'mock' ? (new InMemoryPostTypeDAO({ daoContext: this, datasource: null, metadata: this.metadata, ...this.overrides?.postType, middlewares: [...(this.overrides?.postType?.middlewares || []), ...selectMiddleware('postType', this.middlewares) as T.DAOMiddleware<PostTypeDAOGenerics<MetadataType, OperationMetadataType>>[]], name: 'postType', logger: this.logger }) as unknown as PostTypeDAO<MetadataType, OperationMetadataType>) : new PostTypeDAO({ daoContext: this, datasource: 'default', metadata: this.metadata, ...this.overrides?.postType, knex: db, tableName: 'postTypes', middlewares: [...(this.overrides?.postType?.middlewares || []), ...selectMiddleware('postType', this.middlewares) as T.DAOMiddleware<PostTypeDAOGenerics<MetadataType, OperationMetadataType>>[]], name: 'postType', logger: this.logger })
     }
     return this._postType
   }
   get tag(): TagDAO<MetadataType, OperationMetadataType> {
     if(!this._tag) {
       const db = this.knex.default
-      this._tag = db === 'mock' ? (new InMemoryTagDAO({ daoContext: this, datasource: null, metadata: this.metadata, ...this.overrides?.tag, middlewares: [...(this.overrides?.tag?.middlewares || []), ...selectMiddleware('tag', this.middlewares) as DAOMiddleware<TagDAOGenerics<MetadataType, OperationMetadataType>>[]], name: 'tag', logger: this.logger }) as unknown as TagDAO<MetadataType, OperationMetadataType>) : new TagDAO({ daoContext: this, datasource: 'default', metadata: this.metadata, ...this.overrides?.tag, knex: db, tableName: 'tags', middlewares: [...(this.overrides?.tag?.middlewares || []), ...selectMiddleware('tag', this.middlewares) as DAOMiddleware<TagDAOGenerics<MetadataType, OperationMetadataType>>[]], name: 'tag', logger: this.logger })
+      this._tag = db === 'mock' ? (new InMemoryTagDAO({ daoContext: this, datasource: null, metadata: this.metadata, ...this.overrides?.tag, middlewares: [...(this.overrides?.tag?.middlewares || []), ...selectMiddleware('tag', this.middlewares) as T.DAOMiddleware<TagDAOGenerics<MetadataType, OperationMetadataType>>[]], name: 'tag', logger: this.logger }) as unknown as TagDAO<MetadataType, OperationMetadataType>) : new TagDAO({ daoContext: this, datasource: 'default', metadata: this.metadata, ...this.overrides?.tag, knex: db, tableName: 'tags', middlewares: [...(this.overrides?.tag?.middlewares || []), ...selectMiddleware('tag', this.middlewares) as T.DAOMiddleware<TagDAOGenerics<MetadataType, OperationMetadataType>>[]], name: 'tag', logger: this.logger })
     }
     return this._tag
   }
   get user(): UserDAO<MetadataType, OperationMetadataType> {
     if(!this._user) {
       const db = this.knex.default
-      this._user = db === 'mock' ? (new InMemoryUserDAO({ daoContext: this, datasource: null, metadata: this.metadata, ...this.overrides?.user, middlewares: [...(this.overrides?.user?.middlewares || []), ...selectMiddleware('user', this.middlewares) as DAOMiddleware<UserDAOGenerics<MetadataType, OperationMetadataType>>[]], name: 'user', logger: this.logger }) as unknown as UserDAO<MetadataType, OperationMetadataType>) : new UserDAO({ daoContext: this, datasource: 'default', metadata: this.metadata, ...this.overrides?.user, knex: db, tableName: 'users', middlewares: [...(this.overrides?.user?.middlewares || []), ...selectMiddleware('user', this.middlewares) as DAOMiddleware<UserDAOGenerics<MetadataType, OperationMetadataType>>[]], name: 'user', logger: this.logger })
+      this._user = db === 'mock' ? (new InMemoryUserDAO({ daoContext: this, datasource: null, metadata: this.metadata, ...this.overrides?.user, middlewares: [...(this.overrides?.user?.middlewares || []), ...selectMiddleware('user', this.middlewares) as T.DAOMiddleware<UserDAOGenerics<MetadataType, OperationMetadataType>>[]], name: 'user', logger: this.logger }) as unknown as UserDAO<MetadataType, OperationMetadataType>) : new UserDAO({ daoContext: this, datasource: 'default', metadata: this.metadata, ...this.overrides?.user, knex: db, tableName: 'users', middlewares: [...(this.overrides?.user?.middlewares || []), ...selectMiddleware('user', this.middlewares) as T.DAOMiddleware<UserDAOGenerics<MetadataType, OperationMetadataType>>[]], name: 'user', logger: this.logger })
     }
     return this._user
   }
@@ -674,14 +673,14 @@ export class DAOContext<MetadataType = never, OperationMetadataType = never, Per
   constructor(params: DAOContextParams<MetadataType, OperationMetadataType, Permissions, SecurityDomain>) {
     super({
       ...params,
-      scalars: params.scalars ? userInputDataTypeAdapterToDataTypeAdapter(params.scalars, ['DateTime', 'Decimal', 'JSON', 'Password', 'ID', 'String', 'Boolean', 'Int', 'Float']) : undefined
+      scalars: params.scalars ? T.userInputDataTypeAdapterToDataTypeAdapter(params.scalars, ['DateTime', 'Decimal', 'JSON', 'Password', 'ID', 'String', 'Boolean', 'Int', 'Float']) : undefined
     })
     this.overrides = params.overrides
     this.knex = params.knex
     this.middlewares = params.middlewares || []
-    this.logger = logInputToLogger(params.log)
+    this.logger = T.logInputToLogger(params.log)
     if(params.security && params.security.applySecurity !== false) {
-      const securityMiddlewares = createSecurityPolicyMiddlewares(params.security)
+      const securityMiddlewares = T.createSecurityPolicyMiddlewares(params.security)
       const defaultMiddleware = securityMiddlewares.others ? [groupMiddleware.excludes(Object.fromEntries(Object.keys(securityMiddlewares.middlewares).map(k => [k, true])) as any, securityMiddlewares.others as any)] : []
       this.middlewares = [...(params.middlewares ?? []), ...defaultMiddleware, ...Object.entries(securityMiddlewares.middlewares).map(([name, middleware]) => groupMiddleware.includes({[name]: true} as any, middleware as any))]
     }
@@ -723,16 +722,16 @@ type GroupMiddleware<N extends DAOName, MetadataType, OperationMetadataType> =
   | ExcludeGroupMiddleware<N, MetadataType, OperationMetadataType>
 type IncludeGroupMiddleware<N extends DAOName, MetadataType, OperationMetadataType> = {
   include: { [K in N]: true }
-  middleware: DAOMiddleware<DAOGenericsMap<MetadataType, OperationMetadataType>[N]>
+  middleware: T.DAOMiddleware<DAOGenericsMap<MetadataType, OperationMetadataType>[N]>
 }
 type ExcludeGroupMiddleware<N extends DAOName, MetadataType, OperationMetadataType> = {
   exclude: { [K in N]: true }
-  middleware: DAOMiddleware<DAOGenericsMap<MetadataType, OperationMetadataType>[Exclude<DAOName, N>]>
+  middleware: T.DAOMiddleware<DAOGenericsMap<MetadataType, OperationMetadataType>[Exclude<DAOName, N>]>
 }
 export const groupMiddleware = {
   includes<N extends DAOName, MetadataType, OperationMetadataType>(
     include: { [K in N]: true },
-    middleware: DAOMiddleware<DAOGenericsMap<MetadataType, OperationMetadataType>[N]>,
+    middleware: T.DAOMiddleware<DAOGenericsMap<MetadataType, OperationMetadataType>[N]>,
   ): IncludeGroupMiddleware<N, MetadataType, OperationMetadataType> {
     return { include, middleware }
   },

--- a/tests/id_generator/dao.mock.ts
+++ b/tests/id_generator/dao.mock.ts
@@ -1,9 +1,7 @@
-import { DAOMiddleware, Coordinates, UserInputDriverDataTypeAdapterMap, Schema, AbstractDAOContext, LogicalOperators, QuantityOperators, EqualityOperators, StringOperators, ElementOperators, OneKey, SortDirection, overrideRelations, userInputDataTypeAdapterToDataTypeAdapter, LogFunction, LogInput, logInputToLogger, ParamProjection, DAOGenerics, CRUDPermission, DAOContextSecurtyPolicy, createSecurityPolicyMiddlewares, SelectProjection, mergeProjections, AbstractInMemoryDAO, InMemoryDAOGenerics, InMemoryDAOParams } from '../../src'
+import * as T from '../../src'
 import * as types from './models.mock'
-import { KnexJsDAOGenerics, KnexJsDAOParams, AbstractKnexJsDAO } from '../../src'
 import { Knex } from 'knex'
-import { MongoDBDAOGenerics, MongoDBDAOParams, AbstractMongoDBDAO } from '../../src'
-import { Collection, Db, Filter, Sort, UpdateFilter, Document } from 'mongodb'
+import * as M from 'mongodb'
 
 //--------------------------------------------------------------------------------
 //-------------------------------------- A ---------------------------------------
@@ -12,7 +10,7 @@ import { Collection, Db, Filter, Sort, UpdateFilter, Document } from 'mongodb'
 export type AExcludedFields = never
 export type ARelationFields = never
 
-export function aSchema(): Schema<types.Scalars> {
+export function aSchema(): T.Schema<types.Scalars> {
   return {
     'id': {
       scalar: 'MongoID', 
@@ -27,11 +25,11 @@ export function aSchema(): Schema<types.Scalars> {
 }
 
 type AFilterFields = {
-  'id'?: types.Scalars['MongoID'] | null | EqualityOperators<types.Scalars['MongoID']> | ElementOperators,
-  'value'?: types.Scalars['Int'] | null | EqualityOperators<types.Scalars['Int']> | ElementOperators | QuantityOperators<types.Scalars['Int']>
+  'id'?: types.Scalars['MongoID'] | null | T.EqualityOperators<types.Scalars['MongoID']> | T.ElementOperators,
+  'value'?: types.Scalars['Int'] | null | T.EqualityOperators<types.Scalars['Int']> | T.ElementOperators | T.QuantityOperators<types.Scalars['Int']>
 }
-export type AFilter = AFilterFields & LogicalOperators<AFilterFields | ARawFilter>
-export type ARawFilter = () => Filter<Document>
+export type AFilter = AFilterFields & T.LogicalOperators<AFilterFields | ARawFilter>
+export type ARawFilter = () => M.Filter<M.Document>
 
 export type ARelations = Record<never, string>
 
@@ -39,33 +37,33 @@ export type AProjection = {
   id?: boolean,
   value?: boolean,
 }
-export type AParam<P extends AProjection> = ParamProjection<types.A, AProjection, P>
+export type AParam<P extends AProjection> = T.ParamProjection<types.A, AProjection, P>
 
 export type ASortKeys = 'id' | 'value'
-export type ASort = OneKey<ASortKeys, SortDirection>
-export type ARawSort = () => Sort
+export type ASort = T.OneKey<ASortKeys, T.SortDirection>
+export type ARawSort = () => M.Sort
 
 export type AUpdate = {
   'id'?: types.Scalars['MongoID'],
   'value'?: types.Scalars['Int']
 }
-export type ARawUpdate = () => UpdateFilter<Document>
+export type ARawUpdate = () => M.UpdateFilter<M.Document>
 
 export type AInsert = {
   value: types.Scalars['Int'],
 }
 
-type ADAOGenerics<MetadataType, OperationMetadataType> = MongoDBDAOGenerics<types.A, 'id', 'MongoID', AFilter, ARawFilter, ARelations, AProjection, ASort, ARawSort, AInsert, AUpdate, ARawUpdate, AExcludedFields, ARelationFields, MetadataType, OperationMetadataType, types.Scalars, 'a', DAOContext<MetadataType, OperationMetadataType>>
-export type ADAOParams<MetadataType, OperationMetadataType> = Omit<MongoDBDAOParams<ADAOGenerics<MetadataType, OperationMetadataType>>, 'idGenerator' | 'idField' | 'schema' | 'idScalar' | 'idGeneration'>
-export type InMemoryADAOParams<MetadataType, OperationMetadataType> = Omit<InMemoryDAOParams<ADAOGenerics<MetadataType, OperationMetadataType>>, 'idGenerator' | 'idField' | 'schema' | 'idScalar' | 'idGeneration'>
+type ADAOGenerics<MetadataType, OperationMetadataType> = T.MongoDBDAOGenerics<types.A, 'id', 'MongoID', AFilter, ARawFilter, ARelations, AProjection, ASort, ARawSort, AInsert, AUpdate, ARawUpdate, AExcludedFields, ARelationFields, MetadataType, OperationMetadataType, types.Scalars, 'a', DAOContext<MetadataType, OperationMetadataType>>
+export type ADAOParams<MetadataType, OperationMetadataType> = Omit<T.MongoDBDAOParams<ADAOGenerics<MetadataType, OperationMetadataType>>, 'idGenerator' | 'idField' | 'schema' | 'idScalar' | 'idGeneration'>
+export type InMemoryADAOParams<MetadataType, OperationMetadataType> = Omit<T.InMemoryDAOParams<ADAOGenerics<MetadataType, OperationMetadataType>>, 'idGenerator' | 'idField' | 'schema' | 'idScalar' | 'idGeneration'>
 
-export class ADAO<MetadataType, OperationMetadataType> extends AbstractMongoDBDAO<ADAOGenerics<MetadataType, OperationMetadataType>> {  
+export class ADAO<MetadataType, OperationMetadataType> extends T.AbstractMongoDBDAO<ADAOGenerics<MetadataType, OperationMetadataType>> {  
   
   public static projection<P extends AProjection>(p: P) {
     return p
   }
-  public static mergeProjection<P1 extends AProjection, P2 extends AProjection>(p1: P1, p2: P2): SelectProjection<AProjection, P1, P2> {
-    return mergeProjections(p1, p2) as SelectProjection<AProjection, P1, P2>
+  public static mergeProjection<P1 extends AProjection, P2 extends AProjection>(p1: P1, p2: P2): T.SelectProjection<AProjection, P1, P2> {
+    return T.mergeProjections(p1, p2) as T.SelectProjection<AProjection, P1, P2>
   }
   
   public constructor(params: ADAOParams<MetadataType, OperationMetadataType>){
@@ -73,7 +71,7 @@ export class ADAO<MetadataType, OperationMetadataType> extends AbstractMongoDBDA
       ...params, 
       idField: 'id', 
       schema: aSchema(), 
-      relations: overrideRelations(
+      relations: T.overrideRelations(
         [
           
         ]
@@ -84,13 +82,13 @@ export class ADAO<MetadataType, OperationMetadataType> extends AbstractMongoDBDA
   }
   }
 
-export class InMemoryADAO<MetadataType, OperationMetadataType> extends AbstractInMemoryDAO<ADAOGenerics<MetadataType, OperationMetadataType>> {  
+export class InMemoryADAO<MetadataType, OperationMetadataType> extends T.AbstractInMemoryDAO<ADAOGenerics<MetadataType, OperationMetadataType>> {  
   
   public static projection<P extends AProjection>(p: P) {
     return p
   }
-  public static mergeProjection<P1 extends AProjection, P2 extends AProjection>(p1: P1, p2: P2): SelectProjection<AProjection, P1, P2> {
-    return mergeProjections(p1, p2) as SelectProjection<AProjection, P1, P2>
+  public static mergeProjection<P1 extends AProjection, P2 extends AProjection>(p1: P1, p2: P2): T.SelectProjection<AProjection, P1, P2> {
+    return T.mergeProjections(p1, p2) as T.SelectProjection<AProjection, P1, P2>
   }
   
   public constructor(params: InMemoryADAOParams<MetadataType, OperationMetadataType>){
@@ -98,7 +96,7 @@ export class InMemoryADAO<MetadataType, OperationMetadataType> extends AbstractI
       ...params, 
       idField: 'id', 
       schema: aSchema(), 
-      relations: overrideRelations(
+      relations: T.overrideRelations(
         [
           
         ]
@@ -118,7 +116,7 @@ export class InMemoryADAO<MetadataType, OperationMetadataType> extends AbstractI
 export type BExcludedFields = never
 export type BRelationFields = never
 
-export function bSchema(): Schema<types.Scalars> {
+export function bSchema(): T.Schema<types.Scalars> {
   return {
     'id': {
       scalar: 'ID', 
@@ -132,11 +130,11 @@ export function bSchema(): Schema<types.Scalars> {
 }
 
 type BFilterFields = {
-  'id'?: types.Scalars['ID'] | null | EqualityOperators<types.Scalars['ID']> | ElementOperators,
-  'value'?: types.Scalars['Int'] | null | EqualityOperators<types.Scalars['Int']> | ElementOperators | QuantityOperators<types.Scalars['Int']>
+  'id'?: types.Scalars['ID'] | null | T.EqualityOperators<types.Scalars['ID']> | T.ElementOperators,
+  'value'?: types.Scalars['Int'] | null | T.EqualityOperators<types.Scalars['Int']> | T.ElementOperators | T.QuantityOperators<types.Scalars['Int']>
 }
-export type BFilter = BFilterFields & LogicalOperators<BFilterFields | BRawFilter>
-export type BRawFilter = () => Filter<Document>
+export type BFilter = BFilterFields & T.LogicalOperators<BFilterFields | BRawFilter>
+export type BRawFilter = () => M.Filter<M.Document>
 
 export type BRelations = Record<never, string>
 
@@ -144,34 +142,34 @@ export type BProjection = {
   id?: boolean,
   value?: boolean,
 }
-export type BParam<P extends BProjection> = ParamProjection<types.B, BProjection, P>
+export type BParam<P extends BProjection> = T.ParamProjection<types.B, BProjection, P>
 
 export type BSortKeys = 'id' | 'value'
-export type BSort = OneKey<BSortKeys, SortDirection>
-export type BRawSort = () => Sort
+export type BSort = T.OneKey<BSortKeys, T.SortDirection>
+export type BRawSort = () => M.Sort
 
 export type BUpdate = {
   'id'?: types.Scalars['ID'],
   'value'?: types.Scalars['Int']
 }
-export type BRawUpdate = () => UpdateFilter<Document>
+export type BRawUpdate = () => M.UpdateFilter<M.Document>
 
 export type BInsert = {
   id?: null | types.Scalars['ID'],
   value: types.Scalars['Int'],
 }
 
-type BDAOGenerics<MetadataType, OperationMetadataType> = MongoDBDAOGenerics<types.B, 'id', 'ID', BFilter, BRawFilter, BRelations, BProjection, BSort, BRawSort, BInsert, BUpdate, BRawUpdate, BExcludedFields, BRelationFields, MetadataType, OperationMetadataType, types.Scalars, 'b', DAOContext<MetadataType, OperationMetadataType>>
-export type BDAOParams<MetadataType, OperationMetadataType> = Omit<MongoDBDAOParams<BDAOGenerics<MetadataType, OperationMetadataType>>, 'idField' | 'schema' | 'idScalar' | 'idGeneration'>
-export type InMemoryBDAOParams<MetadataType, OperationMetadataType> = Omit<InMemoryDAOParams<BDAOGenerics<MetadataType, OperationMetadataType>>, 'idField' | 'schema' | 'idScalar' | 'idGeneration'>
+type BDAOGenerics<MetadataType, OperationMetadataType> = T.MongoDBDAOGenerics<types.B, 'id', 'ID', BFilter, BRawFilter, BRelations, BProjection, BSort, BRawSort, BInsert, BUpdate, BRawUpdate, BExcludedFields, BRelationFields, MetadataType, OperationMetadataType, types.Scalars, 'b', DAOContext<MetadataType, OperationMetadataType>>
+export type BDAOParams<MetadataType, OperationMetadataType> = Omit<T.MongoDBDAOParams<BDAOGenerics<MetadataType, OperationMetadataType>>, 'idField' | 'schema' | 'idScalar' | 'idGeneration'>
+export type InMemoryBDAOParams<MetadataType, OperationMetadataType> = Omit<T.InMemoryDAOParams<BDAOGenerics<MetadataType, OperationMetadataType>>, 'idField' | 'schema' | 'idScalar' | 'idGeneration'>
 
-export class BDAO<MetadataType, OperationMetadataType> extends AbstractMongoDBDAO<BDAOGenerics<MetadataType, OperationMetadataType>> {  
+export class BDAO<MetadataType, OperationMetadataType> extends T.AbstractMongoDBDAO<BDAOGenerics<MetadataType, OperationMetadataType>> {  
   
   public static projection<P extends BProjection>(p: P) {
     return p
   }
-  public static mergeProjection<P1 extends BProjection, P2 extends BProjection>(p1: P1, p2: P2): SelectProjection<BProjection, P1, P2> {
-    return mergeProjections(p1, p2) as SelectProjection<BProjection, P1, P2>
+  public static mergeProjection<P1 extends BProjection, P2 extends BProjection>(p1: P1, p2: P2): T.SelectProjection<BProjection, P1, P2> {
+    return T.mergeProjections(p1, p2) as T.SelectProjection<BProjection, P1, P2>
   }
   
   public constructor(params: BDAOParams<MetadataType, OperationMetadataType>){
@@ -179,7 +177,7 @@ export class BDAO<MetadataType, OperationMetadataType> extends AbstractMongoDBDA
       ...params, 
       idField: 'id', 
       schema: bSchema(), 
-      relations: overrideRelations(
+      relations: T.overrideRelations(
         [
           
         ]
@@ -190,13 +188,13 @@ export class BDAO<MetadataType, OperationMetadataType> extends AbstractMongoDBDA
   }
   }
 
-export class InMemoryBDAO<MetadataType, OperationMetadataType> extends AbstractInMemoryDAO<BDAOGenerics<MetadataType, OperationMetadataType>> {  
+export class InMemoryBDAO<MetadataType, OperationMetadataType> extends T.AbstractInMemoryDAO<BDAOGenerics<MetadataType, OperationMetadataType>> {  
   
   public static projection<P extends BProjection>(p: P) {
     return p
   }
-  public static mergeProjection<P1 extends BProjection, P2 extends BProjection>(p1: P1, p2: P2): SelectProjection<BProjection, P1, P2> {
-    return mergeProjections(p1, p2) as SelectProjection<BProjection, P1, P2>
+  public static mergeProjection<P1 extends BProjection, P2 extends BProjection>(p1: P1, p2: P2): T.SelectProjection<BProjection, P1, P2> {
+    return T.mergeProjections(p1, p2) as T.SelectProjection<BProjection, P1, P2>
   }
   
   public constructor(params: InMemoryBDAOParams<MetadataType, OperationMetadataType>){
@@ -204,7 +202,7 @@ export class InMemoryBDAO<MetadataType, OperationMetadataType> extends AbstractI
       ...params, 
       idField: 'id', 
       schema: bSchema(), 
-      relations: overrideRelations(
+      relations: T.overrideRelations(
         [
           
         ]
@@ -224,7 +222,7 @@ export class InMemoryBDAO<MetadataType, OperationMetadataType> extends AbstractI
 export type CExcludedFields = never
 export type CRelationFields = never
 
-export function cSchema(): Schema<types.Scalars> {
+export function cSchema(): T.Schema<types.Scalars> {
   return {
     'id': {
       scalar: 'ID', 
@@ -238,11 +236,11 @@ export function cSchema(): Schema<types.Scalars> {
 }
 
 type CFilterFields = {
-  'id'?: types.Scalars['ID'] | null | EqualityOperators<types.Scalars['ID']> | ElementOperators,
-  'value'?: types.Scalars['Int'] | null | EqualityOperators<types.Scalars['Int']> | ElementOperators | QuantityOperators<types.Scalars['Int']>
+  'id'?: types.Scalars['ID'] | null | T.EqualityOperators<types.Scalars['ID']> | T.ElementOperators,
+  'value'?: types.Scalars['Int'] | null | T.EqualityOperators<types.Scalars['Int']> | T.ElementOperators | T.QuantityOperators<types.Scalars['Int']>
 }
-export type CFilter = CFilterFields & LogicalOperators<CFilterFields | CRawFilter>
-export type CRawFilter = () => Filter<Document>
+export type CFilter = CFilterFields & T.LogicalOperators<CFilterFields | CRawFilter>
+export type CRawFilter = () => M.Filter<M.Document>
 
 export type CRelations = Record<never, string>
 
@@ -250,34 +248,34 @@ export type CProjection = {
   id?: boolean,
   value?: boolean,
 }
-export type CParam<P extends CProjection> = ParamProjection<types.C, CProjection, P>
+export type CParam<P extends CProjection> = T.ParamProjection<types.C, CProjection, P>
 
 export type CSortKeys = 'id' | 'value'
-export type CSort = OneKey<CSortKeys, SortDirection>
-export type CRawSort = () => Sort
+export type CSort = T.OneKey<CSortKeys, T.SortDirection>
+export type CRawSort = () => M.Sort
 
 export type CUpdate = {
   'id'?: types.Scalars['ID'],
   'value'?: types.Scalars['Int']
 }
-export type CRawUpdate = () => UpdateFilter<Document>
+export type CRawUpdate = () => M.UpdateFilter<M.Document>
 
 export type CInsert = {
   id: types.Scalars['ID'],
   value: types.Scalars['Int'],
 }
 
-type CDAOGenerics<MetadataType, OperationMetadataType> = MongoDBDAOGenerics<types.C, 'id', 'ID', CFilter, CRawFilter, CRelations, CProjection, CSort, CRawSort, CInsert, CUpdate, CRawUpdate, CExcludedFields, CRelationFields, MetadataType, OperationMetadataType, types.Scalars, 'c', DAOContext<MetadataType, OperationMetadataType>>
-export type CDAOParams<MetadataType, OperationMetadataType> = Omit<MongoDBDAOParams<CDAOGenerics<MetadataType, OperationMetadataType>>, 'idGenerator' | 'idField' | 'schema' | 'idScalar' | 'idGeneration'>
-export type InMemoryCDAOParams<MetadataType, OperationMetadataType> = Omit<InMemoryDAOParams<CDAOGenerics<MetadataType, OperationMetadataType>>, 'idGenerator' | 'idField' | 'schema' | 'idScalar' | 'idGeneration'>
+type CDAOGenerics<MetadataType, OperationMetadataType> = T.MongoDBDAOGenerics<types.C, 'id', 'ID', CFilter, CRawFilter, CRelations, CProjection, CSort, CRawSort, CInsert, CUpdate, CRawUpdate, CExcludedFields, CRelationFields, MetadataType, OperationMetadataType, types.Scalars, 'c', DAOContext<MetadataType, OperationMetadataType>>
+export type CDAOParams<MetadataType, OperationMetadataType> = Omit<T.MongoDBDAOParams<CDAOGenerics<MetadataType, OperationMetadataType>>, 'idGenerator' | 'idField' | 'schema' | 'idScalar' | 'idGeneration'>
+export type InMemoryCDAOParams<MetadataType, OperationMetadataType> = Omit<T.InMemoryDAOParams<CDAOGenerics<MetadataType, OperationMetadataType>>, 'idGenerator' | 'idField' | 'schema' | 'idScalar' | 'idGeneration'>
 
-export class CDAO<MetadataType, OperationMetadataType> extends AbstractMongoDBDAO<CDAOGenerics<MetadataType, OperationMetadataType>> {  
+export class CDAO<MetadataType, OperationMetadataType> extends T.AbstractMongoDBDAO<CDAOGenerics<MetadataType, OperationMetadataType>> {  
   
   public static projection<P extends CProjection>(p: P) {
     return p
   }
-  public static mergeProjection<P1 extends CProjection, P2 extends CProjection>(p1: P1, p2: P2): SelectProjection<CProjection, P1, P2> {
-    return mergeProjections(p1, p2) as SelectProjection<CProjection, P1, P2>
+  public static mergeProjection<P1 extends CProjection, P2 extends CProjection>(p1: P1, p2: P2): T.SelectProjection<CProjection, P1, P2> {
+    return T.mergeProjections(p1, p2) as T.SelectProjection<CProjection, P1, P2>
   }
   
   public constructor(params: CDAOParams<MetadataType, OperationMetadataType>){
@@ -285,7 +283,7 @@ export class CDAO<MetadataType, OperationMetadataType> extends AbstractMongoDBDA
       ...params, 
       idField: 'id', 
       schema: cSchema(), 
-      relations: overrideRelations(
+      relations: T.overrideRelations(
         [
           
         ]
@@ -296,13 +294,13 @@ export class CDAO<MetadataType, OperationMetadataType> extends AbstractMongoDBDA
   }
   }
 
-export class InMemoryCDAO<MetadataType, OperationMetadataType> extends AbstractInMemoryDAO<CDAOGenerics<MetadataType, OperationMetadataType>> {  
+export class InMemoryCDAO<MetadataType, OperationMetadataType> extends T.AbstractInMemoryDAO<CDAOGenerics<MetadataType, OperationMetadataType>> {  
   
   public static projection<P extends CProjection>(p: P) {
     return p
   }
-  public static mergeProjection<P1 extends CProjection, P2 extends CProjection>(p1: P1, p2: P2): SelectProjection<CProjection, P1, P2> {
-    return mergeProjections(p1, p2) as SelectProjection<CProjection, P1, P2>
+  public static mergeProjection<P1 extends CProjection, P2 extends CProjection>(p1: P1, p2: P2): T.SelectProjection<CProjection, P1, P2> {
+    return T.mergeProjections(p1, p2) as T.SelectProjection<CProjection, P1, P2>
   }
   
   public constructor(params: InMemoryCDAOParams<MetadataType, OperationMetadataType>){
@@ -310,7 +308,7 @@ export class InMemoryCDAO<MetadataType, OperationMetadataType> extends AbstractI
       ...params, 
       idField: 'id', 
       schema: cSchema(), 
-      relations: overrideRelations(
+      relations: T.overrideRelations(
         [
           
         ]
@@ -330,7 +328,7 @@ export class InMemoryCDAO<MetadataType, OperationMetadataType> extends AbstractI
 export type DExcludedFields = never
 export type DRelationFields = never
 
-export function dSchema(): Schema<types.Scalars> {
+export function dSchema(): T.Schema<types.Scalars> {
   return {
     'id': {
       scalar: 'IntAutoInc', 
@@ -344,10 +342,10 @@ export function dSchema(): Schema<types.Scalars> {
 }
 
 type DFilterFields = {
-  'id'?: types.Scalars['IntAutoInc'] | null | EqualityOperators<types.Scalars['IntAutoInc']> | ElementOperators,
-  'value'?: types.Scalars['Int'] | null | EqualityOperators<types.Scalars['Int']> | ElementOperators | QuantityOperators<types.Scalars['Int']>
+  'id'?: types.Scalars['IntAutoInc'] | null | T.EqualityOperators<types.Scalars['IntAutoInc']> | T.ElementOperators,
+  'value'?: types.Scalars['Int'] | null | T.EqualityOperators<types.Scalars['Int']> | T.ElementOperators | T.QuantityOperators<types.Scalars['Int']>
 }
-export type DFilter = DFilterFields & LogicalOperators<DFilterFields | DRawFilter>
+export type DFilter = DFilterFields & T.LogicalOperators<DFilterFields | DRawFilter>
 export type DRawFilter = (builder: Knex.QueryBuilder<any, any>) => Knex.QueryBuilder<any, any>
 
 export type DRelations = Record<never, string>
@@ -356,10 +354,10 @@ export type DProjection = {
   id?: boolean,
   value?: boolean,
 }
-export type DParam<P extends DProjection> = ParamProjection<types.D, DProjection, P>
+export type DParam<P extends DProjection> = T.ParamProjection<types.D, DProjection, P>
 
 export type DSortKeys = 'id' | 'value'
-export type DSort = OneKey<DSortKeys, SortDirection>
+export type DSort = T.OneKey<DSortKeys, T.SortDirection>
 export type DRawSort = (builder: Knex.QueryBuilder<any, any>) => Knex.QueryBuilder<any, any>
 
 export type DUpdate = {
@@ -372,17 +370,17 @@ export type DInsert = {
   value: types.Scalars['Int'],
 }
 
-type DDAOGenerics<MetadataType, OperationMetadataType> = KnexJsDAOGenerics<types.D, 'id', 'IntAutoInc', DFilter, DRawFilter, DRelations, DProjection, DSort, DRawSort, DInsert, DUpdate, DRawUpdate, DExcludedFields, DRelationFields, MetadataType, OperationMetadataType, types.Scalars, 'd', DAOContext<MetadataType, OperationMetadataType>>
-export type DDAOParams<MetadataType, OperationMetadataType> = Omit<KnexJsDAOParams<DDAOGenerics<MetadataType, OperationMetadataType>>, 'idGenerator' | 'idField' | 'schema' | 'idScalar' | 'idGeneration'>
-export type InMemoryDDAOParams<MetadataType, OperationMetadataType> = Omit<InMemoryDAOParams<DDAOGenerics<MetadataType, OperationMetadataType>>, 'idGenerator' | 'idField' | 'schema' | 'idScalar' | 'idGeneration'>
+type DDAOGenerics<MetadataType, OperationMetadataType> = T.KnexJsDAOGenerics<types.D, 'id', 'IntAutoInc', DFilter, DRawFilter, DRelations, DProjection, DSort, DRawSort, DInsert, DUpdate, DRawUpdate, DExcludedFields, DRelationFields, MetadataType, OperationMetadataType, types.Scalars, 'd', DAOContext<MetadataType, OperationMetadataType>>
+export type DDAOParams<MetadataType, OperationMetadataType> = Omit<T.KnexJsDAOParams<DDAOGenerics<MetadataType, OperationMetadataType>>, 'idGenerator' | 'idField' | 'schema' | 'idScalar' | 'idGeneration'>
+export type InMemoryDDAOParams<MetadataType, OperationMetadataType> = Omit<T.InMemoryDAOParams<DDAOGenerics<MetadataType, OperationMetadataType>>, 'idGenerator' | 'idField' | 'schema' | 'idScalar' | 'idGeneration'>
 
-export class DDAO<MetadataType, OperationMetadataType> extends AbstractKnexJsDAO<DDAOGenerics<MetadataType, OperationMetadataType>> {  
+export class DDAO<MetadataType, OperationMetadataType> extends T.AbstractKnexJsDAO<DDAOGenerics<MetadataType, OperationMetadataType>> {  
   
   public static projection<P extends DProjection>(p: P) {
     return p
   }
-  public static mergeProjection<P1 extends DProjection, P2 extends DProjection>(p1: P1, p2: P2): SelectProjection<DProjection, P1, P2> {
-    return mergeProjections(p1, p2) as SelectProjection<DProjection, P1, P2>
+  public static mergeProjection<P1 extends DProjection, P2 extends DProjection>(p1: P1, p2: P2): T.SelectProjection<DProjection, P1, P2> {
+    return T.mergeProjections(p1, p2) as T.SelectProjection<DProjection, P1, P2>
   }
   
   public constructor(params: DDAOParams<MetadataType, OperationMetadataType>){
@@ -390,7 +388,7 @@ export class DDAO<MetadataType, OperationMetadataType> extends AbstractKnexJsDAO
       ...params, 
       idField: 'id', 
       schema: dSchema(), 
-      relations: overrideRelations(
+      relations: T.overrideRelations(
         [
           
         ]
@@ -401,13 +399,13 @@ export class DDAO<MetadataType, OperationMetadataType> extends AbstractKnexJsDAO
   }
   }
 
-export class InMemoryDDAO<MetadataType, OperationMetadataType> extends AbstractInMemoryDAO<DDAOGenerics<MetadataType, OperationMetadataType>> {  
+export class InMemoryDDAO<MetadataType, OperationMetadataType> extends T.AbstractInMemoryDAO<DDAOGenerics<MetadataType, OperationMetadataType>> {  
   
   public static projection<P extends DProjection>(p: P) {
     return p
   }
-  public static mergeProjection<P1 extends DProjection, P2 extends DProjection>(p1: P1, p2: P2): SelectProjection<DProjection, P1, P2> {
-    return mergeProjections(p1, p2) as SelectProjection<DProjection, P1, P2>
+  public static mergeProjection<P1 extends DProjection, P2 extends DProjection>(p1: P1, p2: P2): T.SelectProjection<DProjection, P1, P2> {
+    return T.mergeProjections(p1, p2) as T.SelectProjection<DProjection, P1, P2>
   }
   
   public constructor(params: InMemoryDDAOParams<MetadataType, OperationMetadataType>){
@@ -415,7 +413,7 @@ export class InMemoryDDAO<MetadataType, OperationMetadataType> extends AbstractI
       ...params, 
       idField: 'id', 
       schema: dSchema(), 
-      relations: overrideRelations(
+      relations: T.overrideRelations(
         [
           
         ]
@@ -435,7 +433,7 @@ export class InMemoryDDAO<MetadataType, OperationMetadataType> extends AbstractI
 export type EExcludedFields = never
 export type ERelationFields = never
 
-export function eSchema(): Schema<types.Scalars> {
+export function eSchema(): T.Schema<types.Scalars> {
   return {
     'id': {
       scalar: 'ID', 
@@ -449,10 +447,10 @@ export function eSchema(): Schema<types.Scalars> {
 }
 
 type EFilterFields = {
-  'id'?: types.Scalars['ID'] | null | EqualityOperators<types.Scalars['ID']> | ElementOperators,
-  'value'?: types.Scalars['Int'] | null | EqualityOperators<types.Scalars['Int']> | ElementOperators | QuantityOperators<types.Scalars['Int']>
+  'id'?: types.Scalars['ID'] | null | T.EqualityOperators<types.Scalars['ID']> | T.ElementOperators,
+  'value'?: types.Scalars['Int'] | null | T.EqualityOperators<types.Scalars['Int']> | T.ElementOperators | T.QuantityOperators<types.Scalars['Int']>
 }
-export type EFilter = EFilterFields & LogicalOperators<EFilterFields | ERawFilter>
+export type EFilter = EFilterFields & T.LogicalOperators<EFilterFields | ERawFilter>
 export type ERawFilter = (builder: Knex.QueryBuilder<any, any>) => Knex.QueryBuilder<any, any>
 
 export type ERelations = Record<never, string>
@@ -461,10 +459,10 @@ export type EProjection = {
   id?: boolean,
   value?: boolean,
 }
-export type EParam<P extends EProjection> = ParamProjection<types.E, EProjection, P>
+export type EParam<P extends EProjection> = T.ParamProjection<types.E, EProjection, P>
 
 export type ESortKeys = 'id' | 'value'
-export type ESort = OneKey<ESortKeys, SortDirection>
+export type ESort = T.OneKey<ESortKeys, T.SortDirection>
 export type ERawSort = (builder: Knex.QueryBuilder<any, any>) => Knex.QueryBuilder<any, any>
 
 export type EUpdate = {
@@ -478,17 +476,17 @@ export type EInsert = {
   value: types.Scalars['Int'],
 }
 
-type EDAOGenerics<MetadataType, OperationMetadataType> = KnexJsDAOGenerics<types.E, 'id', 'ID', EFilter, ERawFilter, ERelations, EProjection, ESort, ERawSort, EInsert, EUpdate, ERawUpdate, EExcludedFields, ERelationFields, MetadataType, OperationMetadataType, types.Scalars, 'e', DAOContext<MetadataType, OperationMetadataType>>
-export type EDAOParams<MetadataType, OperationMetadataType> = Omit<KnexJsDAOParams<EDAOGenerics<MetadataType, OperationMetadataType>>, 'idField' | 'schema' | 'idScalar' | 'idGeneration'>
-export type InMemoryEDAOParams<MetadataType, OperationMetadataType> = Omit<InMemoryDAOParams<EDAOGenerics<MetadataType, OperationMetadataType>>, 'idField' | 'schema' | 'idScalar' | 'idGeneration'>
+type EDAOGenerics<MetadataType, OperationMetadataType> = T.KnexJsDAOGenerics<types.E, 'id', 'ID', EFilter, ERawFilter, ERelations, EProjection, ESort, ERawSort, EInsert, EUpdate, ERawUpdate, EExcludedFields, ERelationFields, MetadataType, OperationMetadataType, types.Scalars, 'e', DAOContext<MetadataType, OperationMetadataType>>
+export type EDAOParams<MetadataType, OperationMetadataType> = Omit<T.KnexJsDAOParams<EDAOGenerics<MetadataType, OperationMetadataType>>, 'idField' | 'schema' | 'idScalar' | 'idGeneration'>
+export type InMemoryEDAOParams<MetadataType, OperationMetadataType> = Omit<T.InMemoryDAOParams<EDAOGenerics<MetadataType, OperationMetadataType>>, 'idField' | 'schema' | 'idScalar' | 'idGeneration'>
 
-export class EDAO<MetadataType, OperationMetadataType> extends AbstractKnexJsDAO<EDAOGenerics<MetadataType, OperationMetadataType>> {  
+export class EDAO<MetadataType, OperationMetadataType> extends T.AbstractKnexJsDAO<EDAOGenerics<MetadataType, OperationMetadataType>> {  
   
   public static projection<P extends EProjection>(p: P) {
     return p
   }
-  public static mergeProjection<P1 extends EProjection, P2 extends EProjection>(p1: P1, p2: P2): SelectProjection<EProjection, P1, P2> {
-    return mergeProjections(p1, p2) as SelectProjection<EProjection, P1, P2>
+  public static mergeProjection<P1 extends EProjection, P2 extends EProjection>(p1: P1, p2: P2): T.SelectProjection<EProjection, P1, P2> {
+    return T.mergeProjections(p1, p2) as T.SelectProjection<EProjection, P1, P2>
   }
   
   public constructor(params: EDAOParams<MetadataType, OperationMetadataType>){
@@ -496,7 +494,7 @@ export class EDAO<MetadataType, OperationMetadataType> extends AbstractKnexJsDAO
       ...params, 
       idField: 'id', 
       schema: eSchema(), 
-      relations: overrideRelations(
+      relations: T.overrideRelations(
         [
           
         ]
@@ -507,13 +505,13 @@ export class EDAO<MetadataType, OperationMetadataType> extends AbstractKnexJsDAO
   }
   }
 
-export class InMemoryEDAO<MetadataType, OperationMetadataType> extends AbstractInMemoryDAO<EDAOGenerics<MetadataType, OperationMetadataType>> {  
+export class InMemoryEDAO<MetadataType, OperationMetadataType> extends T.AbstractInMemoryDAO<EDAOGenerics<MetadataType, OperationMetadataType>> {  
   
   public static projection<P extends EProjection>(p: P) {
     return p
   }
-  public static mergeProjection<P1 extends EProjection, P2 extends EProjection>(p1: P1, p2: P2): SelectProjection<EProjection, P1, P2> {
-    return mergeProjections(p1, p2) as SelectProjection<EProjection, P1, P2>
+  public static mergeProjection<P1 extends EProjection, P2 extends EProjection>(p1: P1, p2: P2): T.SelectProjection<EProjection, P1, P2> {
+    return T.mergeProjections(p1, p2) as T.SelectProjection<EProjection, P1, P2>
   }
   
   public constructor(params: InMemoryEDAOParams<MetadataType, OperationMetadataType>){
@@ -521,7 +519,7 @@ export class InMemoryEDAO<MetadataType, OperationMetadataType> extends AbstractI
       ...params, 
       idField: 'id', 
       schema: eSchema(), 
-      relations: overrideRelations(
+      relations: T.overrideRelations(
         [
           
         ]
@@ -541,7 +539,7 @@ export class InMemoryEDAO<MetadataType, OperationMetadataType> extends AbstractI
 export type FExcludedFields = never
 export type FRelationFields = never
 
-export function fSchema(): Schema<types.Scalars> {
+export function fSchema(): T.Schema<types.Scalars> {
   return {
     'id': {
       scalar: 'ID', 
@@ -555,10 +553,10 @@ export function fSchema(): Schema<types.Scalars> {
 }
 
 type FFilterFields = {
-  'id'?: types.Scalars['ID'] | null | EqualityOperators<types.Scalars['ID']> | ElementOperators,
-  'value'?: types.Scalars['Int'] | null | EqualityOperators<types.Scalars['Int']> | ElementOperators | QuantityOperators<types.Scalars['Int']>
+  'id'?: types.Scalars['ID'] | null | T.EqualityOperators<types.Scalars['ID']> | T.ElementOperators,
+  'value'?: types.Scalars['Int'] | null | T.EqualityOperators<types.Scalars['Int']> | T.ElementOperators | T.QuantityOperators<types.Scalars['Int']>
 }
-export type FFilter = FFilterFields & LogicalOperators<FFilterFields | FRawFilter>
+export type FFilter = FFilterFields & T.LogicalOperators<FFilterFields | FRawFilter>
 export type FRawFilter = (builder: Knex.QueryBuilder<any, any>) => Knex.QueryBuilder<any, any>
 
 export type FRelations = Record<never, string>
@@ -567,10 +565,10 @@ export type FProjection = {
   id?: boolean,
   value?: boolean,
 }
-export type FParam<P extends FProjection> = ParamProjection<types.F, FProjection, P>
+export type FParam<P extends FProjection> = T.ParamProjection<types.F, FProjection, P>
 
 export type FSortKeys = 'id' | 'value'
-export type FSort = OneKey<FSortKeys, SortDirection>
+export type FSort = T.OneKey<FSortKeys, T.SortDirection>
 export type FRawSort = (builder: Knex.QueryBuilder<any, any>) => Knex.QueryBuilder<any, any>
 
 export type FUpdate = {
@@ -584,17 +582,17 @@ export type FInsert = {
   value: types.Scalars['Int'],
 }
 
-type FDAOGenerics<MetadataType, OperationMetadataType> = KnexJsDAOGenerics<types.F, 'id', 'ID', FFilter, FRawFilter, FRelations, FProjection, FSort, FRawSort, FInsert, FUpdate, FRawUpdate, FExcludedFields, FRelationFields, MetadataType, OperationMetadataType, types.Scalars, 'f', DAOContext<MetadataType, OperationMetadataType>>
-export type FDAOParams<MetadataType, OperationMetadataType> = Omit<KnexJsDAOParams<FDAOGenerics<MetadataType, OperationMetadataType>>, 'idGenerator' | 'idField' | 'schema' | 'idScalar' | 'idGeneration'>
-export type InMemoryFDAOParams<MetadataType, OperationMetadataType> = Omit<InMemoryDAOParams<FDAOGenerics<MetadataType, OperationMetadataType>>, 'idGenerator' | 'idField' | 'schema' | 'idScalar' | 'idGeneration'>
+type FDAOGenerics<MetadataType, OperationMetadataType> = T.KnexJsDAOGenerics<types.F, 'id', 'ID', FFilter, FRawFilter, FRelations, FProjection, FSort, FRawSort, FInsert, FUpdate, FRawUpdate, FExcludedFields, FRelationFields, MetadataType, OperationMetadataType, types.Scalars, 'f', DAOContext<MetadataType, OperationMetadataType>>
+export type FDAOParams<MetadataType, OperationMetadataType> = Omit<T.KnexJsDAOParams<FDAOGenerics<MetadataType, OperationMetadataType>>, 'idGenerator' | 'idField' | 'schema' | 'idScalar' | 'idGeneration'>
+export type InMemoryFDAOParams<MetadataType, OperationMetadataType> = Omit<T.InMemoryDAOParams<FDAOGenerics<MetadataType, OperationMetadataType>>, 'idGenerator' | 'idField' | 'schema' | 'idScalar' | 'idGeneration'>
 
-export class FDAO<MetadataType, OperationMetadataType> extends AbstractKnexJsDAO<FDAOGenerics<MetadataType, OperationMetadataType>> {  
+export class FDAO<MetadataType, OperationMetadataType> extends T.AbstractKnexJsDAO<FDAOGenerics<MetadataType, OperationMetadataType>> {  
   
   public static projection<P extends FProjection>(p: P) {
     return p
   }
-  public static mergeProjection<P1 extends FProjection, P2 extends FProjection>(p1: P1, p2: P2): SelectProjection<FProjection, P1, P2> {
-    return mergeProjections(p1, p2) as SelectProjection<FProjection, P1, P2>
+  public static mergeProjection<P1 extends FProjection, P2 extends FProjection>(p1: P1, p2: P2): T.SelectProjection<FProjection, P1, P2> {
+    return T.mergeProjections(p1, p2) as T.SelectProjection<FProjection, P1, P2>
   }
   
   public constructor(params: FDAOParams<MetadataType, OperationMetadataType>){
@@ -602,7 +600,7 @@ export class FDAO<MetadataType, OperationMetadataType> extends AbstractKnexJsDAO
       ...params, 
       idField: 'id', 
       schema: fSchema(), 
-      relations: overrideRelations(
+      relations: T.overrideRelations(
         [
           
         ]
@@ -613,13 +611,13 @@ export class FDAO<MetadataType, OperationMetadataType> extends AbstractKnexJsDAO
   }
   }
 
-export class InMemoryFDAO<MetadataType, OperationMetadataType> extends AbstractInMemoryDAO<FDAOGenerics<MetadataType, OperationMetadataType>> {  
+export class InMemoryFDAO<MetadataType, OperationMetadataType> extends T.AbstractInMemoryDAO<FDAOGenerics<MetadataType, OperationMetadataType>> {  
   
   public static projection<P extends FProjection>(p: P) {
     return p
   }
-  public static mergeProjection<P1 extends FProjection, P2 extends FProjection>(p1: P1, p2: P2): SelectProjection<FProjection, P1, P2> {
-    return mergeProjections(p1, p2) as SelectProjection<FProjection, P1, P2>
+  public static mergeProjection<P1 extends FProjection, P2 extends FProjection>(p1: P1, p2: P2): T.SelectProjection<FProjection, P1, P2> {
+    return T.mergeProjections(p1, p2) as T.SelectProjection<FProjection, P1, P2>
   }
   
   public constructor(params: InMemoryFDAOParams<MetadataType, OperationMetadataType>){
@@ -627,7 +625,7 @@ export class InMemoryFDAO<MetadataType, OperationMetadataType> extends AbstractI
       ...params, 
       idField: 'id', 
       schema: fSchema(), 
-      relations: overrideRelations(
+      relations: T.overrideRelations(
         [
           
         ]
@@ -650,16 +648,16 @@ export type DAOContextParams<MetadataType, OperationMetadataType, Permissions ex
     e?: Pick<Partial<EDAOParams<MetadataType, OperationMetadataType>>, 'idGenerator' | 'middlewares' | 'metadata'>,
     f?: Pick<Partial<FDAOParams<MetadataType, OperationMetadataType>>, 'middlewares' | 'metadata'>
   },
-  mongodb: Record<'a' | 'default', Db | 'mock'>,
+  mongodb: Record<'a' | 'default', M.Db | 'mock'>,
   knex: Record<'default', Knex | 'mock'>,
-  scalars?: UserInputDriverDataTypeAdapterMap<types.Scalars, 'both'>,
-  log?: LogInput<'a' | 'b' | 'c' | 'd' | 'e' | 'f'>,
-  security?: DAOContextSecurtyPolicy<DAOGenericsMap<MetadataType, OperationMetadataType>, OperationMetadataType, Permissions, SecurityDomain>
+  scalars?: T.UserInputDriverDataTypeAdapterMap<types.Scalars, 'both'>,
+  log?: T.LogInput<'a' | 'b' | 'c' | 'd' | 'e' | 'f'>,
+  security?: T.DAOContextSecurtyPolicy<DAOGenericsMap<MetadataType, OperationMetadataType>, OperationMetadataType, Permissions, SecurityDomain>
 }
 
-type DAOContextMiddleware<MetadataType = never, OperationMetadataType = never> = DAOMiddleware<DAOGenericsUnion<MetadataType, OperationMetadataType>>
+type DAOContextMiddleware<MetadataType = never, OperationMetadataType = never> = T.DAOMiddleware<DAOGenericsUnion<MetadataType, OperationMetadataType>>
 
-export class DAOContext<MetadataType = never, OperationMetadataType = never, Permissions extends string = never, SecurityDomain extends object = never> extends AbstractDAOContext<'a' | 'default', 'default', types.Scalars, MetadataType>  {
+export class DAOContext<MetadataType = never, OperationMetadataType = never, Permissions extends string = never, SecurityDomain extends object = never> extends T.AbstractDAOContext<'a' | 'default', 'default', types.Scalars, MetadataType>  {
 
   private _a: ADAO<MetadataType, OperationMetadataType> | undefined
   private _b: BDAO<MetadataType, OperationMetadataType> | undefined
@@ -671,52 +669,52 @@ export class DAOContext<MetadataType = never, OperationMetadataType = never, Per
   private params: DAOContextParams<MetadataType, OperationMetadataType, Permissions, SecurityDomain>
   
   private overrides: DAOContextParams<MetadataType, OperationMetadataType, Permissions, SecurityDomain>['overrides']
-  private mongodb: Record<'a' | 'default', Db | 'mock'>
+  private mongodb: Record<'a' | 'default', M.Db | 'mock'>
   private knex: Record<'default', Knex | 'mock'>
   
   private middlewares: (DAOContextMiddleware<MetadataType, OperationMetadataType> | GroupMiddleware<any, MetadataType, OperationMetadataType>)[]
   
-  private logger?: LogFunction<'a' | 'b' | 'c' | 'd' | 'e' | 'f'>
+  private logger?: T.LogFunction<'a' | 'b' | 'c' | 'd' | 'e' | 'f'>
   
   get a(): ADAO<MetadataType, OperationMetadataType> {
     if(!this._a) {
       const db = this.mongodb.a
-      this._a = db === 'mock' ? (new InMemoryADAO({ daoContext: this, datasource: null, metadata: this.metadata, ...this.overrides?.a, middlewares: [...(this.overrides?.a?.middlewares || []), ...selectMiddleware('a', this.middlewares) as DAOMiddleware<ADAOGenerics<MetadataType, OperationMetadataType>>[]], name: 'a', logger: this.logger }) as unknown as ADAO<MetadataType, OperationMetadataType>) : new ADAO({ daoContext: this, datasource: 'a', metadata: this.metadata, ...this.overrides?.a, collection: db.collection('as'), middlewares: [...(this.overrides?.a?.middlewares || []), ...selectMiddleware('a', this.middlewares) as DAOMiddleware<ADAOGenerics<MetadataType, OperationMetadataType>>[]], name: 'a', logger: this.logger })
+      this._a = db === 'mock' ? (new InMemoryADAO({ daoContext: this, datasource: null, metadata: this.metadata, ...this.overrides?.a, middlewares: [...(this.overrides?.a?.middlewares || []), ...selectMiddleware('a', this.middlewares) as T.DAOMiddleware<ADAOGenerics<MetadataType, OperationMetadataType>>[]], name: 'a', logger: this.logger }) as unknown as ADAO<MetadataType, OperationMetadataType>) : new ADAO({ daoContext: this, datasource: 'a', metadata: this.metadata, ...this.overrides?.a, collection: db.collection('as'), middlewares: [...(this.overrides?.a?.middlewares || []), ...selectMiddleware('a', this.middlewares) as T.DAOMiddleware<ADAOGenerics<MetadataType, OperationMetadataType>>[]], name: 'a', logger: this.logger })
     }
     return this._a
   }
   get b(): BDAO<MetadataType, OperationMetadataType> {
     if(!this._b) {
       const db = this.mongodb.default
-      this._b = db === 'mock' ? (new InMemoryBDAO({ daoContext: this, datasource: null, metadata: this.metadata, ...this.overrides?.b, middlewares: [...(this.overrides?.b?.middlewares || []), ...selectMiddleware('b', this.middlewares) as DAOMiddleware<BDAOGenerics<MetadataType, OperationMetadataType>>[]], name: 'b', logger: this.logger }) as unknown as BDAO<MetadataType, OperationMetadataType>) : new BDAO({ daoContext: this, datasource: 'default', metadata: this.metadata, ...this.overrides?.b, collection: db.collection('bs'), middlewares: [...(this.overrides?.b?.middlewares || []), ...selectMiddleware('b', this.middlewares) as DAOMiddleware<BDAOGenerics<MetadataType, OperationMetadataType>>[]], name: 'b', logger: this.logger })
+      this._b = db === 'mock' ? (new InMemoryBDAO({ daoContext: this, datasource: null, metadata: this.metadata, ...this.overrides?.b, middlewares: [...(this.overrides?.b?.middlewares || []), ...selectMiddleware('b', this.middlewares) as T.DAOMiddleware<BDAOGenerics<MetadataType, OperationMetadataType>>[]], name: 'b', logger: this.logger }) as unknown as BDAO<MetadataType, OperationMetadataType>) : new BDAO({ daoContext: this, datasource: 'default', metadata: this.metadata, ...this.overrides?.b, collection: db.collection('bs'), middlewares: [...(this.overrides?.b?.middlewares || []), ...selectMiddleware('b', this.middlewares) as T.DAOMiddleware<BDAOGenerics<MetadataType, OperationMetadataType>>[]], name: 'b', logger: this.logger })
     }
     return this._b
   }
   get c(): CDAO<MetadataType, OperationMetadataType> {
     if(!this._c) {
       const db = this.mongodb.default
-      this._c = db === 'mock' ? (new InMemoryCDAO({ daoContext: this, datasource: null, metadata: this.metadata, ...this.overrides?.c, middlewares: [...(this.overrides?.c?.middlewares || []), ...selectMiddleware('c', this.middlewares) as DAOMiddleware<CDAOGenerics<MetadataType, OperationMetadataType>>[]], name: 'c', logger: this.logger }) as unknown as CDAO<MetadataType, OperationMetadataType>) : new CDAO({ daoContext: this, datasource: 'default', metadata: this.metadata, ...this.overrides?.c, collection: db.collection('cs'), middlewares: [...(this.overrides?.c?.middlewares || []), ...selectMiddleware('c', this.middlewares) as DAOMiddleware<CDAOGenerics<MetadataType, OperationMetadataType>>[]], name: 'c', logger: this.logger })
+      this._c = db === 'mock' ? (new InMemoryCDAO({ daoContext: this, datasource: null, metadata: this.metadata, ...this.overrides?.c, middlewares: [...(this.overrides?.c?.middlewares || []), ...selectMiddleware('c', this.middlewares) as T.DAOMiddleware<CDAOGenerics<MetadataType, OperationMetadataType>>[]], name: 'c', logger: this.logger }) as unknown as CDAO<MetadataType, OperationMetadataType>) : new CDAO({ daoContext: this, datasource: 'default', metadata: this.metadata, ...this.overrides?.c, collection: db.collection('cs'), middlewares: [...(this.overrides?.c?.middlewares || []), ...selectMiddleware('c', this.middlewares) as T.DAOMiddleware<CDAOGenerics<MetadataType, OperationMetadataType>>[]], name: 'c', logger: this.logger })
     }
     return this._c
   }
   get d(): DDAO<MetadataType, OperationMetadataType> {
     if(!this._d) {
       const db = this.knex.default
-      this._d = db === 'mock' ? (new InMemoryDDAO({ daoContext: this, datasource: null, metadata: this.metadata, ...this.overrides?.d, middlewares: [...(this.overrides?.d?.middlewares || []), ...selectMiddleware('d', this.middlewares) as DAOMiddleware<DDAOGenerics<MetadataType, OperationMetadataType>>[]], name: 'd', logger: this.logger }) as unknown as DDAO<MetadataType, OperationMetadataType>) : new DDAO({ daoContext: this, datasource: 'default', metadata: this.metadata, ...this.overrides?.d, knex: db, tableName: 'ds', middlewares: [...(this.overrides?.d?.middlewares || []), ...selectMiddleware('d', this.middlewares) as DAOMiddleware<DDAOGenerics<MetadataType, OperationMetadataType>>[]], name: 'd', logger: this.logger })
+      this._d = db === 'mock' ? (new InMemoryDDAO({ daoContext: this, datasource: null, metadata: this.metadata, ...this.overrides?.d, middlewares: [...(this.overrides?.d?.middlewares || []), ...selectMiddleware('d', this.middlewares) as T.DAOMiddleware<DDAOGenerics<MetadataType, OperationMetadataType>>[]], name: 'd', logger: this.logger }) as unknown as DDAO<MetadataType, OperationMetadataType>) : new DDAO({ daoContext: this, datasource: 'default', metadata: this.metadata, ...this.overrides?.d, knex: db, tableName: 'ds', middlewares: [...(this.overrides?.d?.middlewares || []), ...selectMiddleware('d', this.middlewares) as T.DAOMiddleware<DDAOGenerics<MetadataType, OperationMetadataType>>[]], name: 'd', logger: this.logger })
     }
     return this._d
   }
   get e(): EDAO<MetadataType, OperationMetadataType> {
     if(!this._e) {
       const db = this.knex.default
-      this._e = db === 'mock' ? (new InMemoryEDAO({ daoContext: this, datasource: null, metadata: this.metadata, ...this.overrides?.e, middlewares: [...(this.overrides?.e?.middlewares || []), ...selectMiddleware('e', this.middlewares) as DAOMiddleware<EDAOGenerics<MetadataType, OperationMetadataType>>[]], name: 'e', logger: this.logger }) as unknown as EDAO<MetadataType, OperationMetadataType>) : new EDAO({ daoContext: this, datasource: 'default', metadata: this.metadata, ...this.overrides?.e, knex: db, tableName: 'es', middlewares: [...(this.overrides?.e?.middlewares || []), ...selectMiddleware('e', this.middlewares) as DAOMiddleware<EDAOGenerics<MetadataType, OperationMetadataType>>[]], name: 'e', logger: this.logger })
+      this._e = db === 'mock' ? (new InMemoryEDAO({ daoContext: this, datasource: null, metadata: this.metadata, ...this.overrides?.e, middlewares: [...(this.overrides?.e?.middlewares || []), ...selectMiddleware('e', this.middlewares) as T.DAOMiddleware<EDAOGenerics<MetadataType, OperationMetadataType>>[]], name: 'e', logger: this.logger }) as unknown as EDAO<MetadataType, OperationMetadataType>) : new EDAO({ daoContext: this, datasource: 'default', metadata: this.metadata, ...this.overrides?.e, knex: db, tableName: 'es', middlewares: [...(this.overrides?.e?.middlewares || []), ...selectMiddleware('e', this.middlewares) as T.DAOMiddleware<EDAOGenerics<MetadataType, OperationMetadataType>>[]], name: 'e', logger: this.logger })
     }
     return this._e
   }
   get f(): FDAO<MetadataType, OperationMetadataType> {
     if(!this._f) {
       const db = this.knex.default
-      this._f = db === 'mock' ? (new InMemoryFDAO({ daoContext: this, datasource: null, metadata: this.metadata, ...this.overrides?.f, middlewares: [...(this.overrides?.f?.middlewares || []), ...selectMiddleware('f', this.middlewares) as DAOMiddleware<FDAOGenerics<MetadataType, OperationMetadataType>>[]], name: 'f', logger: this.logger }) as unknown as FDAO<MetadataType, OperationMetadataType>) : new FDAO({ daoContext: this, datasource: 'default', metadata: this.metadata, ...this.overrides?.f, knex: db, tableName: 'fs', middlewares: [...(this.overrides?.f?.middlewares || []), ...selectMiddleware('f', this.middlewares) as DAOMiddleware<FDAOGenerics<MetadataType, OperationMetadataType>>[]], name: 'f', logger: this.logger })
+      this._f = db === 'mock' ? (new InMemoryFDAO({ daoContext: this, datasource: null, metadata: this.metadata, ...this.overrides?.f, middlewares: [...(this.overrides?.f?.middlewares || []), ...selectMiddleware('f', this.middlewares) as T.DAOMiddleware<FDAOGenerics<MetadataType, OperationMetadataType>>[]], name: 'f', logger: this.logger }) as unknown as FDAO<MetadataType, OperationMetadataType>) : new FDAO({ daoContext: this, datasource: 'default', metadata: this.metadata, ...this.overrides?.f, knex: db, tableName: 'fs', middlewares: [...(this.overrides?.f?.middlewares || []), ...selectMiddleware('f', this.middlewares) as T.DAOMiddleware<FDAOGenerics<MetadataType, OperationMetadataType>>[]], name: 'f', logger: this.logger })
     }
     return this._f
   }
@@ -724,22 +722,22 @@ export class DAOContext<MetadataType = never, OperationMetadataType = never, Per
   constructor(params: DAOContextParams<MetadataType, OperationMetadataType, Permissions, SecurityDomain>) {
     super({
       ...params,
-      scalars: params.scalars ? userInputDataTypeAdapterToDataTypeAdapter(params.scalars, ['Decimal', 'IntAutoInc', 'JSON', 'MongoID', 'ID', 'String', 'Boolean', 'Int', 'Float']) : undefined
+      scalars: params.scalars ? T.userInputDataTypeAdapterToDataTypeAdapter(params.scalars, ['Decimal', 'IntAutoInc', 'JSON', 'MongoID', 'ID', 'String', 'Boolean', 'Int', 'Float']) : undefined
     })
     this.overrides = params.overrides
     this.mongodb = params.mongodb
     this.knex = params.knex
     this.middlewares = params.middlewares || []
-    this.logger = logInputToLogger(params.log)
+    this.logger = T.logInputToLogger(params.log)
     if(params.security && params.security.applySecurity !== false) {
-      const securityMiddlewares = createSecurityPolicyMiddlewares(params.security)
+      const securityMiddlewares = T.createSecurityPolicyMiddlewares(params.security)
       const defaultMiddleware = securityMiddlewares.others ? [groupMiddleware.excludes(Object.fromEntries(Object.keys(securityMiddlewares.middlewares).map(k => [k, true])) as any, securityMiddlewares.others as any)] : []
       this.middlewares = [...(params.middlewares ?? []), ...defaultMiddleware, ...Object.entries(securityMiddlewares.middlewares).map(([name, middleware]) => groupMiddleware.includes({[name]: true} as any, middleware as any))]
     }
     this.params = params
   }
   
-  public async execQuery<T>(run: (dbs: { mongodb: Record<'a' | 'default', Db | 'mock'>, knex: Record<'default', Knex | 'mock'> }, entities: { a: Collection<Document> | null, b: Collection<Document> | null, c: Collection<Document> | null, d: Knex.QueryBuilder<any, unknown[]> | null, e: Knex.QueryBuilder<any, unknown[]> | null, f: Knex.QueryBuilder<any, unknown[]> | null }) => Promise<T>): Promise<T> {
+  public async execQuery<T>(run: (dbs: { mongodb: Record<'a' | 'default', M.Db | 'mock'>, knex: Record<'default', Knex | 'mock'> }, entities: { a: M.Collection<M.Document> | null, b: M.Collection<M.Document> | null, c: M.Collection<M.Document> | null, d: Knex.QueryBuilder<any, unknown[]> | null, e: Knex.QueryBuilder<any, unknown[]> | null, f: Knex.QueryBuilder<any, unknown[]> | null }) => Promise<T>): Promise<T> {
     return run({ mongodb: this.mongodb, knex: this.knex }, { a: this.mongodb.a === 'mock' ? null : this.mongodb.a.collection('as'), b: this.mongodb.default === 'mock' ? null : this.mongodb.default.collection('bs'), c: this.mongodb.default === 'mock' ? null : this.mongodb.default.collection('cs'), d: this.knex.default === 'mock' ? null : this.knex.default.table('ds'), e: this.knex.default === 'mock' ? null : this.knex.default.table('es'), f: this.knex.default === 'mock' ? null : this.knex.default.table('fs') })
   }
   
@@ -775,16 +773,16 @@ type GroupMiddleware<N extends DAOName, MetadataType, OperationMetadataType> =
   | ExcludeGroupMiddleware<N, MetadataType, OperationMetadataType>
 type IncludeGroupMiddleware<N extends DAOName, MetadataType, OperationMetadataType> = {
   include: { [K in N]: true }
-  middleware: DAOMiddleware<DAOGenericsMap<MetadataType, OperationMetadataType>[N]>
+  middleware: T.DAOMiddleware<DAOGenericsMap<MetadataType, OperationMetadataType>[N]>
 }
 type ExcludeGroupMiddleware<N extends DAOName, MetadataType, OperationMetadataType> = {
   exclude: { [K in N]: true }
-  middleware: DAOMiddleware<DAOGenericsMap<MetadataType, OperationMetadataType>[Exclude<DAOName, N>]>
+  middleware: T.DAOMiddleware<DAOGenericsMap<MetadataType, OperationMetadataType>[Exclude<DAOName, N>]>
 }
 export const groupMiddleware = {
   includes<N extends DAOName, MetadataType, OperationMetadataType>(
     include: { [K in N]: true },
-    middleware: DAOMiddleware<DAOGenericsMap<MetadataType, OperationMetadataType>[N]>,
+    middleware: T.DAOMiddleware<DAOGenericsMap<MetadataType, OperationMetadataType>[N]>,
   ): IncludeGroupMiddleware<N, MetadataType, OperationMetadataType> {
     return { include, middleware }
   },

--- a/tests/in-memory/dao.mock.ts
+++ b/tests/in-memory/dao.mock.ts
@@ -1,4 +1,4 @@
-import { DAOMiddleware, Coordinates, UserInputDriverDataTypeAdapterMap, Schema, AbstractDAOContext, LogicalOperators, QuantityOperators, EqualityOperators, StringOperators, ElementOperators, OneKey, SortDirection, overrideRelations, userInputDataTypeAdapterToDataTypeAdapter, LogFunction, LogInput, logInputToLogger, ParamProjection, DAOGenerics, CRUDPermission, DAOContextSecurtyPolicy, createSecurityPolicyMiddlewares, SelectProjection, mergeProjections, AbstractInMemoryDAO, InMemoryDAOGenerics, InMemoryDAOParams } from '../../src'
+import * as T from '../../src'
 import * as types from './models.mock'
 
 //--------------------------------------------------------------------------------
@@ -8,7 +8,7 @@ import * as types from './models.mock'
 export type AddressExcludedFields = never
 export type AddressRelationFields = 'cities'
 
-export function addressSchema(): Schema<types.Scalars> {
+export function addressSchema(): T.Schema<types.Scalars> {
   return {
     'id': {
       scalar: 'ID', 
@@ -18,9 +18,9 @@ export function addressSchema(): Schema<types.Scalars> {
 }
 
 type AddressFilterFields = {
-  'id'?: types.Scalars['ID'] | null | EqualityOperators<types.Scalars['ID']> | ElementOperators
+  'id'?: types.Scalars['ID'] | null | T.EqualityOperators<types.Scalars['ID']> | T.ElementOperators
 }
-export type AddressFilter = AddressFilterFields & LogicalOperators<AddressFilterFields | AddressRawFilter>
+export type AddressFilter = AddressFilterFields & T.LogicalOperators<AddressFilterFields | AddressRawFilter>
 export type AddressRawFilter = never
 
 export type AddressRelations = {
@@ -37,10 +37,10 @@ export type AddressProjection = {
   cities?: CityProjection | boolean,
   id?: boolean,
 }
-export type AddressParam<P extends AddressProjection> = ParamProjection<types.Address, AddressProjection, P>
+export type AddressParam<P extends AddressProjection> = T.ParamProjection<types.Address, AddressProjection, P>
 
 export type AddressSortKeys = 'id'
-export type AddressSort = OneKey<AddressSortKeys, SortDirection>
+export type AddressSort = T.OneKey<AddressSortKeys, T.SortDirection>
 export type AddressRawSort = never
 
 export type AddressUpdate = {
@@ -52,17 +52,17 @@ export type AddressInsert = {
   id?: null | types.Scalars['ID'],
 }
 
-type AddressDAOGenerics<MetadataType, OperationMetadataType> = InMemoryDAOGenerics<types.Address, 'id', 'ID', AddressFilter, AddressRawFilter, AddressRelations, AddressProjection, AddressSort, AddressRawSort, AddressInsert, AddressUpdate, AddressRawUpdate, AddressExcludedFields, AddressRelationFields, MetadataType, OperationMetadataType, types.Scalars, 'address', DAOContext<MetadataType, OperationMetadataType>>
-export type AddressDAOParams<MetadataType, OperationMetadataType> = Omit<InMemoryDAOParams<AddressDAOGenerics<MetadataType, OperationMetadataType>>, 'idField' | 'schema' | 'idScalar' | 'idGeneration'>
-export type InMemoryAddressDAOParams<MetadataType, OperationMetadataType> = Omit<InMemoryDAOParams<AddressDAOGenerics<MetadataType, OperationMetadataType>>, 'idField' | 'schema' | 'idScalar' | 'idGeneration'>
+type AddressDAOGenerics<MetadataType, OperationMetadataType> = T.InMemoryDAOGenerics<types.Address, 'id', 'ID', AddressFilter, AddressRawFilter, AddressRelations, AddressProjection, AddressSort, AddressRawSort, AddressInsert, AddressUpdate, AddressRawUpdate, AddressExcludedFields, AddressRelationFields, MetadataType, OperationMetadataType, types.Scalars, 'address', DAOContext<MetadataType, OperationMetadataType>>
+export type AddressDAOParams<MetadataType, OperationMetadataType> = Omit<T.InMemoryDAOParams<AddressDAOGenerics<MetadataType, OperationMetadataType>>, 'idField' | 'schema' | 'idScalar' | 'idGeneration'>
+export type InMemoryAddressDAOParams<MetadataType, OperationMetadataType> = Omit<T.InMemoryDAOParams<AddressDAOGenerics<MetadataType, OperationMetadataType>>, 'idField' | 'schema' | 'idScalar' | 'idGeneration'>
 
-export class AddressDAO<MetadataType, OperationMetadataType> extends AbstractInMemoryDAO<AddressDAOGenerics<MetadataType, OperationMetadataType>> {  
+export class AddressDAO<MetadataType, OperationMetadataType> extends T.AbstractInMemoryDAO<AddressDAOGenerics<MetadataType, OperationMetadataType>> {  
   
   public static projection<P extends AddressProjection>(p: P) {
     return p
   }
-  public static mergeProjection<P1 extends AddressProjection, P2 extends AddressProjection>(p1: P1, p2: P2): SelectProjection<AddressProjection, P1, P2> {
-    return mergeProjections(p1, p2) as SelectProjection<AddressProjection, P1, P2>
+  public static mergeProjection<P1 extends AddressProjection, P2 extends AddressProjection>(p1: P1, p2: P2): T.SelectProjection<AddressProjection, P1, P2> {
+    return T.mergeProjections(p1, p2) as T.SelectProjection<AddressProjection, P1, P2>
   }
   
   public constructor(params: AddressDAOParams<MetadataType, OperationMetadataType>){
@@ -70,7 +70,7 @@ export class AddressDAO<MetadataType, OperationMetadataType> extends AbstractInM
       ...params, 
       idField: 'id', 
       schema: addressSchema(), 
-      relations: overrideRelations(
+      relations: T.overrideRelations(
         [
           { type: '1-n', reference: 'foreign', field: 'cities', refFrom: 'addressId', refTo: 'id', dao: 'city', required: false }
         ]
@@ -81,13 +81,13 @@ export class AddressDAO<MetadataType, OperationMetadataType> extends AbstractInM
   }
   }
 
-export class InMemoryAddressDAO<MetadataType, OperationMetadataType> extends AbstractInMemoryDAO<AddressDAOGenerics<MetadataType, OperationMetadataType>> {  
+export class InMemoryAddressDAO<MetadataType, OperationMetadataType> extends T.AbstractInMemoryDAO<AddressDAOGenerics<MetadataType, OperationMetadataType>> {  
   
   public static projection<P extends AddressProjection>(p: P) {
     return p
   }
-  public static mergeProjection<P1 extends AddressProjection, P2 extends AddressProjection>(p1: P1, p2: P2): SelectProjection<AddressProjection, P1, P2> {
-    return mergeProjections(p1, p2) as SelectProjection<AddressProjection, P1, P2>
+  public static mergeProjection<P1 extends AddressProjection, P2 extends AddressProjection>(p1: P1, p2: P2): T.SelectProjection<AddressProjection, P1, P2> {
+    return T.mergeProjections(p1, p2) as T.SelectProjection<AddressProjection, P1, P2>
   }
   
   public constructor(params: InMemoryAddressDAOParams<MetadataType, OperationMetadataType>){
@@ -95,7 +95,7 @@ export class InMemoryAddressDAO<MetadataType, OperationMetadataType> extends Abs
       ...params, 
       idField: 'id', 
       schema: addressSchema(), 
-      relations: overrideRelations(
+      relations: T.overrideRelations(
         [
           { type: '1-n', reference: 'foreign', field: 'cities', refFrom: 'addressId', refTo: 'id', dao: 'city', required: false }
         ]
@@ -115,7 +115,7 @@ export class InMemoryAddressDAO<MetadataType, OperationMetadataType> extends Abs
 export type AuditExcludedFields = never
 export type AuditRelationFields = never
 
-export function auditSchema(): Schema<types.Scalars> {
+export function auditSchema(): T.Schema<types.Scalars> {
   return {
     'changes': {
       scalar: 'String'
@@ -133,11 +133,11 @@ export function auditSchema(): Schema<types.Scalars> {
 }
 
 type AuditFilterFields = {
-  'changes'?: types.Scalars['String'] | null | EqualityOperators<types.Scalars['String']> | ElementOperators | StringOperators,
-  'entityId'?: types.Scalars['ID'] | null | EqualityOperators<types.Scalars['ID']> | ElementOperators,
-  'id'?: types.Scalars['ID'] | null | EqualityOperators<types.Scalars['ID']> | ElementOperators
+  'changes'?: types.Scalars['String'] | null | T.EqualityOperators<types.Scalars['String']> | T.ElementOperators | T.StringOperators,
+  'entityId'?: types.Scalars['ID'] | null | T.EqualityOperators<types.Scalars['ID']> | T.ElementOperators,
+  'id'?: types.Scalars['ID'] | null | T.EqualityOperators<types.Scalars['ID']> | T.ElementOperators
 }
-export type AuditFilter = AuditFilterFields & LogicalOperators<AuditFilterFields | AuditRawFilter>
+export type AuditFilter = AuditFilterFields & T.LogicalOperators<AuditFilterFields | AuditRawFilter>
 export type AuditRawFilter = never
 
 export type AuditRelations = Record<never, string>
@@ -147,10 +147,10 @@ export type AuditProjection = {
   entityId?: boolean,
   id?: boolean,
 }
-export type AuditParam<P extends AuditProjection> = ParamProjection<types.Audit, AuditProjection, P>
+export type AuditParam<P extends AuditProjection> = T.ParamProjection<types.Audit, AuditProjection, P>
 
 export type AuditSortKeys = 'changes' | 'entityId' | 'id'
-export type AuditSort = OneKey<AuditSortKeys, SortDirection>
+export type AuditSort = T.OneKey<AuditSortKeys, T.SortDirection>
 export type AuditRawSort = never
 
 export type AuditUpdate = {
@@ -165,17 +165,17 @@ export type AuditInsert = {
   entityId: types.Scalars['ID'],
 }
 
-type AuditDAOGenerics<MetadataType, OperationMetadataType> = InMemoryDAOGenerics<types.Audit, 'id', 'ID', AuditFilter, AuditRawFilter, AuditRelations, AuditProjection, AuditSort, AuditRawSort, AuditInsert, AuditUpdate, AuditRawUpdate, AuditExcludedFields, AuditRelationFields, MetadataType, OperationMetadataType, types.Scalars, 'audit', DAOContext<MetadataType, OperationMetadataType>>
-export type AuditDAOParams<MetadataType, OperationMetadataType> = Omit<InMemoryDAOParams<AuditDAOGenerics<MetadataType, OperationMetadataType>>, 'idGenerator' | 'idField' | 'schema' | 'idScalar' | 'idGeneration'>
-export type InMemoryAuditDAOParams<MetadataType, OperationMetadataType> = Omit<InMemoryDAOParams<AuditDAOGenerics<MetadataType, OperationMetadataType>>, 'idGenerator' | 'idField' | 'schema' | 'idScalar' | 'idGeneration'>
+type AuditDAOGenerics<MetadataType, OperationMetadataType> = T.InMemoryDAOGenerics<types.Audit, 'id', 'ID', AuditFilter, AuditRawFilter, AuditRelations, AuditProjection, AuditSort, AuditRawSort, AuditInsert, AuditUpdate, AuditRawUpdate, AuditExcludedFields, AuditRelationFields, MetadataType, OperationMetadataType, types.Scalars, 'audit', DAOContext<MetadataType, OperationMetadataType>>
+export type AuditDAOParams<MetadataType, OperationMetadataType> = Omit<T.InMemoryDAOParams<AuditDAOGenerics<MetadataType, OperationMetadataType>>, 'idGenerator' | 'idField' | 'schema' | 'idScalar' | 'idGeneration'>
+export type InMemoryAuditDAOParams<MetadataType, OperationMetadataType> = Omit<T.InMemoryDAOParams<AuditDAOGenerics<MetadataType, OperationMetadataType>>, 'idGenerator' | 'idField' | 'schema' | 'idScalar' | 'idGeneration'>
 
-export class AuditDAO<MetadataType, OperationMetadataType> extends AbstractInMemoryDAO<AuditDAOGenerics<MetadataType, OperationMetadataType>> {  
+export class AuditDAO<MetadataType, OperationMetadataType> extends T.AbstractInMemoryDAO<AuditDAOGenerics<MetadataType, OperationMetadataType>> {  
   
   public static projection<P extends AuditProjection>(p: P) {
     return p
   }
-  public static mergeProjection<P1 extends AuditProjection, P2 extends AuditProjection>(p1: P1, p2: P2): SelectProjection<AuditProjection, P1, P2> {
-    return mergeProjections(p1, p2) as SelectProjection<AuditProjection, P1, P2>
+  public static mergeProjection<P1 extends AuditProjection, P2 extends AuditProjection>(p1: P1, p2: P2): T.SelectProjection<AuditProjection, P1, P2> {
+    return T.mergeProjections(p1, p2) as T.SelectProjection<AuditProjection, P1, P2>
   }
   
   public constructor(params: AuditDAOParams<MetadataType, OperationMetadataType>){
@@ -183,7 +183,7 @@ export class AuditDAO<MetadataType, OperationMetadataType> extends AbstractInMem
       ...params, 
       idField: 'id', 
       schema: auditSchema(), 
-      relations: overrideRelations(
+      relations: T.overrideRelations(
         [
           
         ]
@@ -194,13 +194,13 @@ export class AuditDAO<MetadataType, OperationMetadataType> extends AbstractInMem
   }
   }
 
-export class InMemoryAuditDAO<MetadataType, OperationMetadataType> extends AbstractInMemoryDAO<AuditDAOGenerics<MetadataType, OperationMetadataType>> {  
+export class InMemoryAuditDAO<MetadataType, OperationMetadataType> extends T.AbstractInMemoryDAO<AuditDAOGenerics<MetadataType, OperationMetadataType>> {  
   
   public static projection<P extends AuditProjection>(p: P) {
     return p
   }
-  public static mergeProjection<P1 extends AuditProjection, P2 extends AuditProjection>(p1: P1, p2: P2): SelectProjection<AuditProjection, P1, P2> {
-    return mergeProjections(p1, p2) as SelectProjection<AuditProjection, P1, P2>
+  public static mergeProjection<P1 extends AuditProjection, P2 extends AuditProjection>(p1: P1, p2: P2): T.SelectProjection<AuditProjection, P1, P2> {
+    return T.mergeProjections(p1, p2) as T.SelectProjection<AuditProjection, P1, P2>
   }
   
   public constructor(params: InMemoryAuditDAOParams<MetadataType, OperationMetadataType>){
@@ -208,7 +208,7 @@ export class InMemoryAuditDAO<MetadataType, OperationMetadataType> extends Abstr
       ...params, 
       idField: 'id', 
       schema: auditSchema(), 
-      relations: overrideRelations(
+      relations: T.overrideRelations(
         [
           
         ]
@@ -225,7 +225,7 @@ export class InMemoryAuditDAO<MetadataType, OperationMetadataType> extends Abstr
 //---------------------------------- AUDITABLE -----------------------------------
 //--------------------------------------------------------------------------------
 
-export function auditableSchema(): Schema<types.Scalars> {
+export function auditableSchema(): T.Schema<types.Scalars> {
   return {
     'createdBy': {
       scalar: 'String', 
@@ -262,7 +262,7 @@ export type AuditableProjection = {
   state?: boolean,
   versions?: AuditProjection | boolean,
 }
-export type AuditableParam<P extends AuditableProjection> = ParamProjection<types.Auditable, AuditableProjection, P>
+export type AuditableParam<P extends AuditableProjection> = T.ParamProjection<types.Auditable, AuditableProjection, P>
 
 export type AuditableInsert = {
   createdBy: types.Scalars['String'],
@@ -282,7 +282,7 @@ export type AuditableInsert = {
 export type CityExcludedFields = 'computedAddressName' | 'computedName'
 export type CityRelationFields = never
 
-export function citySchema(): Schema<types.Scalars> {
+export function citySchema(): T.Schema<types.Scalars> {
   return {
     'addressId': {
       scalar: 'ID', 
@@ -300,11 +300,11 @@ export function citySchema(): Schema<types.Scalars> {
 }
 
 type CityFilterFields = {
-  'addressId'?: types.Scalars['ID'] | null | EqualityOperators<types.Scalars['ID']> | ElementOperators,
-  'id'?: types.Scalars['ID'] | null | EqualityOperators<types.Scalars['ID']> | ElementOperators,
-  'name'?: types.Scalars['String'] | null | EqualityOperators<types.Scalars['String']> | ElementOperators | StringOperators
+  'addressId'?: types.Scalars['ID'] | null | T.EqualityOperators<types.Scalars['ID']> | T.ElementOperators,
+  'id'?: types.Scalars['ID'] | null | T.EqualityOperators<types.Scalars['ID']> | T.ElementOperators,
+  'name'?: types.Scalars['String'] | null | T.EqualityOperators<types.Scalars['String']> | T.ElementOperators | T.StringOperators
 }
-export type CityFilter = CityFilterFields & LogicalOperators<CityFilterFields | CityRawFilter>
+export type CityFilter = CityFilterFields & T.LogicalOperators<CityFilterFields | CityRawFilter>
 export type CityRawFilter = never
 
 export type CityRelations = Record<never, string>
@@ -316,10 +316,10 @@ export type CityProjection = {
   id?: boolean,
   name?: boolean,
 }
-export type CityParam<P extends CityProjection> = ParamProjection<types.City, CityProjection, P>
+export type CityParam<P extends CityProjection> = T.ParamProjection<types.City, CityProjection, P>
 
 export type CitySortKeys = 'addressId' | 'id' | 'name'
-export type CitySort = OneKey<CitySortKeys, SortDirection>
+export type CitySort = T.OneKey<CitySortKeys, T.SortDirection>
 export type CityRawSort = never
 
 export type CityUpdate = {
@@ -335,17 +335,17 @@ export type CityInsert = {
   name: types.Scalars['String'],
 }
 
-type CityDAOGenerics<MetadataType, OperationMetadataType> = InMemoryDAOGenerics<types.City, 'id', 'ID', CityFilter, CityRawFilter, CityRelations, CityProjection, CitySort, CityRawSort, CityInsert, CityUpdate, CityRawUpdate, CityExcludedFields, CityRelationFields, MetadataType, OperationMetadataType, types.Scalars, 'city', DAOContext<MetadataType, OperationMetadataType>>
-export type CityDAOParams<MetadataType, OperationMetadataType> = Omit<InMemoryDAOParams<CityDAOGenerics<MetadataType, OperationMetadataType>>, 'idField' | 'schema' | 'idScalar' | 'idGeneration'>
-export type InMemoryCityDAOParams<MetadataType, OperationMetadataType> = Omit<InMemoryDAOParams<CityDAOGenerics<MetadataType, OperationMetadataType>>, 'idField' | 'schema' | 'idScalar' | 'idGeneration'>
+type CityDAOGenerics<MetadataType, OperationMetadataType> = T.InMemoryDAOGenerics<types.City, 'id', 'ID', CityFilter, CityRawFilter, CityRelations, CityProjection, CitySort, CityRawSort, CityInsert, CityUpdate, CityRawUpdate, CityExcludedFields, CityRelationFields, MetadataType, OperationMetadataType, types.Scalars, 'city', DAOContext<MetadataType, OperationMetadataType>>
+export type CityDAOParams<MetadataType, OperationMetadataType> = Omit<T.InMemoryDAOParams<CityDAOGenerics<MetadataType, OperationMetadataType>>, 'idField' | 'schema' | 'idScalar' | 'idGeneration'>
+export type InMemoryCityDAOParams<MetadataType, OperationMetadataType> = Omit<T.InMemoryDAOParams<CityDAOGenerics<MetadataType, OperationMetadataType>>, 'idField' | 'schema' | 'idScalar' | 'idGeneration'>
 
-export class CityDAO<MetadataType, OperationMetadataType> extends AbstractInMemoryDAO<CityDAOGenerics<MetadataType, OperationMetadataType>> {  
+export class CityDAO<MetadataType, OperationMetadataType> extends T.AbstractInMemoryDAO<CityDAOGenerics<MetadataType, OperationMetadataType>> {  
   
   public static projection<P extends CityProjection>(p: P) {
     return p
   }
-  public static mergeProjection<P1 extends CityProjection, P2 extends CityProjection>(p1: P1, p2: P2): SelectProjection<CityProjection, P1, P2> {
-    return mergeProjections(p1, p2) as SelectProjection<CityProjection, P1, P2>
+  public static mergeProjection<P1 extends CityProjection, P2 extends CityProjection>(p1: P1, p2: P2): T.SelectProjection<CityProjection, P1, P2> {
+    return T.mergeProjections(p1, p2) as T.SelectProjection<CityProjection, P1, P2>
   }
   
   public constructor(params: CityDAOParams<MetadataType, OperationMetadataType>){
@@ -353,7 +353,7 @@ export class CityDAO<MetadataType, OperationMetadataType> extends AbstractInMemo
       ...params, 
       idField: 'id', 
       schema: citySchema(), 
-      relations: overrideRelations(
+      relations: T.overrideRelations(
         [
           
         ]
@@ -364,13 +364,13 @@ export class CityDAO<MetadataType, OperationMetadataType> extends AbstractInMemo
   }
   }
 
-export class InMemoryCityDAO<MetadataType, OperationMetadataType> extends AbstractInMemoryDAO<CityDAOGenerics<MetadataType, OperationMetadataType>> {  
+export class InMemoryCityDAO<MetadataType, OperationMetadataType> extends T.AbstractInMemoryDAO<CityDAOGenerics<MetadataType, OperationMetadataType>> {  
   
   public static projection<P extends CityProjection>(p: P) {
     return p
   }
-  public static mergeProjection<P1 extends CityProjection, P2 extends CityProjection>(p1: P1, p2: P2): SelectProjection<CityProjection, P1, P2> {
-    return mergeProjections(p1, p2) as SelectProjection<CityProjection, P1, P2>
+  public static mergeProjection<P1 extends CityProjection, P2 extends CityProjection>(p1: P1, p2: P2): T.SelectProjection<CityProjection, P1, P2> {
+    return T.mergeProjections(p1, p2) as T.SelectProjection<CityProjection, P1, P2>
   }
   
   public constructor(params: InMemoryCityDAOParams<MetadataType, OperationMetadataType>){
@@ -378,7 +378,7 @@ export class InMemoryCityDAO<MetadataType, OperationMetadataType> extends Abstra
       ...params, 
       idField: 'id', 
       schema: citySchema(), 
-      relations: overrideRelations(
+      relations: T.overrideRelations(
         [
           
         ]
@@ -398,7 +398,7 @@ export class InMemoryCityDAO<MetadataType, OperationMetadataType> extends Abstra
 export type DefaultFieldsEntityExcludedFields = never
 export type DefaultFieldsEntityRelationFields = never
 
-export function defaultFieldsEntitySchema(): Schema<types.Scalars> {
+export function defaultFieldsEntitySchema(): T.Schema<types.Scalars> {
   return {
     'creationDate': {
       scalar: 'Int', 
@@ -430,14 +430,14 @@ export function defaultFieldsEntitySchema(): Schema<types.Scalars> {
 }
 
 type DefaultFieldsEntityFilterFields = {
-  'creationDate'?: types.Scalars['Int'] | null | EqualityOperators<types.Scalars['Int']> | ElementOperators | QuantityOperators<types.Scalars['Int']>,
-  'id'?: types.Scalars['ID'] | null | EqualityOperators<types.Scalars['ID']> | ElementOperators,
-  'live'?: types.Scalars['Live'] | null | EqualityOperators<types.Scalars['Live']> | ElementOperators,
-  'name'?: types.Scalars['String'] | null | EqualityOperators<types.Scalars['String']> | ElementOperators | StringOperators,
-  'opt1'?: types.Scalars['Live'] | null | EqualityOperators<types.Scalars['Live']> | ElementOperators,
-  'opt2'?: types.Scalars['Live'] | null | EqualityOperators<types.Scalars['Live']> | ElementOperators
+  'creationDate'?: types.Scalars['Int'] | null | T.EqualityOperators<types.Scalars['Int']> | T.ElementOperators | T.QuantityOperators<types.Scalars['Int']>,
+  'id'?: types.Scalars['ID'] | null | T.EqualityOperators<types.Scalars['ID']> | T.ElementOperators,
+  'live'?: types.Scalars['Live'] | null | T.EqualityOperators<types.Scalars['Live']> | T.ElementOperators,
+  'name'?: types.Scalars['String'] | null | T.EqualityOperators<types.Scalars['String']> | T.ElementOperators | T.StringOperators,
+  'opt1'?: types.Scalars['Live'] | null | T.EqualityOperators<types.Scalars['Live']> | T.ElementOperators,
+  'opt2'?: types.Scalars['Live'] | null | T.EqualityOperators<types.Scalars['Live']> | T.ElementOperators
 }
-export type DefaultFieldsEntityFilter = DefaultFieldsEntityFilterFields & LogicalOperators<DefaultFieldsEntityFilterFields | DefaultFieldsEntityRawFilter>
+export type DefaultFieldsEntityFilter = DefaultFieldsEntityFilterFields & T.LogicalOperators<DefaultFieldsEntityFilterFields | DefaultFieldsEntityRawFilter>
 export type DefaultFieldsEntityRawFilter = never
 
 export type DefaultFieldsEntityRelations = Record<never, string>
@@ -450,10 +450,10 @@ export type DefaultFieldsEntityProjection = {
   opt1?: boolean,
   opt2?: boolean,
 }
-export type DefaultFieldsEntityParam<P extends DefaultFieldsEntityProjection> = ParamProjection<types.DefaultFieldsEntity, DefaultFieldsEntityProjection, P>
+export type DefaultFieldsEntityParam<P extends DefaultFieldsEntityProjection> = T.ParamProjection<types.DefaultFieldsEntity, DefaultFieldsEntityProjection, P>
 
 export type DefaultFieldsEntitySortKeys = 'creationDate' | 'id' | 'live' | 'name' | 'opt1' | 'opt2'
-export type DefaultFieldsEntitySort = OneKey<DefaultFieldsEntitySortKeys, SortDirection>
+export type DefaultFieldsEntitySort = T.OneKey<DefaultFieldsEntitySortKeys, T.SortDirection>
 export type DefaultFieldsEntityRawSort = never
 
 export type DefaultFieldsEntityUpdate = {
@@ -475,17 +475,17 @@ export type DefaultFieldsEntityInsert = {
   opt2?: null | types.Scalars['Live'],
 }
 
-type DefaultFieldsEntityDAOGenerics<MetadataType, OperationMetadataType> = InMemoryDAOGenerics<types.DefaultFieldsEntity, 'id', 'ID', DefaultFieldsEntityFilter, DefaultFieldsEntityRawFilter, DefaultFieldsEntityRelations, DefaultFieldsEntityProjection, DefaultFieldsEntitySort, DefaultFieldsEntityRawSort, DefaultFieldsEntityInsert, DefaultFieldsEntityUpdate, DefaultFieldsEntityRawUpdate, DefaultFieldsEntityExcludedFields, DefaultFieldsEntityRelationFields, MetadataType, OperationMetadataType, types.Scalars, 'defaultFieldsEntity', DAOContext<MetadataType, OperationMetadataType>>
-export type DefaultFieldsEntityDAOParams<MetadataType, OperationMetadataType> = Omit<InMemoryDAOParams<DefaultFieldsEntityDAOGenerics<MetadataType, OperationMetadataType>>, 'idGenerator' | 'idField' | 'schema' | 'idScalar' | 'idGeneration'>
-export type InMemoryDefaultFieldsEntityDAOParams<MetadataType, OperationMetadataType> = Omit<InMemoryDAOParams<DefaultFieldsEntityDAOGenerics<MetadataType, OperationMetadataType>>, 'idGenerator' | 'idField' | 'schema' | 'idScalar' | 'idGeneration'>
+type DefaultFieldsEntityDAOGenerics<MetadataType, OperationMetadataType> = T.InMemoryDAOGenerics<types.DefaultFieldsEntity, 'id', 'ID', DefaultFieldsEntityFilter, DefaultFieldsEntityRawFilter, DefaultFieldsEntityRelations, DefaultFieldsEntityProjection, DefaultFieldsEntitySort, DefaultFieldsEntityRawSort, DefaultFieldsEntityInsert, DefaultFieldsEntityUpdate, DefaultFieldsEntityRawUpdate, DefaultFieldsEntityExcludedFields, DefaultFieldsEntityRelationFields, MetadataType, OperationMetadataType, types.Scalars, 'defaultFieldsEntity', DAOContext<MetadataType, OperationMetadataType>>
+export type DefaultFieldsEntityDAOParams<MetadataType, OperationMetadataType> = Omit<T.InMemoryDAOParams<DefaultFieldsEntityDAOGenerics<MetadataType, OperationMetadataType>>, 'idGenerator' | 'idField' | 'schema' | 'idScalar' | 'idGeneration'>
+export type InMemoryDefaultFieldsEntityDAOParams<MetadataType, OperationMetadataType> = Omit<T.InMemoryDAOParams<DefaultFieldsEntityDAOGenerics<MetadataType, OperationMetadataType>>, 'idGenerator' | 'idField' | 'schema' | 'idScalar' | 'idGeneration'>
 
-export class DefaultFieldsEntityDAO<MetadataType, OperationMetadataType> extends AbstractInMemoryDAO<DefaultFieldsEntityDAOGenerics<MetadataType, OperationMetadataType>> {  
+export class DefaultFieldsEntityDAO<MetadataType, OperationMetadataType> extends T.AbstractInMemoryDAO<DefaultFieldsEntityDAOGenerics<MetadataType, OperationMetadataType>> {  
   
   public static projection<P extends DefaultFieldsEntityProjection>(p: P) {
     return p
   }
-  public static mergeProjection<P1 extends DefaultFieldsEntityProjection, P2 extends DefaultFieldsEntityProjection>(p1: P1, p2: P2): SelectProjection<DefaultFieldsEntityProjection, P1, P2> {
-    return mergeProjections(p1, p2) as SelectProjection<DefaultFieldsEntityProjection, P1, P2>
+  public static mergeProjection<P1 extends DefaultFieldsEntityProjection, P2 extends DefaultFieldsEntityProjection>(p1: P1, p2: P2): T.SelectProjection<DefaultFieldsEntityProjection, P1, P2> {
+    return T.mergeProjections(p1, p2) as T.SelectProjection<DefaultFieldsEntityProjection, P1, P2>
   }
   
   public constructor(params: DefaultFieldsEntityDAOParams<MetadataType, OperationMetadataType>){
@@ -493,7 +493,7 @@ export class DefaultFieldsEntityDAO<MetadataType, OperationMetadataType> extends
       ...params, 
       idField: 'id', 
       schema: defaultFieldsEntitySchema(), 
-      relations: overrideRelations(
+      relations: T.overrideRelations(
         [
           
         ]
@@ -504,13 +504,13 @@ export class DefaultFieldsEntityDAO<MetadataType, OperationMetadataType> extends
   }
   }
 
-export class InMemoryDefaultFieldsEntityDAO<MetadataType, OperationMetadataType> extends AbstractInMemoryDAO<DefaultFieldsEntityDAOGenerics<MetadataType, OperationMetadataType>> {  
+export class InMemoryDefaultFieldsEntityDAO<MetadataType, OperationMetadataType> extends T.AbstractInMemoryDAO<DefaultFieldsEntityDAOGenerics<MetadataType, OperationMetadataType>> {  
   
   public static projection<P extends DefaultFieldsEntityProjection>(p: P) {
     return p
   }
-  public static mergeProjection<P1 extends DefaultFieldsEntityProjection, P2 extends DefaultFieldsEntityProjection>(p1: P1, p2: P2): SelectProjection<DefaultFieldsEntityProjection, P1, P2> {
-    return mergeProjections(p1, p2) as SelectProjection<DefaultFieldsEntityProjection, P1, P2>
+  public static mergeProjection<P1 extends DefaultFieldsEntityProjection, P2 extends DefaultFieldsEntityProjection>(p1: P1, p2: P2): T.SelectProjection<DefaultFieldsEntityProjection, P1, P2> {
+    return T.mergeProjections(p1, p2) as T.SelectProjection<DefaultFieldsEntityProjection, P1, P2>
   }
   
   public constructor(params: InMemoryDefaultFieldsEntityDAOParams<MetadataType, OperationMetadataType>){
@@ -518,7 +518,7 @@ export class InMemoryDefaultFieldsEntityDAO<MetadataType, OperationMetadataType>
       ...params, 
       idField: 'id', 
       schema: defaultFieldsEntitySchema(), 
-      relations: overrideRelations(
+      relations: T.overrideRelations(
         [
           
         ]
@@ -538,7 +538,7 @@ export class InMemoryDefaultFieldsEntityDAO<MetadataType, OperationMetadataType>
 export type DeviceExcludedFields = never
 export type DeviceRelationFields = 'user'
 
-export function deviceSchema(): Schema<types.Scalars> {
+export function deviceSchema(): T.Schema<types.Scalars> {
   return {
     'id': {
       scalar: 'ID', 
@@ -555,11 +555,11 @@ export function deviceSchema(): Schema<types.Scalars> {
 }
 
 type DeviceFilterFields = {
-  'id'?: types.Scalars['ID'] | null | EqualityOperators<types.Scalars['ID']> | ElementOperators,
-  'name'?: types.Scalars['String'] | null | EqualityOperators<types.Scalars['String']> | ElementOperators | StringOperators,
-  'userId'?: types.Scalars['ID'] | null | EqualityOperators<types.Scalars['ID']> | ElementOperators
+  'id'?: types.Scalars['ID'] | null | T.EqualityOperators<types.Scalars['ID']> | T.ElementOperators,
+  'name'?: types.Scalars['String'] | null | T.EqualityOperators<types.Scalars['String']> | T.ElementOperators | T.StringOperators,
+  'userId'?: types.Scalars['ID'] | null | T.EqualityOperators<types.Scalars['ID']> | T.ElementOperators
 }
-export type DeviceFilter = DeviceFilterFields & LogicalOperators<DeviceFilterFields | DeviceRawFilter>
+export type DeviceFilter = DeviceFilterFields & T.LogicalOperators<DeviceFilterFields | DeviceRawFilter>
 export type DeviceRawFilter = never
 
 export type DeviceRelations = Record<never, string>
@@ -570,10 +570,10 @@ export type DeviceProjection = {
   user?: UserProjection | boolean,
   userId?: boolean,
 }
-export type DeviceParam<P extends DeviceProjection> = ParamProjection<types.Device, DeviceProjection, P>
+export type DeviceParam<P extends DeviceProjection> = T.ParamProjection<types.Device, DeviceProjection, P>
 
 export type DeviceSortKeys = 'id' | 'name' | 'userId'
-export type DeviceSort = OneKey<DeviceSortKeys, SortDirection>
+export type DeviceSort = T.OneKey<DeviceSortKeys, T.SortDirection>
 export type DeviceRawSort = never
 
 export type DeviceUpdate = {
@@ -589,17 +589,17 @@ export type DeviceInsert = {
   userId?: null | types.Scalars['ID'],
 }
 
-type DeviceDAOGenerics<MetadataType, OperationMetadataType> = InMemoryDAOGenerics<types.Device, 'id', 'ID', DeviceFilter, DeviceRawFilter, DeviceRelations, DeviceProjection, DeviceSort, DeviceRawSort, DeviceInsert, DeviceUpdate, DeviceRawUpdate, DeviceExcludedFields, DeviceRelationFields, MetadataType, OperationMetadataType, types.Scalars, 'device', DAOContext<MetadataType, OperationMetadataType>>
-export type DeviceDAOParams<MetadataType, OperationMetadataType> = Omit<InMemoryDAOParams<DeviceDAOGenerics<MetadataType, OperationMetadataType>>, 'idField' | 'schema' | 'idScalar' | 'idGeneration'>
-export type InMemoryDeviceDAOParams<MetadataType, OperationMetadataType> = Omit<InMemoryDAOParams<DeviceDAOGenerics<MetadataType, OperationMetadataType>>, 'idField' | 'schema' | 'idScalar' | 'idGeneration'>
+type DeviceDAOGenerics<MetadataType, OperationMetadataType> = T.InMemoryDAOGenerics<types.Device, 'id', 'ID', DeviceFilter, DeviceRawFilter, DeviceRelations, DeviceProjection, DeviceSort, DeviceRawSort, DeviceInsert, DeviceUpdate, DeviceRawUpdate, DeviceExcludedFields, DeviceRelationFields, MetadataType, OperationMetadataType, types.Scalars, 'device', DAOContext<MetadataType, OperationMetadataType>>
+export type DeviceDAOParams<MetadataType, OperationMetadataType> = Omit<T.InMemoryDAOParams<DeviceDAOGenerics<MetadataType, OperationMetadataType>>, 'idField' | 'schema' | 'idScalar' | 'idGeneration'>
+export type InMemoryDeviceDAOParams<MetadataType, OperationMetadataType> = Omit<T.InMemoryDAOParams<DeviceDAOGenerics<MetadataType, OperationMetadataType>>, 'idField' | 'schema' | 'idScalar' | 'idGeneration'>
 
-export class DeviceDAO<MetadataType, OperationMetadataType> extends AbstractInMemoryDAO<DeviceDAOGenerics<MetadataType, OperationMetadataType>> {  
+export class DeviceDAO<MetadataType, OperationMetadataType> extends T.AbstractInMemoryDAO<DeviceDAOGenerics<MetadataType, OperationMetadataType>> {  
   
   public static projection<P extends DeviceProjection>(p: P) {
     return p
   }
-  public static mergeProjection<P1 extends DeviceProjection, P2 extends DeviceProjection>(p1: P1, p2: P2): SelectProjection<DeviceProjection, P1, P2> {
-    return mergeProjections(p1, p2) as SelectProjection<DeviceProjection, P1, P2>
+  public static mergeProjection<P1 extends DeviceProjection, P2 extends DeviceProjection>(p1: P1, p2: P2): T.SelectProjection<DeviceProjection, P1, P2> {
+    return T.mergeProjections(p1, p2) as T.SelectProjection<DeviceProjection, P1, P2>
   }
   
   public constructor(params: DeviceDAOParams<MetadataType, OperationMetadataType>){
@@ -607,7 +607,7 @@ export class DeviceDAO<MetadataType, OperationMetadataType> extends AbstractInMe
       ...params, 
       idField: 'id', 
       schema: deviceSchema(), 
-      relations: overrideRelations(
+      relations: T.overrideRelations(
         [
           { type: '1-1', reference: 'inner', field: 'user', refFrom: 'userId', refTo: 'id', dao: 'user', required: false }
         ]
@@ -618,13 +618,13 @@ export class DeviceDAO<MetadataType, OperationMetadataType> extends AbstractInMe
   }
   }
 
-export class InMemoryDeviceDAO<MetadataType, OperationMetadataType> extends AbstractInMemoryDAO<DeviceDAOGenerics<MetadataType, OperationMetadataType>> {  
+export class InMemoryDeviceDAO<MetadataType, OperationMetadataType> extends T.AbstractInMemoryDAO<DeviceDAOGenerics<MetadataType, OperationMetadataType>> {  
   
   public static projection<P extends DeviceProjection>(p: P) {
     return p
   }
-  public static mergeProjection<P1 extends DeviceProjection, P2 extends DeviceProjection>(p1: P1, p2: P2): SelectProjection<DeviceProjection, P1, P2> {
-    return mergeProjections(p1, p2) as SelectProjection<DeviceProjection, P1, P2>
+  public static mergeProjection<P1 extends DeviceProjection, P2 extends DeviceProjection>(p1: P1, p2: P2): T.SelectProjection<DeviceProjection, P1, P2> {
+    return T.mergeProjections(p1, p2) as T.SelectProjection<DeviceProjection, P1, P2>
   }
   
   public constructor(params: InMemoryDeviceDAOParams<MetadataType, OperationMetadataType>){
@@ -632,7 +632,7 @@ export class InMemoryDeviceDAO<MetadataType, OperationMetadataType> extends Abst
       ...params, 
       idField: 'id', 
       schema: deviceSchema(), 
-      relations: overrideRelations(
+      relations: T.overrideRelations(
         [
           { type: '1-1', reference: 'inner', field: 'user', refFrom: 'userId', refTo: 'id', dao: 'user', required: false }
         ]
@@ -652,7 +652,7 @@ export class InMemoryDeviceDAO<MetadataType, OperationMetadataType> extends Abst
 export type DogExcludedFields = never
 export type DogRelationFields = 'owner'
 
-export function dogSchema(): Schema<types.Scalars> {
+export function dogSchema(): T.Schema<types.Scalars> {
   return {
     'id': {
       scalar: 'ID', 
@@ -670,11 +670,11 @@ export function dogSchema(): Schema<types.Scalars> {
 }
 
 type DogFilterFields = {
-  'id'?: types.Scalars['ID'] | null | EqualityOperators<types.Scalars['ID']> | ElementOperators,
-  'name'?: types.Scalars['String'] | null | EqualityOperators<types.Scalars['String']> | ElementOperators | StringOperators,
-  'ownerId'?: types.Scalars['ID'] | null | EqualityOperators<types.Scalars['ID']> | ElementOperators
+  'id'?: types.Scalars['ID'] | null | T.EqualityOperators<types.Scalars['ID']> | T.ElementOperators,
+  'name'?: types.Scalars['String'] | null | T.EqualityOperators<types.Scalars['String']> | T.ElementOperators | T.StringOperators,
+  'ownerId'?: types.Scalars['ID'] | null | T.EqualityOperators<types.Scalars['ID']> | T.ElementOperators
 }
-export type DogFilter = DogFilterFields & LogicalOperators<DogFilterFields | DogRawFilter>
+export type DogFilter = DogFilterFields & T.LogicalOperators<DogFilterFields | DogRawFilter>
 export type DogRawFilter = never
 
 export type DogRelations = Record<never, string>
@@ -685,10 +685,10 @@ export type DogProjection = {
   owner?: UserProjection | boolean,
   ownerId?: boolean,
 }
-export type DogParam<P extends DogProjection> = ParamProjection<types.Dog, DogProjection, P>
+export type DogParam<P extends DogProjection> = T.ParamProjection<types.Dog, DogProjection, P>
 
 export type DogSortKeys = 'id' | 'name' | 'ownerId'
-export type DogSort = OneKey<DogSortKeys, SortDirection>
+export type DogSort = T.OneKey<DogSortKeys, T.SortDirection>
 export type DogRawSort = never
 
 export type DogUpdate = {
@@ -704,17 +704,17 @@ export type DogInsert = {
   ownerId: types.Scalars['ID'],
 }
 
-type DogDAOGenerics<MetadataType, OperationMetadataType> = InMemoryDAOGenerics<types.Dog, 'id', 'ID', DogFilter, DogRawFilter, DogRelations, DogProjection, DogSort, DogRawSort, DogInsert, DogUpdate, DogRawUpdate, DogExcludedFields, DogRelationFields, MetadataType, OperationMetadataType, types.Scalars, 'dog', DAOContext<MetadataType, OperationMetadataType>>
-export type DogDAOParams<MetadataType, OperationMetadataType> = Omit<InMemoryDAOParams<DogDAOGenerics<MetadataType, OperationMetadataType>>, 'idField' | 'schema' | 'idScalar' | 'idGeneration'>
-export type InMemoryDogDAOParams<MetadataType, OperationMetadataType> = Omit<InMemoryDAOParams<DogDAOGenerics<MetadataType, OperationMetadataType>>, 'idField' | 'schema' | 'idScalar' | 'idGeneration'>
+type DogDAOGenerics<MetadataType, OperationMetadataType> = T.InMemoryDAOGenerics<types.Dog, 'id', 'ID', DogFilter, DogRawFilter, DogRelations, DogProjection, DogSort, DogRawSort, DogInsert, DogUpdate, DogRawUpdate, DogExcludedFields, DogRelationFields, MetadataType, OperationMetadataType, types.Scalars, 'dog', DAOContext<MetadataType, OperationMetadataType>>
+export type DogDAOParams<MetadataType, OperationMetadataType> = Omit<T.InMemoryDAOParams<DogDAOGenerics<MetadataType, OperationMetadataType>>, 'idField' | 'schema' | 'idScalar' | 'idGeneration'>
+export type InMemoryDogDAOParams<MetadataType, OperationMetadataType> = Omit<T.InMemoryDAOParams<DogDAOGenerics<MetadataType, OperationMetadataType>>, 'idField' | 'schema' | 'idScalar' | 'idGeneration'>
 
-export class DogDAO<MetadataType, OperationMetadataType> extends AbstractInMemoryDAO<DogDAOGenerics<MetadataType, OperationMetadataType>> {  
+export class DogDAO<MetadataType, OperationMetadataType> extends T.AbstractInMemoryDAO<DogDAOGenerics<MetadataType, OperationMetadataType>> {  
   
   public static projection<P extends DogProjection>(p: P) {
     return p
   }
-  public static mergeProjection<P1 extends DogProjection, P2 extends DogProjection>(p1: P1, p2: P2): SelectProjection<DogProjection, P1, P2> {
-    return mergeProjections(p1, p2) as SelectProjection<DogProjection, P1, P2>
+  public static mergeProjection<P1 extends DogProjection, P2 extends DogProjection>(p1: P1, p2: P2): T.SelectProjection<DogProjection, P1, P2> {
+    return T.mergeProjections(p1, p2) as T.SelectProjection<DogProjection, P1, P2>
   }
   
   public constructor(params: DogDAOParams<MetadataType, OperationMetadataType>){
@@ -722,7 +722,7 @@ export class DogDAO<MetadataType, OperationMetadataType> extends AbstractInMemor
       ...params, 
       idField: 'id', 
       schema: dogSchema(), 
-      relations: overrideRelations(
+      relations: T.overrideRelations(
         [
           { type: '1-1', reference: 'inner', field: 'owner', refFrom: 'ownerId', refTo: 'id', dao: 'user', required: false }
         ]
@@ -733,13 +733,13 @@ export class DogDAO<MetadataType, OperationMetadataType> extends AbstractInMemor
   }
   }
 
-export class InMemoryDogDAO<MetadataType, OperationMetadataType> extends AbstractInMemoryDAO<DogDAOGenerics<MetadataType, OperationMetadataType>> {  
+export class InMemoryDogDAO<MetadataType, OperationMetadataType> extends T.AbstractInMemoryDAO<DogDAOGenerics<MetadataType, OperationMetadataType>> {  
   
   public static projection<P extends DogProjection>(p: P) {
     return p
   }
-  public static mergeProjection<P1 extends DogProjection, P2 extends DogProjection>(p1: P1, p2: P2): SelectProjection<DogProjection, P1, P2> {
-    return mergeProjections(p1, p2) as SelectProjection<DogProjection, P1, P2>
+  public static mergeProjection<P1 extends DogProjection, P2 extends DogProjection>(p1: P1, p2: P2): T.SelectProjection<DogProjection, P1, P2> {
+    return T.mergeProjections(p1, p2) as T.SelectProjection<DogProjection, P1, P2>
   }
   
   public constructor(params: InMemoryDogDAOParams<MetadataType, OperationMetadataType>){
@@ -747,7 +747,7 @@ export class InMemoryDogDAO<MetadataType, OperationMetadataType> extends Abstrac
       ...params, 
       idField: 'id', 
       schema: dogSchema(), 
-      relations: overrideRelations(
+      relations: T.overrideRelations(
         [
           { type: '1-1', reference: 'inner', field: 'owner', refFrom: 'ownerId', refTo: 'id', dao: 'user', required: false }
         ]
@@ -767,7 +767,7 @@ export class InMemoryDogDAO<MetadataType, OperationMetadataType> extends Abstrac
 export type HotelExcludedFields = never
 export type HotelRelationFields = never
 
-export function hotelSchema(): Schema<types.Scalars> {
+export function hotelSchema(): T.Schema<types.Scalars> {
   return {
     'audit': { embedded: auditableSchema(), required: true, defaultGenerationStrategy: 'middleware' },
     'id': {
@@ -783,16 +783,16 @@ export function hotelSchema(): Schema<types.Scalars> {
 }
 
 type HotelFilterFields = {
-  'audit.createdBy'?: types.Scalars['String'] | null | EqualityOperators<types.Scalars['String']> | ElementOperators | StringOperators,
-  'audit.createdOn'?: types.Scalars['Int'] | null | EqualityOperators<types.Scalars['Int']> | ElementOperators | QuantityOperators<types.Scalars['Int']>,
-  'audit.deletedOn'?: types.Scalars['Int'] | null | EqualityOperators<types.Scalars['Int']> | ElementOperators | QuantityOperators<types.Scalars['Int']>,
-  'audit.modifiedBy'?: types.Scalars['String'] | null | EqualityOperators<types.Scalars['String']> | ElementOperators | StringOperators,
-  'audit.modifiedOn'?: types.Scalars['Int'] | null | EqualityOperators<types.Scalars['Int']> | ElementOperators | QuantityOperators<types.Scalars['Int']>,
-  'audit.state'?: types.State | null | EqualityOperators<types.State> | ElementOperators | StringOperators,
-  'id'?: types.Scalars['ID'] | null | EqualityOperators<types.Scalars['ID']> | ElementOperators,
-  'name'?: types.Scalars['String'] | null | EqualityOperators<types.Scalars['String']> | ElementOperators | StringOperators
+  'audit.createdBy'?: types.Scalars['String'] | null | T.EqualityOperators<types.Scalars['String']> | T.ElementOperators | T.StringOperators,
+  'audit.createdOn'?: types.Scalars['Int'] | null | T.EqualityOperators<types.Scalars['Int']> | T.ElementOperators | T.QuantityOperators<types.Scalars['Int']>,
+  'audit.deletedOn'?: types.Scalars['Int'] | null | T.EqualityOperators<types.Scalars['Int']> | T.ElementOperators | T.QuantityOperators<types.Scalars['Int']>,
+  'audit.modifiedBy'?: types.Scalars['String'] | null | T.EqualityOperators<types.Scalars['String']> | T.ElementOperators | T.StringOperators,
+  'audit.modifiedOn'?: types.Scalars['Int'] | null | T.EqualityOperators<types.Scalars['Int']> | T.ElementOperators | T.QuantityOperators<types.Scalars['Int']>,
+  'audit.state'?: types.State | null | T.EqualityOperators<types.State> | T.ElementOperators | T.StringOperators,
+  'id'?: types.Scalars['ID'] | null | T.EqualityOperators<types.Scalars['ID']> | T.ElementOperators,
+  'name'?: types.Scalars['String'] | null | T.EqualityOperators<types.Scalars['String']> | T.ElementOperators | T.StringOperators
 }
-export type HotelFilter = HotelFilterFields & LogicalOperators<HotelFilterFields | HotelRawFilter>
+export type HotelFilter = HotelFilterFields & T.LogicalOperators<HotelFilterFields | HotelRawFilter>
 export type HotelRawFilter = never
 
 export type HotelRelations = Record<never, string>
@@ -810,10 +810,10 @@ export type HotelProjection = {
   id?: boolean,
   name?: boolean,
 }
-export type HotelParam<P extends HotelProjection> = ParamProjection<types.Hotel, HotelProjection, P>
+export type HotelParam<P extends HotelProjection> = T.ParamProjection<types.Hotel, HotelProjection, P>
 
 export type HotelSortKeys = 'audit.createdBy' | 'audit.createdOn' | 'audit.deletedOn' | 'audit.modifiedBy' | 'audit.modifiedOn' | 'audit.state' | 'id' | 'name'
-export type HotelSort = OneKey<HotelSortKeys, SortDirection>
+export type HotelSort = T.OneKey<HotelSortKeys, T.SortDirection>
 export type HotelRawSort = never
 
 export type HotelUpdate = {
@@ -834,17 +834,17 @@ export type HotelInsert = {
   name: types.Scalars['String'],
 }
 
-type HotelDAOGenerics<MetadataType, OperationMetadataType> = InMemoryDAOGenerics<types.Hotel, 'id', 'ID', HotelFilter, HotelRawFilter, HotelRelations, HotelProjection, HotelSort, HotelRawSort, HotelInsert, HotelUpdate, HotelRawUpdate, HotelExcludedFields, HotelRelationFields, MetadataType, OperationMetadataType, types.Scalars, 'hotel', DAOContext<MetadataType, OperationMetadataType>>
-export type HotelDAOParams<MetadataType, OperationMetadataType> = Omit<InMemoryDAOParams<HotelDAOGenerics<MetadataType, OperationMetadataType>>, 'idGenerator' | 'idField' | 'schema' | 'idScalar' | 'idGeneration'>
-export type InMemoryHotelDAOParams<MetadataType, OperationMetadataType> = Omit<InMemoryDAOParams<HotelDAOGenerics<MetadataType, OperationMetadataType>>, 'idGenerator' | 'idField' | 'schema' | 'idScalar' | 'idGeneration'>
+type HotelDAOGenerics<MetadataType, OperationMetadataType> = T.InMemoryDAOGenerics<types.Hotel, 'id', 'ID', HotelFilter, HotelRawFilter, HotelRelations, HotelProjection, HotelSort, HotelRawSort, HotelInsert, HotelUpdate, HotelRawUpdate, HotelExcludedFields, HotelRelationFields, MetadataType, OperationMetadataType, types.Scalars, 'hotel', DAOContext<MetadataType, OperationMetadataType>>
+export type HotelDAOParams<MetadataType, OperationMetadataType> = Omit<T.InMemoryDAOParams<HotelDAOGenerics<MetadataType, OperationMetadataType>>, 'idGenerator' | 'idField' | 'schema' | 'idScalar' | 'idGeneration'>
+export type InMemoryHotelDAOParams<MetadataType, OperationMetadataType> = Omit<T.InMemoryDAOParams<HotelDAOGenerics<MetadataType, OperationMetadataType>>, 'idGenerator' | 'idField' | 'schema' | 'idScalar' | 'idGeneration'>
 
-export class HotelDAO<MetadataType, OperationMetadataType> extends AbstractInMemoryDAO<HotelDAOGenerics<MetadataType, OperationMetadataType>> {  
+export class HotelDAO<MetadataType, OperationMetadataType> extends T.AbstractInMemoryDAO<HotelDAOGenerics<MetadataType, OperationMetadataType>> {  
   
   public static projection<P extends HotelProjection>(p: P) {
     return p
   }
-  public static mergeProjection<P1 extends HotelProjection, P2 extends HotelProjection>(p1: P1, p2: P2): SelectProjection<HotelProjection, P1, P2> {
-    return mergeProjections(p1, p2) as SelectProjection<HotelProjection, P1, P2>
+  public static mergeProjection<P1 extends HotelProjection, P2 extends HotelProjection>(p1: P1, p2: P2): T.SelectProjection<HotelProjection, P1, P2> {
+    return T.mergeProjections(p1, p2) as T.SelectProjection<HotelProjection, P1, P2>
   }
   
   public constructor(params: HotelDAOParams<MetadataType, OperationMetadataType>){
@@ -852,7 +852,7 @@ export class HotelDAO<MetadataType, OperationMetadataType> extends AbstractInMem
       ...params, 
       idField: 'id', 
       schema: hotelSchema(), 
-      relations: overrideRelations(
+      relations: T.overrideRelations(
         [
           { type: '1-n', reference: 'foreign', field: 'audit.versions', refFrom: 'entityId', refTo: 'id', dao: 'audit', required: true }
         ]
@@ -863,13 +863,13 @@ export class HotelDAO<MetadataType, OperationMetadataType> extends AbstractInMem
   }
   }
 
-export class InMemoryHotelDAO<MetadataType, OperationMetadataType> extends AbstractInMemoryDAO<HotelDAOGenerics<MetadataType, OperationMetadataType>> {  
+export class InMemoryHotelDAO<MetadataType, OperationMetadataType> extends T.AbstractInMemoryDAO<HotelDAOGenerics<MetadataType, OperationMetadataType>> {  
   
   public static projection<P extends HotelProjection>(p: P) {
     return p
   }
-  public static mergeProjection<P1 extends HotelProjection, P2 extends HotelProjection>(p1: P1, p2: P2): SelectProjection<HotelProjection, P1, P2> {
-    return mergeProjections(p1, p2) as SelectProjection<HotelProjection, P1, P2>
+  public static mergeProjection<P1 extends HotelProjection, P2 extends HotelProjection>(p1: P1, p2: P2): T.SelectProjection<HotelProjection, P1, P2> {
+    return T.mergeProjections(p1, p2) as T.SelectProjection<HotelProjection, P1, P2>
   }
   
   public constructor(params: InMemoryHotelDAOParams<MetadataType, OperationMetadataType>){
@@ -877,7 +877,7 @@ export class InMemoryHotelDAO<MetadataType, OperationMetadataType> extends Abstr
       ...params, 
       idField: 'id', 
       schema: hotelSchema(), 
-      relations: overrideRelations(
+      relations: T.overrideRelations(
         [
           { type: '1-n', reference: 'foreign', field: 'audit.versions', refFrom: 'entityId', refTo: 'id', dao: 'audit', required: true }
         ]
@@ -897,7 +897,7 @@ export class InMemoryHotelDAO<MetadataType, OperationMetadataType> extends Abstr
 export type MockedEntityExcludedFields = never
 export type MockedEntityRelationFields = 'user'
 
-export function mockedEntitySchema(): Schema<types.Scalars> {
+export function mockedEntitySchema(): T.Schema<types.Scalars> {
   return {
     'id': {
       scalar: 'ID', 
@@ -916,11 +916,11 @@ export function mockedEntitySchema(): Schema<types.Scalars> {
 }
 
 type MockedEntityFilterFields = {
-  'id'?: types.Scalars['ID'] | null | EqualityOperators<types.Scalars['ID']> | ElementOperators,
-  'name'?: types.Scalars['String'] | null | EqualityOperators<types.Scalars['String']> | ElementOperators | StringOperators,
-  'userId'?: types.Scalars['ID'] | null | EqualityOperators<types.Scalars['ID']> | ElementOperators
+  'id'?: types.Scalars['ID'] | null | T.EqualityOperators<types.Scalars['ID']> | T.ElementOperators,
+  'name'?: types.Scalars['String'] | null | T.EqualityOperators<types.Scalars['String']> | T.ElementOperators | T.StringOperators,
+  'userId'?: types.Scalars['ID'] | null | T.EqualityOperators<types.Scalars['ID']> | T.ElementOperators
 }
-export type MockedEntityFilter = MockedEntityFilterFields & LogicalOperators<MockedEntityFilterFields | MockedEntityRawFilter>
+export type MockedEntityFilter = MockedEntityFilterFields & T.LogicalOperators<MockedEntityFilterFields | MockedEntityRawFilter>
 export type MockedEntityRawFilter = never
 
 export type MockedEntityRelations = Record<never, string>
@@ -931,10 +931,10 @@ export type MockedEntityProjection = {
   user?: UserProjection | boolean,
   userId?: boolean,
 }
-export type MockedEntityParam<P extends MockedEntityProjection> = ParamProjection<types.MockedEntity, MockedEntityProjection, P>
+export type MockedEntityParam<P extends MockedEntityProjection> = T.ParamProjection<types.MockedEntity, MockedEntityProjection, P>
 
 export type MockedEntitySortKeys = 'id' | 'name' | 'userId'
-export type MockedEntitySort = OneKey<MockedEntitySortKeys, SortDirection>
+export type MockedEntitySort = T.OneKey<MockedEntitySortKeys, T.SortDirection>
 export type MockedEntityRawSort = never
 
 export type MockedEntityUpdate = {
@@ -949,17 +949,17 @@ export type MockedEntityInsert = {
   userId: types.Scalars['ID'],
 }
 
-type MockedEntityDAOGenerics<MetadataType, OperationMetadataType> = InMemoryDAOGenerics<types.MockedEntity, 'id', 'ID', MockedEntityFilter, MockedEntityRawFilter, MockedEntityRelations, MockedEntityProjection, MockedEntitySort, MockedEntityRawSort, MockedEntityInsert, MockedEntityUpdate, MockedEntityRawUpdate, MockedEntityExcludedFields, MockedEntityRelationFields, MetadataType, OperationMetadataType, types.Scalars, 'mockedEntity', DAOContext<MetadataType, OperationMetadataType>>
-export type MockedEntityDAOParams<MetadataType, OperationMetadataType> = Omit<InMemoryDAOParams<MockedEntityDAOGenerics<MetadataType, OperationMetadataType>>, 'idGenerator' | 'idField' | 'schema' | 'idScalar' | 'idGeneration'>
-export type InMemoryMockedEntityDAOParams<MetadataType, OperationMetadataType> = Omit<InMemoryDAOParams<MockedEntityDAOGenerics<MetadataType, OperationMetadataType>>, 'idGenerator' | 'idField' | 'schema' | 'idScalar' | 'idGeneration'>
+type MockedEntityDAOGenerics<MetadataType, OperationMetadataType> = T.InMemoryDAOGenerics<types.MockedEntity, 'id', 'ID', MockedEntityFilter, MockedEntityRawFilter, MockedEntityRelations, MockedEntityProjection, MockedEntitySort, MockedEntityRawSort, MockedEntityInsert, MockedEntityUpdate, MockedEntityRawUpdate, MockedEntityExcludedFields, MockedEntityRelationFields, MetadataType, OperationMetadataType, types.Scalars, 'mockedEntity', DAOContext<MetadataType, OperationMetadataType>>
+export type MockedEntityDAOParams<MetadataType, OperationMetadataType> = Omit<T.InMemoryDAOParams<MockedEntityDAOGenerics<MetadataType, OperationMetadataType>>, 'idGenerator' | 'idField' | 'schema' | 'idScalar' | 'idGeneration'>
+export type InMemoryMockedEntityDAOParams<MetadataType, OperationMetadataType> = Omit<T.InMemoryDAOParams<MockedEntityDAOGenerics<MetadataType, OperationMetadataType>>, 'idGenerator' | 'idField' | 'schema' | 'idScalar' | 'idGeneration'>
 
-export class MockedEntityDAO<MetadataType, OperationMetadataType> extends AbstractInMemoryDAO<MockedEntityDAOGenerics<MetadataType, OperationMetadataType>> {  
+export class MockedEntityDAO<MetadataType, OperationMetadataType> extends T.AbstractInMemoryDAO<MockedEntityDAOGenerics<MetadataType, OperationMetadataType>> {  
   
   public static projection<P extends MockedEntityProjection>(p: P) {
     return p
   }
-  public static mergeProjection<P1 extends MockedEntityProjection, P2 extends MockedEntityProjection>(p1: P1, p2: P2): SelectProjection<MockedEntityProjection, P1, P2> {
-    return mergeProjections(p1, p2) as SelectProjection<MockedEntityProjection, P1, P2>
+  public static mergeProjection<P1 extends MockedEntityProjection, P2 extends MockedEntityProjection>(p1: P1, p2: P2): T.SelectProjection<MockedEntityProjection, P1, P2> {
+    return T.mergeProjections(p1, p2) as T.SelectProjection<MockedEntityProjection, P1, P2>
   }
   
   public constructor(params: MockedEntityDAOParams<MetadataType, OperationMetadataType>){
@@ -967,7 +967,7 @@ export class MockedEntityDAO<MetadataType, OperationMetadataType> extends Abstra
       ...params, 
       idField: 'id', 
       schema: mockedEntitySchema(), 
-      relations: overrideRelations(
+      relations: T.overrideRelations(
         [
           { type: '1-1', reference: 'inner', field: 'user', refFrom: 'userId', refTo: 'id', dao: 'user', required: true }
         ]
@@ -978,13 +978,13 @@ export class MockedEntityDAO<MetadataType, OperationMetadataType> extends Abstra
   }
   }
 
-export class InMemoryMockedEntityDAO<MetadataType, OperationMetadataType> extends AbstractInMemoryDAO<MockedEntityDAOGenerics<MetadataType, OperationMetadataType>> {  
+export class InMemoryMockedEntityDAO<MetadataType, OperationMetadataType> extends T.AbstractInMemoryDAO<MockedEntityDAOGenerics<MetadataType, OperationMetadataType>> {  
   
   public static projection<P extends MockedEntityProjection>(p: P) {
     return p
   }
-  public static mergeProjection<P1 extends MockedEntityProjection, P2 extends MockedEntityProjection>(p1: P1, p2: P2): SelectProjection<MockedEntityProjection, P1, P2> {
-    return mergeProjections(p1, p2) as SelectProjection<MockedEntityProjection, P1, P2>
+  public static mergeProjection<P1 extends MockedEntityProjection, P2 extends MockedEntityProjection>(p1: P1, p2: P2): T.SelectProjection<MockedEntityProjection, P1, P2> {
+    return T.mergeProjections(p1, p2) as T.SelectProjection<MockedEntityProjection, P1, P2>
   }
   
   public constructor(params: InMemoryMockedEntityDAOParams<MetadataType, OperationMetadataType>){
@@ -992,7 +992,7 @@ export class InMemoryMockedEntityDAO<MetadataType, OperationMetadataType> extend
       ...params, 
       idField: 'id', 
       schema: mockedEntitySchema(), 
-      relations: overrideRelations(
+      relations: T.overrideRelations(
         [
           { type: '1-1', reference: 'inner', field: 'user', refFrom: 'userId', refTo: 'id', dao: 'user', required: true }
         ]
@@ -1012,7 +1012,7 @@ export class InMemoryMockedEntityDAO<MetadataType, OperationMetadataType> extend
 export type OrganizationExcludedFields = 'computedName'
 export type OrganizationRelationFields = never
 
-export function organizationSchema(): Schema<types.Scalars> {
+export function organizationSchema(): T.Schema<types.Scalars> {
   return {
     'address': { embedded: addressSchema() },
     'id': {
@@ -1030,12 +1030,12 @@ export function organizationSchema(): Schema<types.Scalars> {
 }
 
 type OrganizationFilterFields = {
-  'address.id'?: types.Scalars['ID'] | null | EqualityOperators<types.Scalars['ID']> | ElementOperators,
-  'id'?: types.Scalars['ID'] | null | EqualityOperators<types.Scalars['ID']> | ElementOperators,
-  'name'?: types.Scalars['String'] | null | EqualityOperators<types.Scalars['String']> | ElementOperators | StringOperators,
-  'vatNumber'?: types.Scalars['String'] | null | EqualityOperators<types.Scalars['String']> | ElementOperators | StringOperators
+  'address.id'?: types.Scalars['ID'] | null | T.EqualityOperators<types.Scalars['ID']> | T.ElementOperators,
+  'id'?: types.Scalars['ID'] | null | T.EqualityOperators<types.Scalars['ID']> | T.ElementOperators,
+  'name'?: types.Scalars['String'] | null | T.EqualityOperators<types.Scalars['String']> | T.ElementOperators | T.StringOperators,
+  'vatNumber'?: types.Scalars['String'] | null | T.EqualityOperators<types.Scalars['String']> | T.ElementOperators | T.StringOperators
 }
-export type OrganizationFilter = OrganizationFilterFields & LogicalOperators<OrganizationFilterFields | OrganizationRawFilter>
+export type OrganizationFilter = OrganizationFilterFields & T.LogicalOperators<OrganizationFilterFields | OrganizationRawFilter>
 export type OrganizationRawFilter = never
 
 export type OrganizationRelations = Record<never, string>
@@ -1050,10 +1050,10 @@ export type OrganizationProjection = {
   name?: boolean,
   vatNumber?: boolean,
 }
-export type OrganizationParam<P extends OrganizationProjection> = ParamProjection<types.Organization, OrganizationProjection, P>
+export type OrganizationParam<P extends OrganizationProjection> = T.ParamProjection<types.Organization, OrganizationProjection, P>
 
 export type OrganizationSortKeys = 'address.id' | 'id' | 'name' | 'vatNumber'
-export type OrganizationSort = OneKey<OrganizationSortKeys, SortDirection>
+export type OrganizationSort = T.OneKey<OrganizationSortKeys, T.SortDirection>
 export type OrganizationRawSort = never
 
 export type OrganizationUpdate = {
@@ -1072,17 +1072,17 @@ export type OrganizationInsert = {
   vatNumber?: null | types.Scalars['String'],
 }
 
-type OrganizationDAOGenerics<MetadataType, OperationMetadataType> = InMemoryDAOGenerics<types.Organization, 'id', 'ID', OrganizationFilter, OrganizationRawFilter, OrganizationRelations, OrganizationProjection, OrganizationSort, OrganizationRawSort, OrganizationInsert, OrganizationUpdate, OrganizationRawUpdate, OrganizationExcludedFields, OrganizationRelationFields, MetadataType, OperationMetadataType, types.Scalars, 'organization', DAOContext<MetadataType, OperationMetadataType>>
-export type OrganizationDAOParams<MetadataType, OperationMetadataType> = Omit<InMemoryDAOParams<OrganizationDAOGenerics<MetadataType, OperationMetadataType>>, 'idField' | 'schema' | 'idScalar' | 'idGeneration'>
-export type InMemoryOrganizationDAOParams<MetadataType, OperationMetadataType> = Omit<InMemoryDAOParams<OrganizationDAOGenerics<MetadataType, OperationMetadataType>>, 'idField' | 'schema' | 'idScalar' | 'idGeneration'>
+type OrganizationDAOGenerics<MetadataType, OperationMetadataType> = T.InMemoryDAOGenerics<types.Organization, 'id', 'ID', OrganizationFilter, OrganizationRawFilter, OrganizationRelations, OrganizationProjection, OrganizationSort, OrganizationRawSort, OrganizationInsert, OrganizationUpdate, OrganizationRawUpdate, OrganizationExcludedFields, OrganizationRelationFields, MetadataType, OperationMetadataType, types.Scalars, 'organization', DAOContext<MetadataType, OperationMetadataType>>
+export type OrganizationDAOParams<MetadataType, OperationMetadataType> = Omit<T.InMemoryDAOParams<OrganizationDAOGenerics<MetadataType, OperationMetadataType>>, 'idField' | 'schema' | 'idScalar' | 'idGeneration'>
+export type InMemoryOrganizationDAOParams<MetadataType, OperationMetadataType> = Omit<T.InMemoryDAOParams<OrganizationDAOGenerics<MetadataType, OperationMetadataType>>, 'idField' | 'schema' | 'idScalar' | 'idGeneration'>
 
-export class OrganizationDAO<MetadataType, OperationMetadataType> extends AbstractInMemoryDAO<OrganizationDAOGenerics<MetadataType, OperationMetadataType>> {  
+export class OrganizationDAO<MetadataType, OperationMetadataType> extends T.AbstractInMemoryDAO<OrganizationDAOGenerics<MetadataType, OperationMetadataType>> {  
   
   public static projection<P extends OrganizationProjection>(p: P) {
     return p
   }
-  public static mergeProjection<P1 extends OrganizationProjection, P2 extends OrganizationProjection>(p1: P1, p2: P2): SelectProjection<OrganizationProjection, P1, P2> {
-    return mergeProjections(p1, p2) as SelectProjection<OrganizationProjection, P1, P2>
+  public static mergeProjection<P1 extends OrganizationProjection, P2 extends OrganizationProjection>(p1: P1, p2: P2): T.SelectProjection<OrganizationProjection, P1, P2> {
+    return T.mergeProjections(p1, p2) as T.SelectProjection<OrganizationProjection, P1, P2>
   }
   
   public constructor(params: OrganizationDAOParams<MetadataType, OperationMetadataType>){
@@ -1090,7 +1090,7 @@ export class OrganizationDAO<MetadataType, OperationMetadataType> extends Abstra
       ...params, 
       idField: 'id', 
       schema: organizationSchema(), 
-      relations: overrideRelations(
+      relations: T.overrideRelations(
         [
           { type: '1-n', reference: 'foreign', field: 'address.cities', refFrom: 'addressId', refTo: 'address.id', dao: 'city', required: false }
         ]
@@ -1101,13 +1101,13 @@ export class OrganizationDAO<MetadataType, OperationMetadataType> extends Abstra
   }
   }
 
-export class InMemoryOrganizationDAO<MetadataType, OperationMetadataType> extends AbstractInMemoryDAO<OrganizationDAOGenerics<MetadataType, OperationMetadataType>> {  
+export class InMemoryOrganizationDAO<MetadataType, OperationMetadataType> extends T.AbstractInMemoryDAO<OrganizationDAOGenerics<MetadataType, OperationMetadataType>> {  
   
   public static projection<P extends OrganizationProjection>(p: P) {
     return p
   }
-  public static mergeProjection<P1 extends OrganizationProjection, P2 extends OrganizationProjection>(p1: P1, p2: P2): SelectProjection<OrganizationProjection, P1, P2> {
-    return mergeProjections(p1, p2) as SelectProjection<OrganizationProjection, P1, P2>
+  public static mergeProjection<P1 extends OrganizationProjection, P2 extends OrganizationProjection>(p1: P1, p2: P2): T.SelectProjection<OrganizationProjection, P1, P2> {
+    return T.mergeProjections(p1, p2) as T.SelectProjection<OrganizationProjection, P1, P2>
   }
   
   public constructor(params: InMemoryOrganizationDAOParams<MetadataType, OperationMetadataType>){
@@ -1115,7 +1115,7 @@ export class InMemoryOrganizationDAO<MetadataType, OperationMetadataType> extend
       ...params, 
       idField: 'id', 
       schema: organizationSchema(), 
-      relations: overrideRelations(
+      relations: T.overrideRelations(
         [
           { type: '1-n', reference: 'foreign', field: 'address.cities', refFrom: 'addressId', refTo: 'address.id', dao: 'city', required: false }
         ]
@@ -1135,7 +1135,7 @@ export class InMemoryOrganizationDAO<MetadataType, OperationMetadataType> extend
 export type PostExcludedFields = never
 export type PostRelationFields = 'author'
 
-export function postSchema(): Schema<types.Scalars> {
+export function postSchema(): T.Schema<types.Scalars> {
   return {
     'authorId': {
       scalar: 'ID', 
@@ -1165,16 +1165,16 @@ export function postSchema(): Schema<types.Scalars> {
 }
 
 type PostFilterFields = {
-  'authorId'?: types.Scalars['ID'] | null | EqualityOperators<types.Scalars['ID']> | ElementOperators,
-  'body'?: types.Scalars['String'] | null | EqualityOperators<types.Scalars['String']> | ElementOperators | StringOperators,
-  'clicks'?: types.Scalars['Int'] | null | EqualityOperators<types.Scalars['Int']> | ElementOperators | QuantityOperators<types.Scalars['Int']>,
-  'id'?: types.Scalars['ID'] | null | EqualityOperators<types.Scalars['ID']> | ElementOperators,
-  'metadata.region'?: types.Scalars['String'] | null | EqualityOperators<types.Scalars['String']> | ElementOperators | StringOperators,
-  'metadata.visible'?: types.Scalars['Boolean'] | null | EqualityOperators<types.Scalars['Boolean']> | ElementOperators,
-  'title'?: types.Scalars['String'] | null | EqualityOperators<types.Scalars['String']> | ElementOperators | StringOperators,
-  'views'?: types.Scalars['Int'] | null | EqualityOperators<types.Scalars['Int']> | ElementOperators | QuantityOperators<types.Scalars['Int']>
+  'authorId'?: types.Scalars['ID'] | null | T.EqualityOperators<types.Scalars['ID']> | T.ElementOperators,
+  'body'?: types.Scalars['String'] | null | T.EqualityOperators<types.Scalars['String']> | T.ElementOperators | T.StringOperators,
+  'clicks'?: types.Scalars['Int'] | null | T.EqualityOperators<types.Scalars['Int']> | T.ElementOperators | T.QuantityOperators<types.Scalars['Int']>,
+  'id'?: types.Scalars['ID'] | null | T.EqualityOperators<types.Scalars['ID']> | T.ElementOperators,
+  'metadata.region'?: types.Scalars['String'] | null | T.EqualityOperators<types.Scalars['String']> | T.ElementOperators | T.StringOperators,
+  'metadata.visible'?: types.Scalars['Boolean'] | null | T.EqualityOperators<types.Scalars['Boolean']> | T.ElementOperators,
+  'title'?: types.Scalars['String'] | null | T.EqualityOperators<types.Scalars['String']> | T.ElementOperators | T.StringOperators,
+  'views'?: types.Scalars['Int'] | null | T.EqualityOperators<types.Scalars['Int']> | T.ElementOperators | T.QuantityOperators<types.Scalars['Int']>
 }
-export type PostFilter = PostFilterFields & LogicalOperators<PostFilterFields | PostRawFilter>
+export type PostFilter = PostFilterFields & T.LogicalOperators<PostFilterFields | PostRawFilter>
 export type PostRawFilter = never
 
 export type PostRelations = Record<never, string>
@@ -1192,10 +1192,10 @@ export type PostProjection = {
   title?: boolean,
   views?: boolean,
 }
-export type PostParam<P extends PostProjection> = ParamProjection<types.Post, PostProjection, P>
+export type PostParam<P extends PostProjection> = T.ParamProjection<types.Post, PostProjection, P>
 
 export type PostSortKeys = 'authorId' | 'body' | 'clicks' | 'id' | 'metadata.region' | 'metadata.visible' | 'title' | 'views'
-export type PostSort = OneKey<PostSortKeys, SortDirection>
+export type PostSort = T.OneKey<PostSortKeys, T.SortDirection>
 export type PostRawSort = never
 
 export type PostUpdate = {
@@ -1221,17 +1221,17 @@ export type PostInsert = {
   views: types.Scalars['Int'],
 }
 
-type PostDAOGenerics<MetadataType, OperationMetadataType> = InMemoryDAOGenerics<types.Post, 'id', 'ID', PostFilter, PostRawFilter, PostRelations, PostProjection, PostSort, PostRawSort, PostInsert, PostUpdate, PostRawUpdate, PostExcludedFields, PostRelationFields, MetadataType, OperationMetadataType, types.Scalars, 'post', DAOContext<MetadataType, OperationMetadataType>>
-export type PostDAOParams<MetadataType, OperationMetadataType> = Omit<InMemoryDAOParams<PostDAOGenerics<MetadataType, OperationMetadataType>>, 'idField' | 'schema' | 'idScalar' | 'idGeneration'>
-export type InMemoryPostDAOParams<MetadataType, OperationMetadataType> = Omit<InMemoryDAOParams<PostDAOGenerics<MetadataType, OperationMetadataType>>, 'idField' | 'schema' | 'idScalar' | 'idGeneration'>
+type PostDAOGenerics<MetadataType, OperationMetadataType> = T.InMemoryDAOGenerics<types.Post, 'id', 'ID', PostFilter, PostRawFilter, PostRelations, PostProjection, PostSort, PostRawSort, PostInsert, PostUpdate, PostRawUpdate, PostExcludedFields, PostRelationFields, MetadataType, OperationMetadataType, types.Scalars, 'post', DAOContext<MetadataType, OperationMetadataType>>
+export type PostDAOParams<MetadataType, OperationMetadataType> = Omit<T.InMemoryDAOParams<PostDAOGenerics<MetadataType, OperationMetadataType>>, 'idField' | 'schema' | 'idScalar' | 'idGeneration'>
+export type InMemoryPostDAOParams<MetadataType, OperationMetadataType> = Omit<T.InMemoryDAOParams<PostDAOGenerics<MetadataType, OperationMetadataType>>, 'idField' | 'schema' | 'idScalar' | 'idGeneration'>
 
-export class PostDAO<MetadataType, OperationMetadataType> extends AbstractInMemoryDAO<PostDAOGenerics<MetadataType, OperationMetadataType>> {  
+export class PostDAO<MetadataType, OperationMetadataType> extends T.AbstractInMemoryDAO<PostDAOGenerics<MetadataType, OperationMetadataType>> {  
   
   public static projection<P extends PostProjection>(p: P) {
     return p
   }
-  public static mergeProjection<P1 extends PostProjection, P2 extends PostProjection>(p1: P1, p2: P2): SelectProjection<PostProjection, P1, P2> {
-    return mergeProjections(p1, p2) as SelectProjection<PostProjection, P1, P2>
+  public static mergeProjection<P1 extends PostProjection, P2 extends PostProjection>(p1: P1, p2: P2): T.SelectProjection<PostProjection, P1, P2> {
+    return T.mergeProjections(p1, p2) as T.SelectProjection<PostProjection, P1, P2>
   }
   
   public constructor(params: PostDAOParams<MetadataType, OperationMetadataType>){
@@ -1239,7 +1239,7 @@ export class PostDAO<MetadataType, OperationMetadataType> extends AbstractInMemo
       ...params, 
       idField: 'id', 
       schema: postSchema(), 
-      relations: overrideRelations(
+      relations: T.overrideRelations(
         [
           { type: '1-1', reference: 'inner', field: 'author', refFrom: 'authorId', refTo: 'id', dao: 'user', required: true }
         ]
@@ -1250,13 +1250,13 @@ export class PostDAO<MetadataType, OperationMetadataType> extends AbstractInMemo
   }
   }
 
-export class InMemoryPostDAO<MetadataType, OperationMetadataType> extends AbstractInMemoryDAO<PostDAOGenerics<MetadataType, OperationMetadataType>> {  
+export class InMemoryPostDAO<MetadataType, OperationMetadataType> extends T.AbstractInMemoryDAO<PostDAOGenerics<MetadataType, OperationMetadataType>> {  
   
   public static projection<P extends PostProjection>(p: P) {
     return p
   }
-  public static mergeProjection<P1 extends PostProjection, P2 extends PostProjection>(p1: P1, p2: P2): SelectProjection<PostProjection, P1, P2> {
-    return mergeProjections(p1, p2) as SelectProjection<PostProjection, P1, P2>
+  public static mergeProjection<P1 extends PostProjection, P2 extends PostProjection>(p1: P1, p2: P2): T.SelectProjection<PostProjection, P1, P2> {
+    return T.mergeProjections(p1, p2) as T.SelectProjection<PostProjection, P1, P2>
   }
   
   public constructor(params: InMemoryPostDAOParams<MetadataType, OperationMetadataType>){
@@ -1264,7 +1264,7 @@ export class InMemoryPostDAO<MetadataType, OperationMetadataType> extends Abstra
       ...params, 
       idField: 'id', 
       schema: postSchema(), 
-      relations: overrideRelations(
+      relations: T.overrideRelations(
         [
           { type: '1-1', reference: 'inner', field: 'author', refFrom: 'authorId', refTo: 'id', dao: 'user', required: true }
         ]
@@ -1281,7 +1281,7 @@ export class InMemoryPostDAO<MetadataType, OperationMetadataType> extends Abstra
 //--------------------------------- POSTMETADATA ---------------------------------
 //--------------------------------------------------------------------------------
 
-export function postMetadataSchema(): Schema<types.Scalars> {
+export function postMetadataSchema(): T.Schema<types.Scalars> {
   return {
     'region': {
       scalar: 'String', 
@@ -1298,7 +1298,7 @@ export type PostMetadataProjection = {
   region?: boolean,
   visible?: boolean,
 }
-export type PostMetadataParam<P extends PostMetadataProjection> = ParamProjection<types.PostMetadata, PostMetadataProjection, P>
+export type PostMetadataParam<P extends PostMetadataProjection> = T.ParamProjection<types.PostMetadata, PostMetadataProjection, P>
 
 export type PostMetadataInsert = {
   region: types.Scalars['String'],
@@ -1314,7 +1314,7 @@ export type PostMetadataInsert = {
 export type PostTypeExcludedFields = never
 export type PostTypeRelationFields = never
 
-export function postTypeSchema(): Schema<types.Scalars> {
+export function postTypeSchema(): T.Schema<types.Scalars> {
   return {
     'id': {
       scalar: 'ID', 
@@ -1328,10 +1328,10 @@ export function postTypeSchema(): Schema<types.Scalars> {
 }
 
 type PostTypeFilterFields = {
-  'id'?: types.Scalars['ID'] | null | EqualityOperators<types.Scalars['ID']> | ElementOperators,
-  'name'?: types.Scalars['String'] | null | EqualityOperators<types.Scalars['String']> | ElementOperators | StringOperators
+  'id'?: types.Scalars['ID'] | null | T.EqualityOperators<types.Scalars['ID']> | T.ElementOperators,
+  'name'?: types.Scalars['String'] | null | T.EqualityOperators<types.Scalars['String']> | T.ElementOperators | T.StringOperators
 }
-export type PostTypeFilter = PostTypeFilterFields & LogicalOperators<PostTypeFilterFields | PostTypeRawFilter>
+export type PostTypeFilter = PostTypeFilterFields & T.LogicalOperators<PostTypeFilterFields | PostTypeRawFilter>
 export type PostTypeRawFilter = never
 
 export type PostTypeRelations = Record<never, string>
@@ -1340,10 +1340,10 @@ export type PostTypeProjection = {
   id?: boolean,
   name?: boolean,
 }
-export type PostTypeParam<P extends PostTypeProjection> = ParamProjection<types.PostType, PostTypeProjection, P>
+export type PostTypeParam<P extends PostTypeProjection> = T.ParamProjection<types.PostType, PostTypeProjection, P>
 
 export type PostTypeSortKeys = 'id' | 'name'
-export type PostTypeSort = OneKey<PostTypeSortKeys, SortDirection>
+export type PostTypeSort = T.OneKey<PostTypeSortKeys, T.SortDirection>
 export type PostTypeRawSort = never
 
 export type PostTypeUpdate = {
@@ -1357,17 +1357,17 @@ export type PostTypeInsert = {
   name: types.Scalars['String'],
 }
 
-type PostTypeDAOGenerics<MetadataType, OperationMetadataType> = InMemoryDAOGenerics<types.PostType, 'id', 'ID', PostTypeFilter, PostTypeRawFilter, PostTypeRelations, PostTypeProjection, PostTypeSort, PostTypeRawSort, PostTypeInsert, PostTypeUpdate, PostTypeRawUpdate, PostTypeExcludedFields, PostTypeRelationFields, MetadataType, OperationMetadataType, types.Scalars, 'postType', DAOContext<MetadataType, OperationMetadataType>>
-export type PostTypeDAOParams<MetadataType, OperationMetadataType> = Omit<InMemoryDAOParams<PostTypeDAOGenerics<MetadataType, OperationMetadataType>>, 'idGenerator' | 'idField' | 'schema' | 'idScalar' | 'idGeneration'>
-export type InMemoryPostTypeDAOParams<MetadataType, OperationMetadataType> = Omit<InMemoryDAOParams<PostTypeDAOGenerics<MetadataType, OperationMetadataType>>, 'idGenerator' | 'idField' | 'schema' | 'idScalar' | 'idGeneration'>
+type PostTypeDAOGenerics<MetadataType, OperationMetadataType> = T.InMemoryDAOGenerics<types.PostType, 'id', 'ID', PostTypeFilter, PostTypeRawFilter, PostTypeRelations, PostTypeProjection, PostTypeSort, PostTypeRawSort, PostTypeInsert, PostTypeUpdate, PostTypeRawUpdate, PostTypeExcludedFields, PostTypeRelationFields, MetadataType, OperationMetadataType, types.Scalars, 'postType', DAOContext<MetadataType, OperationMetadataType>>
+export type PostTypeDAOParams<MetadataType, OperationMetadataType> = Omit<T.InMemoryDAOParams<PostTypeDAOGenerics<MetadataType, OperationMetadataType>>, 'idGenerator' | 'idField' | 'schema' | 'idScalar' | 'idGeneration'>
+export type InMemoryPostTypeDAOParams<MetadataType, OperationMetadataType> = Omit<T.InMemoryDAOParams<PostTypeDAOGenerics<MetadataType, OperationMetadataType>>, 'idGenerator' | 'idField' | 'schema' | 'idScalar' | 'idGeneration'>
 
-export class PostTypeDAO<MetadataType, OperationMetadataType> extends AbstractInMemoryDAO<PostTypeDAOGenerics<MetadataType, OperationMetadataType>> {  
+export class PostTypeDAO<MetadataType, OperationMetadataType> extends T.AbstractInMemoryDAO<PostTypeDAOGenerics<MetadataType, OperationMetadataType>> {  
   
   public static projection<P extends PostTypeProjection>(p: P) {
     return p
   }
-  public static mergeProjection<P1 extends PostTypeProjection, P2 extends PostTypeProjection>(p1: P1, p2: P2): SelectProjection<PostTypeProjection, P1, P2> {
-    return mergeProjections(p1, p2) as SelectProjection<PostTypeProjection, P1, P2>
+  public static mergeProjection<P1 extends PostTypeProjection, P2 extends PostTypeProjection>(p1: P1, p2: P2): T.SelectProjection<PostTypeProjection, P1, P2> {
+    return T.mergeProjections(p1, p2) as T.SelectProjection<PostTypeProjection, P1, P2>
   }
   
   public constructor(params: PostTypeDAOParams<MetadataType, OperationMetadataType>){
@@ -1375,7 +1375,7 @@ export class PostTypeDAO<MetadataType, OperationMetadataType> extends AbstractIn
       ...params, 
       idField: 'id', 
       schema: postTypeSchema(), 
-      relations: overrideRelations(
+      relations: T.overrideRelations(
         [
           
         ]
@@ -1386,13 +1386,13 @@ export class PostTypeDAO<MetadataType, OperationMetadataType> extends AbstractIn
   }
   }
 
-export class InMemoryPostTypeDAO<MetadataType, OperationMetadataType> extends AbstractInMemoryDAO<PostTypeDAOGenerics<MetadataType, OperationMetadataType>> {  
+export class InMemoryPostTypeDAO<MetadataType, OperationMetadataType> extends T.AbstractInMemoryDAO<PostTypeDAOGenerics<MetadataType, OperationMetadataType>> {  
   
   public static projection<P extends PostTypeProjection>(p: P) {
     return p
   }
-  public static mergeProjection<P1 extends PostTypeProjection, P2 extends PostTypeProjection>(p1: P1, p2: P2): SelectProjection<PostTypeProjection, P1, P2> {
-    return mergeProjections(p1, p2) as SelectProjection<PostTypeProjection, P1, P2>
+  public static mergeProjection<P1 extends PostTypeProjection, P2 extends PostTypeProjection>(p1: P1, p2: P2): T.SelectProjection<PostTypeProjection, P1, P2> {
+    return T.mergeProjections(p1, p2) as T.SelectProjection<PostTypeProjection, P1, P2>
   }
   
   public constructor(params: InMemoryPostTypeDAOParams<MetadataType, OperationMetadataType>){
@@ -1400,7 +1400,7 @@ export class InMemoryPostTypeDAO<MetadataType, OperationMetadataType> extends Ab
       ...params, 
       idField: 'id', 
       schema: postTypeSchema(), 
-      relations: overrideRelations(
+      relations: T.overrideRelations(
         [
           
         ]
@@ -1420,7 +1420,7 @@ export class InMemoryPostTypeDAO<MetadataType, OperationMetadataType> extends Ab
 export type UserExcludedFields = never
 export type UserRelationFields = 'dogs' | 'friends'
 
-export function userSchema(): Schema<types.Scalars> {
+export function userSchema(): T.Schema<types.Scalars> {
   return {
     'amount': {
       scalar: 'Decimal'
@@ -1464,29 +1464,29 @@ export function userSchema(): Schema<types.Scalars> {
 }
 
 type UserFilterFields = {
-  'amount'?: types.Scalars['Decimal'] | null | EqualityOperators<types.Scalars['Decimal']> | ElementOperators,
-  'amounts'?: types.Scalars['Decimal'][] | null | EqualityOperators<types.Scalars['Decimal'][]> | ElementOperators,
-  'credentials.password'?: types.Scalars['Password'] | null | EqualityOperators<types.Scalars['Password']> | ElementOperators,
-  'credentials.username'?: types.Scalars['String'] | null | EqualityOperators<types.Scalars['String']> | ElementOperators | StringOperators,
-  'embeddedPost.authorId'?: types.Scalars['ID'] | null | EqualityOperators<types.Scalars['ID']> | ElementOperators,
-  'embeddedPost.body'?: types.Scalars['String'] | null | EqualityOperators<types.Scalars['String']> | ElementOperators | StringOperators,
-  'embeddedPost.clicks'?: types.Scalars['Int'] | null | EqualityOperators<types.Scalars['Int']> | ElementOperators | QuantityOperators<types.Scalars['Int']>,
-  'embeddedPost.id'?: types.Scalars['ID'] | null | EqualityOperators<types.Scalars['ID']> | ElementOperators,
-  'embeddedPost.metadata.region'?: types.Scalars['String'] | null | EqualityOperators<types.Scalars['String']> | ElementOperators | StringOperators,
-  'embeddedPost.metadata.visible'?: types.Scalars['Boolean'] | null | EqualityOperators<types.Scalars['Boolean']> | ElementOperators,
-  'embeddedPost.title'?: types.Scalars['String'] | null | EqualityOperators<types.Scalars['String']> | ElementOperators | StringOperators,
-  'embeddedPost.views'?: types.Scalars['Int'] | null | EqualityOperators<types.Scalars['Int']> | ElementOperators | QuantityOperators<types.Scalars['Int']>,
-  'firstName'?: types.Scalars['String'] | null | EqualityOperators<types.Scalars['String']> | ElementOperators | StringOperators,
-  'friendsId'?: types.Scalars['ID'][] | null | EqualityOperators<types.Scalars['ID'][]> | ElementOperators,
-  'id'?: types.Scalars['ID'] | null | EqualityOperators<types.Scalars['ID']> | ElementOperators,
-  'lastName'?: types.Scalars['String'] | null | EqualityOperators<types.Scalars['String']> | ElementOperators | StringOperators,
-  'live'?: types.Scalars['Boolean'] | null | EqualityOperators<types.Scalars['Boolean']> | ElementOperators,
-  'localization'?: types.Scalars['Coordinates'] | null | EqualityOperators<types.Scalars['Coordinates']> | ElementOperators,
-  'title'?: types.Scalars['LocalizedString'] | null | EqualityOperators<types.Scalars['LocalizedString']> | ElementOperators,
-  'usernamePasswordCredentials.password'?: types.Scalars['Password'] | null | EqualityOperators<types.Scalars['Password']> | ElementOperators,
-  'usernamePasswordCredentials.username'?: types.Scalars['String'] | null | EqualityOperators<types.Scalars['String']> | ElementOperators | StringOperators
+  'amount'?: types.Scalars['Decimal'] | null | T.EqualityOperators<types.Scalars['Decimal']> | T.ElementOperators,
+  'amounts'?: types.Scalars['Decimal'][] | null | T.EqualityOperators<types.Scalars['Decimal'][]> | T.ElementOperators,
+  'credentials.password'?: types.Scalars['Password'] | null | T.EqualityOperators<types.Scalars['Password']> | T.ElementOperators,
+  'credentials.username'?: types.Scalars['String'] | null | T.EqualityOperators<types.Scalars['String']> | T.ElementOperators | T.StringOperators,
+  'embeddedPost.authorId'?: types.Scalars['ID'] | null | T.EqualityOperators<types.Scalars['ID']> | T.ElementOperators,
+  'embeddedPost.body'?: types.Scalars['String'] | null | T.EqualityOperators<types.Scalars['String']> | T.ElementOperators | T.StringOperators,
+  'embeddedPost.clicks'?: types.Scalars['Int'] | null | T.EqualityOperators<types.Scalars['Int']> | T.ElementOperators | T.QuantityOperators<types.Scalars['Int']>,
+  'embeddedPost.id'?: types.Scalars['ID'] | null | T.EqualityOperators<types.Scalars['ID']> | T.ElementOperators,
+  'embeddedPost.metadata.region'?: types.Scalars['String'] | null | T.EqualityOperators<types.Scalars['String']> | T.ElementOperators | T.StringOperators,
+  'embeddedPost.metadata.visible'?: types.Scalars['Boolean'] | null | T.EqualityOperators<types.Scalars['Boolean']> | T.ElementOperators,
+  'embeddedPost.title'?: types.Scalars['String'] | null | T.EqualityOperators<types.Scalars['String']> | T.ElementOperators | T.StringOperators,
+  'embeddedPost.views'?: types.Scalars['Int'] | null | T.EqualityOperators<types.Scalars['Int']> | T.ElementOperators | T.QuantityOperators<types.Scalars['Int']>,
+  'firstName'?: types.Scalars['String'] | null | T.EqualityOperators<types.Scalars['String']> | T.ElementOperators | T.StringOperators,
+  'friendsId'?: types.Scalars['ID'][] | null | T.EqualityOperators<types.Scalars['ID'][]> | T.ElementOperators,
+  'id'?: types.Scalars['ID'] | null | T.EqualityOperators<types.Scalars['ID']> | T.ElementOperators,
+  'lastName'?: types.Scalars['String'] | null | T.EqualityOperators<types.Scalars['String']> | T.ElementOperators | T.StringOperators,
+  'live'?: types.Scalars['Boolean'] | null | T.EqualityOperators<types.Scalars['Boolean']> | T.ElementOperators,
+  'localization'?: types.Scalars['Coordinates'] | null | T.EqualityOperators<types.Scalars['Coordinates']> | T.ElementOperators,
+  'title'?: types.Scalars['LocalizedString'] | null | T.EqualityOperators<types.Scalars['LocalizedString']> | T.ElementOperators,
+  'usernamePasswordCredentials.password'?: types.Scalars['Password'] | null | T.EqualityOperators<types.Scalars['Password']> | T.ElementOperators,
+  'usernamePasswordCredentials.username'?: types.Scalars['String'] | null | T.EqualityOperators<types.Scalars['String']> | T.ElementOperators | T.StringOperators
 }
-export type UserFilter = UserFilterFields & LogicalOperators<UserFilterFields | UserRawFilter>
+export type UserFilter = UserFilterFields & T.LogicalOperators<UserFilterFields | UserRawFilter>
 export type UserRawFilter = never
 
 export type UserRelations = {
@@ -1540,10 +1540,10 @@ export type UserProjection = {
     username?: boolean,
   } | boolean,
 }
-export type UserParam<P extends UserProjection> = ParamProjection<types.User, UserProjection, P>
+export type UserParam<P extends UserProjection> = T.ParamProjection<types.User, UserProjection, P>
 
 export type UserSortKeys = 'amount' | 'amounts' | 'credentials.password' | 'credentials.username' | 'embeddedPost.authorId' | 'embeddedPost.body' | 'embeddedPost.clicks' | 'embeddedPost.id' | 'embeddedPost.metadata.region' | 'embeddedPost.metadata.visible' | 'embeddedPost.title' | 'embeddedPost.views' | 'firstName' | 'friendsId' | 'id' | 'lastName' | 'live' | 'localization' | 'title' | 'usernamePasswordCredentials.password' | 'usernamePasswordCredentials.username'
-export type UserSort = OneKey<UserSortKeys, SortDirection>
+export type UserSort = T.OneKey<UserSortKeys, T.SortDirection>
 export type UserRawSort = never
 
 export type UserUpdate = {
@@ -1588,17 +1588,17 @@ export type UserInsert = {
   usernamePasswordCredentials?: null | UsernamePasswordCredentialsInsert,
 }
 
-type UserDAOGenerics<MetadataType, OperationMetadataType> = InMemoryDAOGenerics<types.User, 'id', 'ID', UserFilter, UserRawFilter, UserRelations, UserProjection, UserSort, UserRawSort, UserInsert, UserUpdate, UserRawUpdate, UserExcludedFields, UserRelationFields, MetadataType, OperationMetadataType, types.Scalars, 'user', DAOContext<MetadataType, OperationMetadataType>>
-export type UserDAOParams<MetadataType, OperationMetadataType> = Omit<InMemoryDAOParams<UserDAOGenerics<MetadataType, OperationMetadataType>>, 'idField' | 'schema' | 'idScalar' | 'idGeneration'>
-export type InMemoryUserDAOParams<MetadataType, OperationMetadataType> = Omit<InMemoryDAOParams<UserDAOGenerics<MetadataType, OperationMetadataType>>, 'idField' | 'schema' | 'idScalar' | 'idGeneration'>
+type UserDAOGenerics<MetadataType, OperationMetadataType> = T.InMemoryDAOGenerics<types.User, 'id', 'ID', UserFilter, UserRawFilter, UserRelations, UserProjection, UserSort, UserRawSort, UserInsert, UserUpdate, UserRawUpdate, UserExcludedFields, UserRelationFields, MetadataType, OperationMetadataType, types.Scalars, 'user', DAOContext<MetadataType, OperationMetadataType>>
+export type UserDAOParams<MetadataType, OperationMetadataType> = Omit<T.InMemoryDAOParams<UserDAOGenerics<MetadataType, OperationMetadataType>>, 'idField' | 'schema' | 'idScalar' | 'idGeneration'>
+export type InMemoryUserDAOParams<MetadataType, OperationMetadataType> = Omit<T.InMemoryDAOParams<UserDAOGenerics<MetadataType, OperationMetadataType>>, 'idField' | 'schema' | 'idScalar' | 'idGeneration'>
 
-export class UserDAO<MetadataType, OperationMetadataType> extends AbstractInMemoryDAO<UserDAOGenerics<MetadataType, OperationMetadataType>> {  
+export class UserDAO<MetadataType, OperationMetadataType> extends T.AbstractInMemoryDAO<UserDAOGenerics<MetadataType, OperationMetadataType>> {  
   
   public static projection<P extends UserProjection>(p: P) {
     return p
   }
-  public static mergeProjection<P1 extends UserProjection, P2 extends UserProjection>(p1: P1, p2: P2): SelectProjection<UserProjection, P1, P2> {
-    return mergeProjections(p1, p2) as SelectProjection<UserProjection, P1, P2>
+  public static mergeProjection<P1 extends UserProjection, P2 extends UserProjection>(p1: P1, p2: P2): T.SelectProjection<UserProjection, P1, P2> {
+    return T.mergeProjections(p1, p2) as T.SelectProjection<UserProjection, P1, P2>
   }
   
   public constructor(params: UserDAOParams<MetadataType, OperationMetadataType>){
@@ -1606,7 +1606,7 @@ export class UserDAO<MetadataType, OperationMetadataType> extends AbstractInMemo
       ...params, 
       idField: 'id', 
       schema: userSchema(), 
-      relations: overrideRelations(
+      relations: T.overrideRelations(
         [
           { type: '1-n', reference: 'foreign', field: 'dogs', refFrom: 'ownerId', refTo: 'id', dao: 'dog', required: false },
           { type: '1-1', reference: 'inner', field: 'embeddedPost.author', refFrom: 'embeddedPost.authorId', refTo: 'id', dao: 'user', required: true },
@@ -1619,13 +1619,13 @@ export class UserDAO<MetadataType, OperationMetadataType> extends AbstractInMemo
   }
   }
 
-export class InMemoryUserDAO<MetadataType, OperationMetadataType> extends AbstractInMemoryDAO<UserDAOGenerics<MetadataType, OperationMetadataType>> {  
+export class InMemoryUserDAO<MetadataType, OperationMetadataType> extends T.AbstractInMemoryDAO<UserDAOGenerics<MetadataType, OperationMetadataType>> {  
   
   public static projection<P extends UserProjection>(p: P) {
     return p
   }
-  public static mergeProjection<P1 extends UserProjection, P2 extends UserProjection>(p1: P1, p2: P2): SelectProjection<UserProjection, P1, P2> {
-    return mergeProjections(p1, p2) as SelectProjection<UserProjection, P1, P2>
+  public static mergeProjection<P1 extends UserProjection, P2 extends UserProjection>(p1: P1, p2: P2): T.SelectProjection<UserProjection, P1, P2> {
+    return T.mergeProjections(p1, p2) as T.SelectProjection<UserProjection, P1, P2>
   }
   
   public constructor(params: InMemoryUserDAOParams<MetadataType, OperationMetadataType>){
@@ -1633,7 +1633,7 @@ export class InMemoryUserDAO<MetadataType, OperationMetadataType> extends Abstra
       ...params, 
       idField: 'id', 
       schema: userSchema(), 
-      relations: overrideRelations(
+      relations: T.overrideRelations(
         [
           { type: '1-n', reference: 'foreign', field: 'dogs', refFrom: 'ownerId', refTo: 'id', dao: 'dog', required: false },
           { type: '1-1', reference: 'inner', field: 'embeddedPost.author', refFrom: 'embeddedPost.authorId', refTo: 'id', dao: 'user', required: true },
@@ -1652,7 +1652,7 @@ export class InMemoryUserDAO<MetadataType, OperationMetadataType> extends Abstra
 //------------------------- USERNAMEPASSWORDCREDENTIALS --------------------------
 //--------------------------------------------------------------------------------
 
-export function usernamePasswordCredentialsSchema(): Schema<types.Scalars> {
+export function usernamePasswordCredentialsSchema(): T.Schema<types.Scalars> {
   return {
     'password': {
       scalar: 'Password', 
@@ -1671,7 +1671,7 @@ export type UsernamePasswordCredentialsProjection = {
   password?: boolean,
   username?: boolean,
 }
-export type UsernamePasswordCredentialsParam<P extends UsernamePasswordCredentialsProjection> = ParamProjection<types.UsernamePasswordCredentials, UsernamePasswordCredentialsProjection, P>
+export type UsernamePasswordCredentialsParam<P extends UsernamePasswordCredentialsProjection> = T.ParamProjection<types.UsernamePasswordCredentials, UsernamePasswordCredentialsProjection, P>
 
 export type UsernamePasswordCredentialsInsert = {
   password: types.Scalars['Password'],
@@ -1696,14 +1696,14 @@ export type DAOContextParams<MetadataType, OperationMetadataType, Permissions ex
     postType?: Pick<Partial<PostTypeDAOParams<MetadataType, OperationMetadataType>>, 'middlewares' | 'metadata'>,
     user?: Pick<Partial<UserDAOParams<MetadataType, OperationMetadataType>>, 'idGenerator' | 'middlewares' | 'metadata'>
   },
-  scalars?: UserInputDriverDataTypeAdapterMap<types.Scalars, 'knex'>,
-  log?: LogInput<'address' | 'audit' | 'city' | 'defaultFieldsEntity' | 'device' | 'dog' | 'hotel' | 'mockedEntity' | 'organization' | 'post' | 'postType' | 'user'>,
-  security?: DAOContextSecurtyPolicy<DAOGenericsMap<MetadataType, OperationMetadataType>, OperationMetadataType, Permissions, SecurityDomain>
+  scalars?: T.UserInputDriverDataTypeAdapterMap<types.Scalars, 'knex'>,
+  log?: T.LogInput<'address' | 'audit' | 'city' | 'defaultFieldsEntity' | 'device' | 'dog' | 'hotel' | 'mockedEntity' | 'organization' | 'post' | 'postType' | 'user'>,
+  security?: T.DAOContextSecurtyPolicy<DAOGenericsMap<MetadataType, OperationMetadataType>, OperationMetadataType, Permissions, SecurityDomain>
 }
 
-type DAOContextMiddleware<MetadataType = never, OperationMetadataType = never> = DAOMiddleware<DAOGenericsUnion<MetadataType, OperationMetadataType>>
+type DAOContextMiddleware<MetadataType = never, OperationMetadataType = never> = T.DAOMiddleware<DAOGenericsUnion<MetadataType, OperationMetadataType>>
 
-export class DAOContext<MetadataType = never, OperationMetadataType = never, Permissions extends string = never, SecurityDomain extends object = never> extends AbstractDAOContext<never, never, types.Scalars, MetadataType>  {
+export class DAOContext<MetadataType = never, OperationMetadataType = never, Permissions extends string = never, SecurityDomain extends object = never> extends T.AbstractDAOContext<never, never, types.Scalars, MetadataType>  {
 
   private _address: AddressDAO<MetadataType, OperationMetadataType> | undefined
   private _audit: AuditDAO<MetadataType, OperationMetadataType> | undefined
@@ -1724,77 +1724,77 @@ export class DAOContext<MetadataType = never, OperationMetadataType = never, Per
   
   private middlewares: (DAOContextMiddleware<MetadataType, OperationMetadataType> | GroupMiddleware<any, MetadataType, OperationMetadataType>)[]
   
-  private logger?: LogFunction<'address' | 'audit' | 'city' | 'defaultFieldsEntity' | 'device' | 'dog' | 'hotel' | 'mockedEntity' | 'organization' | 'post' | 'postType' | 'user'>
+  private logger?: T.LogFunction<'address' | 'audit' | 'city' | 'defaultFieldsEntity' | 'device' | 'dog' | 'hotel' | 'mockedEntity' | 'organization' | 'post' | 'postType' | 'user'>
   
   get address(): AddressDAO<MetadataType, OperationMetadataType> {
     if(!this._address) {
-      this._address = new AddressDAO({ daoContext: this, datasource: null, metadata: this.metadata, ...this.overrides?.address, middlewares: [...(this.overrides?.address?.middlewares || []), ...selectMiddleware('address', this.middlewares) as DAOMiddleware<AddressDAOGenerics<MetadataType, OperationMetadataType>>[]], name: 'address', logger: this.logger })
+      this._address = new AddressDAO({ daoContext: this, datasource: null, metadata: this.metadata, ...this.overrides?.address, middlewares: [...(this.overrides?.address?.middlewares || []), ...selectMiddleware('address', this.middlewares) as T.DAOMiddleware<AddressDAOGenerics<MetadataType, OperationMetadataType>>[]], name: 'address', logger: this.logger })
     }
     return this._address
   }
   get audit(): AuditDAO<MetadataType, OperationMetadataType> {
     if(!this._audit) {
-      this._audit = new AuditDAO({ daoContext: this, datasource: null, metadata: this.metadata, ...this.overrides?.audit, middlewares: [...(this.overrides?.audit?.middlewares || []), ...selectMiddleware('audit', this.middlewares) as DAOMiddleware<AuditDAOGenerics<MetadataType, OperationMetadataType>>[]], name: 'audit', logger: this.logger })
+      this._audit = new AuditDAO({ daoContext: this, datasource: null, metadata: this.metadata, ...this.overrides?.audit, middlewares: [...(this.overrides?.audit?.middlewares || []), ...selectMiddleware('audit', this.middlewares) as T.DAOMiddleware<AuditDAOGenerics<MetadataType, OperationMetadataType>>[]], name: 'audit', logger: this.logger })
     }
     return this._audit
   }
   get city(): CityDAO<MetadataType, OperationMetadataType> {
     if(!this._city) {
-      this._city = new CityDAO({ daoContext: this, datasource: null, metadata: this.metadata, ...this.overrides?.city, middlewares: [...(this.overrides?.city?.middlewares || []), ...selectMiddleware('city', this.middlewares) as DAOMiddleware<CityDAOGenerics<MetadataType, OperationMetadataType>>[]], name: 'city', logger: this.logger })
+      this._city = new CityDAO({ daoContext: this, datasource: null, metadata: this.metadata, ...this.overrides?.city, middlewares: [...(this.overrides?.city?.middlewares || []), ...selectMiddleware('city', this.middlewares) as T.DAOMiddleware<CityDAOGenerics<MetadataType, OperationMetadataType>>[]], name: 'city', logger: this.logger })
     }
     return this._city
   }
   get defaultFieldsEntity(): DefaultFieldsEntityDAO<MetadataType, OperationMetadataType> {
     if(!this._defaultFieldsEntity) {
-      this._defaultFieldsEntity = new DefaultFieldsEntityDAO({ daoContext: this, datasource: null, metadata: this.metadata, ...this.overrides?.defaultFieldsEntity, middlewares: [...(this.overrides?.defaultFieldsEntity?.middlewares || []), ...selectMiddleware('defaultFieldsEntity', this.middlewares) as DAOMiddleware<DefaultFieldsEntityDAOGenerics<MetadataType, OperationMetadataType>>[]], name: 'defaultFieldsEntity', logger: this.logger })
+      this._defaultFieldsEntity = new DefaultFieldsEntityDAO({ daoContext: this, datasource: null, metadata: this.metadata, ...this.overrides?.defaultFieldsEntity, middlewares: [...(this.overrides?.defaultFieldsEntity?.middlewares || []), ...selectMiddleware('defaultFieldsEntity', this.middlewares) as T.DAOMiddleware<DefaultFieldsEntityDAOGenerics<MetadataType, OperationMetadataType>>[]], name: 'defaultFieldsEntity', logger: this.logger })
     }
     return this._defaultFieldsEntity
   }
   get device(): DeviceDAO<MetadataType, OperationMetadataType> {
     if(!this._device) {
-      this._device = new DeviceDAO({ daoContext: this, datasource: null, metadata: this.metadata, ...this.overrides?.device, middlewares: [...(this.overrides?.device?.middlewares || []), ...selectMiddleware('device', this.middlewares) as DAOMiddleware<DeviceDAOGenerics<MetadataType, OperationMetadataType>>[]], name: 'device', logger: this.logger })
+      this._device = new DeviceDAO({ daoContext: this, datasource: null, metadata: this.metadata, ...this.overrides?.device, middlewares: [...(this.overrides?.device?.middlewares || []), ...selectMiddleware('device', this.middlewares) as T.DAOMiddleware<DeviceDAOGenerics<MetadataType, OperationMetadataType>>[]], name: 'device', logger: this.logger })
     }
     return this._device
   }
   get dog(): DogDAO<MetadataType, OperationMetadataType> {
     if(!this._dog) {
-      this._dog = new DogDAO({ daoContext: this, datasource: null, metadata: this.metadata, ...this.overrides?.dog, middlewares: [...(this.overrides?.dog?.middlewares || []), ...selectMiddleware('dog', this.middlewares) as DAOMiddleware<DogDAOGenerics<MetadataType, OperationMetadataType>>[]], name: 'dog', logger: this.logger })
+      this._dog = new DogDAO({ daoContext: this, datasource: null, metadata: this.metadata, ...this.overrides?.dog, middlewares: [...(this.overrides?.dog?.middlewares || []), ...selectMiddleware('dog', this.middlewares) as T.DAOMiddleware<DogDAOGenerics<MetadataType, OperationMetadataType>>[]], name: 'dog', logger: this.logger })
     }
     return this._dog
   }
   get hotel(): HotelDAO<MetadataType, OperationMetadataType> {
     if(!this._hotel) {
-      this._hotel = new HotelDAO({ daoContext: this, datasource: null, metadata: this.metadata, ...this.overrides?.hotel, middlewares: [...(this.overrides?.hotel?.middlewares || []), ...selectMiddleware('hotel', this.middlewares) as DAOMiddleware<HotelDAOGenerics<MetadataType, OperationMetadataType>>[]], name: 'hotel', logger: this.logger })
+      this._hotel = new HotelDAO({ daoContext: this, datasource: null, metadata: this.metadata, ...this.overrides?.hotel, middlewares: [...(this.overrides?.hotel?.middlewares || []), ...selectMiddleware('hotel', this.middlewares) as T.DAOMiddleware<HotelDAOGenerics<MetadataType, OperationMetadataType>>[]], name: 'hotel', logger: this.logger })
     }
     return this._hotel
   }
   get mockedEntity(): MockedEntityDAO<MetadataType, OperationMetadataType> {
     if(!this._mockedEntity) {
-      this._mockedEntity = new MockedEntityDAO({ daoContext: this, datasource: null, metadata: this.metadata, ...this.overrides?.mockedEntity, middlewares: [...(this.overrides?.mockedEntity?.middlewares || []), ...selectMiddleware('mockedEntity', this.middlewares) as DAOMiddleware<MockedEntityDAOGenerics<MetadataType, OperationMetadataType>>[]], name: 'mockedEntity', logger: this.logger })
+      this._mockedEntity = new MockedEntityDAO({ daoContext: this, datasource: null, metadata: this.metadata, ...this.overrides?.mockedEntity, middlewares: [...(this.overrides?.mockedEntity?.middlewares || []), ...selectMiddleware('mockedEntity', this.middlewares) as T.DAOMiddleware<MockedEntityDAOGenerics<MetadataType, OperationMetadataType>>[]], name: 'mockedEntity', logger: this.logger })
     }
     return this._mockedEntity
   }
   get organization(): OrganizationDAO<MetadataType, OperationMetadataType> {
     if(!this._organization) {
-      this._organization = new OrganizationDAO({ daoContext: this, datasource: null, metadata: this.metadata, ...this.overrides?.organization, middlewares: [...(this.overrides?.organization?.middlewares || []), ...selectMiddleware('organization', this.middlewares) as DAOMiddleware<OrganizationDAOGenerics<MetadataType, OperationMetadataType>>[]], name: 'organization', logger: this.logger })
+      this._organization = new OrganizationDAO({ daoContext: this, datasource: null, metadata: this.metadata, ...this.overrides?.organization, middlewares: [...(this.overrides?.organization?.middlewares || []), ...selectMiddleware('organization', this.middlewares) as T.DAOMiddleware<OrganizationDAOGenerics<MetadataType, OperationMetadataType>>[]], name: 'organization', logger: this.logger })
     }
     return this._organization
   }
   get post(): PostDAO<MetadataType, OperationMetadataType> {
     if(!this._post) {
-      this._post = new PostDAO({ daoContext: this, datasource: null, metadata: this.metadata, ...this.overrides?.post, middlewares: [...(this.overrides?.post?.middlewares || []), ...selectMiddleware('post', this.middlewares) as DAOMiddleware<PostDAOGenerics<MetadataType, OperationMetadataType>>[]], name: 'post', logger: this.logger })
+      this._post = new PostDAO({ daoContext: this, datasource: null, metadata: this.metadata, ...this.overrides?.post, middlewares: [...(this.overrides?.post?.middlewares || []), ...selectMiddleware('post', this.middlewares) as T.DAOMiddleware<PostDAOGenerics<MetadataType, OperationMetadataType>>[]], name: 'post', logger: this.logger })
     }
     return this._post
   }
   get postType(): PostTypeDAO<MetadataType, OperationMetadataType> {
     if(!this._postType) {
-      this._postType = new PostTypeDAO({ daoContext: this, datasource: null, metadata: this.metadata, ...this.overrides?.postType, middlewares: [...(this.overrides?.postType?.middlewares || []), ...selectMiddleware('postType', this.middlewares) as DAOMiddleware<PostTypeDAOGenerics<MetadataType, OperationMetadataType>>[]], name: 'postType', logger: this.logger })
+      this._postType = new PostTypeDAO({ daoContext: this, datasource: null, metadata: this.metadata, ...this.overrides?.postType, middlewares: [...(this.overrides?.postType?.middlewares || []), ...selectMiddleware('postType', this.middlewares) as T.DAOMiddleware<PostTypeDAOGenerics<MetadataType, OperationMetadataType>>[]], name: 'postType', logger: this.logger })
     }
     return this._postType
   }
   get user(): UserDAO<MetadataType, OperationMetadataType> {
     if(!this._user) {
-      this._user = new UserDAO({ daoContext: this, datasource: null, metadata: this.metadata, ...this.overrides?.user, middlewares: [...(this.overrides?.user?.middlewares || []), ...selectMiddleware('user', this.middlewares) as DAOMiddleware<UserDAOGenerics<MetadataType, OperationMetadataType>>[]], name: 'user', logger: this.logger })
+      this._user = new UserDAO({ daoContext: this, datasource: null, metadata: this.metadata, ...this.overrides?.user, middlewares: [...(this.overrides?.user?.middlewares || []), ...selectMiddleware('user', this.middlewares) as T.DAOMiddleware<UserDAOGenerics<MetadataType, OperationMetadataType>>[]], name: 'user', logger: this.logger })
     }
     return this._user
   }
@@ -1802,13 +1802,13 @@ export class DAOContext<MetadataType = never, OperationMetadataType = never, Per
   constructor(params: DAOContextParams<MetadataType, OperationMetadataType, Permissions, SecurityDomain>) {
     super({
       ...params,
-      scalars: params.scalars ? userInputDataTypeAdapterToDataTypeAdapter(params.scalars, ['Coordinates', 'Decimal', 'JSON', 'Live', 'LocalizedString', 'Password', 'ID', 'String', 'Boolean', 'Int', 'Float']) : undefined
+      scalars: params.scalars ? T.userInputDataTypeAdapterToDataTypeAdapter(params.scalars, ['Coordinates', 'Decimal', 'JSON', 'Live', 'LocalizedString', 'Password', 'ID', 'String', 'Boolean', 'Int', 'Float']) : undefined
     })
     this.overrides = params.overrides
     this.middlewares = params.middlewares || []
-    this.logger = logInputToLogger(params.log)
+    this.logger = T.logInputToLogger(params.log)
     if(params.security && params.security.applySecurity !== false) {
-      const securityMiddlewares = createSecurityPolicyMiddlewares(params.security)
+      const securityMiddlewares = T.createSecurityPolicyMiddlewares(params.security)
       const defaultMiddleware = securityMiddlewares.others ? [groupMiddleware.excludes(Object.fromEntries(Object.keys(securityMiddlewares.middlewares).map(k => [k, true])) as any, securityMiddlewares.others as any)] : []
       this.middlewares = [...(params.middlewares ?? []), ...defaultMiddleware, ...Object.entries(securityMiddlewares.middlewares).map(([name, middleware]) => groupMiddleware.includes({[name]: true} as any, middleware as any))]
     }
@@ -1853,16 +1853,16 @@ type GroupMiddleware<N extends DAOName, MetadataType, OperationMetadataType> =
   | ExcludeGroupMiddleware<N, MetadataType, OperationMetadataType>
 type IncludeGroupMiddleware<N extends DAOName, MetadataType, OperationMetadataType> = {
   include: { [K in N]: true }
-  middleware: DAOMiddleware<DAOGenericsMap<MetadataType, OperationMetadataType>[N]>
+  middleware: T.DAOMiddleware<DAOGenericsMap<MetadataType, OperationMetadataType>[N]>
 }
 type ExcludeGroupMiddleware<N extends DAOName, MetadataType, OperationMetadataType> = {
   exclude: { [K in N]: true }
-  middleware: DAOMiddleware<DAOGenericsMap<MetadataType, OperationMetadataType>[Exclude<DAOName, N>]>
+  middleware: T.DAOMiddleware<DAOGenericsMap<MetadataType, OperationMetadataType>[Exclude<DAOName, N>]>
 }
 export const groupMiddleware = {
   includes<N extends DAOName, MetadataType, OperationMetadataType>(
     include: { [K in N]: true },
-    middleware: DAOMiddleware<DAOGenericsMap<MetadataType, OperationMetadataType>[N]>,
+    middleware: T.DAOMiddleware<DAOGenericsMap<MetadataType, OperationMetadataType>[N]>,
   ): IncludeGroupMiddleware<N, MetadataType, OperationMetadataType> {
     return { include, middleware }
   },

--- a/tests/mongodb/dao.mock.ts
+++ b/tests/mongodb/dao.mock.ts
@@ -1,7 +1,6 @@
-import { DAOMiddleware, Coordinates, UserInputDriverDataTypeAdapterMap, Schema, AbstractDAOContext, LogicalOperators, QuantityOperators, EqualityOperators, StringOperators, ElementOperators, OneKey, SortDirection, overrideRelations, userInputDataTypeAdapterToDataTypeAdapter, LogFunction, LogInput, logInputToLogger, ParamProjection, DAOGenerics, CRUDPermission, DAOContextSecurtyPolicy, createSecurityPolicyMiddlewares, SelectProjection, mergeProjections, AbstractInMemoryDAO, InMemoryDAOGenerics, InMemoryDAOParams } from '../../src'
+import * as T from '../../src'
 import * as types from './models.mock'
-import { MongoDBDAOGenerics, MongoDBDAOParams, AbstractMongoDBDAO } from '../../src'
-import { Collection, Db, Filter, Sort, UpdateFilter, Document } from 'mongodb'
+import * as M from 'mongodb'
 
 //--------------------------------------------------------------------------------
 //----------------------------------- ADDRESS ------------------------------------
@@ -10,7 +9,7 @@ import { Collection, Db, Filter, Sort, UpdateFilter, Document } from 'mongodb'
 export type AddressExcludedFields = never
 export type AddressRelationFields = 'cities'
 
-export function addressSchema(): Schema<types.Scalars> {
+export function addressSchema(): T.Schema<types.Scalars> {
   return {
     'id': {
       scalar: 'ID', 
@@ -20,10 +19,10 @@ export function addressSchema(): Schema<types.Scalars> {
 }
 
 type AddressFilterFields = {
-  'id'?: types.Scalars['ID'] | null | EqualityOperators<types.Scalars['ID']> | ElementOperators
+  'id'?: types.Scalars['ID'] | null | T.EqualityOperators<types.Scalars['ID']> | T.ElementOperators
 }
-export type AddressFilter = AddressFilterFields & LogicalOperators<AddressFilterFields | AddressRawFilter>
-export type AddressRawFilter = () => Filter<Document>
+export type AddressFilter = AddressFilterFields & T.LogicalOperators<AddressFilterFields | AddressRawFilter>
+export type AddressRawFilter = () => M.Filter<M.Document>
 
 export type AddressRelations = {
   cities?: {
@@ -39,32 +38,32 @@ export type AddressProjection = {
   cities?: CityProjection | boolean,
   id?: boolean,
 }
-export type AddressParam<P extends AddressProjection> = ParamProjection<types.Address, AddressProjection, P>
+export type AddressParam<P extends AddressProjection> = T.ParamProjection<types.Address, AddressProjection, P>
 
 export type AddressSortKeys = 'id'
-export type AddressSort = OneKey<AddressSortKeys, SortDirection>
-export type AddressRawSort = () => Sort
+export type AddressSort = T.OneKey<AddressSortKeys, T.SortDirection>
+export type AddressRawSort = () => M.Sort
 
 export type AddressUpdate = {
   'id'?: types.Scalars['ID']
 }
-export type AddressRawUpdate = () => UpdateFilter<Document>
+export type AddressRawUpdate = () => M.UpdateFilter<M.Document>
 
 export type AddressInsert = {
   id?: null | types.Scalars['ID'],
 }
 
-type AddressDAOGenerics<MetadataType, OperationMetadataType> = MongoDBDAOGenerics<types.Address, 'id', 'ID', AddressFilter, AddressRawFilter, AddressRelations, AddressProjection, AddressSort, AddressRawSort, AddressInsert, AddressUpdate, AddressRawUpdate, AddressExcludedFields, AddressRelationFields, MetadataType, OperationMetadataType, types.Scalars, 'address', DAOContext<MetadataType, OperationMetadataType>>
-export type AddressDAOParams<MetadataType, OperationMetadataType> = Omit<MongoDBDAOParams<AddressDAOGenerics<MetadataType, OperationMetadataType>>, 'idField' | 'schema' | 'idScalar' | 'idGeneration'>
-export type InMemoryAddressDAOParams<MetadataType, OperationMetadataType> = Omit<InMemoryDAOParams<AddressDAOGenerics<MetadataType, OperationMetadataType>>, 'idField' | 'schema' | 'idScalar' | 'idGeneration'>
+type AddressDAOGenerics<MetadataType, OperationMetadataType> = T.MongoDBDAOGenerics<types.Address, 'id', 'ID', AddressFilter, AddressRawFilter, AddressRelations, AddressProjection, AddressSort, AddressRawSort, AddressInsert, AddressUpdate, AddressRawUpdate, AddressExcludedFields, AddressRelationFields, MetadataType, OperationMetadataType, types.Scalars, 'address', DAOContext<MetadataType, OperationMetadataType>>
+export type AddressDAOParams<MetadataType, OperationMetadataType> = Omit<T.MongoDBDAOParams<AddressDAOGenerics<MetadataType, OperationMetadataType>>, 'idField' | 'schema' | 'idScalar' | 'idGeneration'>
+export type InMemoryAddressDAOParams<MetadataType, OperationMetadataType> = Omit<T.InMemoryDAOParams<AddressDAOGenerics<MetadataType, OperationMetadataType>>, 'idField' | 'schema' | 'idScalar' | 'idGeneration'>
 
-export class AddressDAO<MetadataType, OperationMetadataType> extends AbstractMongoDBDAO<AddressDAOGenerics<MetadataType, OperationMetadataType>> {  
+export class AddressDAO<MetadataType, OperationMetadataType> extends T.AbstractMongoDBDAO<AddressDAOGenerics<MetadataType, OperationMetadataType>> {  
   
   public static projection<P extends AddressProjection>(p: P) {
     return p
   }
-  public static mergeProjection<P1 extends AddressProjection, P2 extends AddressProjection>(p1: P1, p2: P2): SelectProjection<AddressProjection, P1, P2> {
-    return mergeProjections(p1, p2) as SelectProjection<AddressProjection, P1, P2>
+  public static mergeProjection<P1 extends AddressProjection, P2 extends AddressProjection>(p1: P1, p2: P2): T.SelectProjection<AddressProjection, P1, P2> {
+    return T.mergeProjections(p1, p2) as T.SelectProjection<AddressProjection, P1, P2>
   }
   
   public constructor(params: AddressDAOParams<MetadataType, OperationMetadataType>){
@@ -72,7 +71,7 @@ export class AddressDAO<MetadataType, OperationMetadataType> extends AbstractMon
       ...params, 
       idField: 'id', 
       schema: addressSchema(), 
-      relations: overrideRelations(
+      relations: T.overrideRelations(
         [
           { type: '1-n', reference: 'foreign', field: 'cities', refFrom: 'addressId', refTo: 'id', dao: 'city', required: false }
         ]
@@ -83,13 +82,13 @@ export class AddressDAO<MetadataType, OperationMetadataType> extends AbstractMon
   }
   }
 
-export class InMemoryAddressDAO<MetadataType, OperationMetadataType> extends AbstractInMemoryDAO<AddressDAOGenerics<MetadataType, OperationMetadataType>> {  
+export class InMemoryAddressDAO<MetadataType, OperationMetadataType> extends T.AbstractInMemoryDAO<AddressDAOGenerics<MetadataType, OperationMetadataType>> {  
   
   public static projection<P extends AddressProjection>(p: P) {
     return p
   }
-  public static mergeProjection<P1 extends AddressProjection, P2 extends AddressProjection>(p1: P1, p2: P2): SelectProjection<AddressProjection, P1, P2> {
-    return mergeProjections(p1, p2) as SelectProjection<AddressProjection, P1, P2>
+  public static mergeProjection<P1 extends AddressProjection, P2 extends AddressProjection>(p1: P1, p2: P2): T.SelectProjection<AddressProjection, P1, P2> {
+    return T.mergeProjections(p1, p2) as T.SelectProjection<AddressProjection, P1, P2>
   }
   
   public constructor(params: InMemoryAddressDAOParams<MetadataType, OperationMetadataType>){
@@ -97,7 +96,7 @@ export class InMemoryAddressDAO<MetadataType, OperationMetadataType> extends Abs
       ...params, 
       idField: 'id', 
       schema: addressSchema(), 
-      relations: overrideRelations(
+      relations: T.overrideRelations(
         [
           { type: '1-n', reference: 'foreign', field: 'cities', refFrom: 'addressId', refTo: 'id', dao: 'city', required: false }
         ]
@@ -117,7 +116,7 @@ export class InMemoryAddressDAO<MetadataType, OperationMetadataType> extends Abs
 export type AuditExcludedFields = never
 export type AuditRelationFields = never
 
-export function auditSchema(): Schema<types.Scalars> {
+export function auditSchema(): T.Schema<types.Scalars> {
   return {
     'changes': {
       scalar: 'String'
@@ -135,12 +134,12 @@ export function auditSchema(): Schema<types.Scalars> {
 }
 
 type AuditFilterFields = {
-  'changes'?: types.Scalars['String'] | null | EqualityOperators<types.Scalars['String']> | ElementOperators | StringOperators,
-  'entityId'?: types.Scalars['ID'] | null | EqualityOperators<types.Scalars['ID']> | ElementOperators,
-  'id'?: types.Scalars['ID'] | null | EqualityOperators<types.Scalars['ID']> | ElementOperators
+  'changes'?: types.Scalars['String'] | null | T.EqualityOperators<types.Scalars['String']> | T.ElementOperators | T.StringOperators,
+  'entityId'?: types.Scalars['ID'] | null | T.EqualityOperators<types.Scalars['ID']> | T.ElementOperators,
+  'id'?: types.Scalars['ID'] | null | T.EqualityOperators<types.Scalars['ID']> | T.ElementOperators
 }
-export type AuditFilter = AuditFilterFields & LogicalOperators<AuditFilterFields | AuditRawFilter>
-export type AuditRawFilter = () => Filter<Document>
+export type AuditFilter = AuditFilterFields & T.LogicalOperators<AuditFilterFields | AuditRawFilter>
+export type AuditRawFilter = () => M.Filter<M.Document>
 
 export type AuditRelations = Record<never, string>
 
@@ -149,35 +148,35 @@ export type AuditProjection = {
   entityId?: boolean,
   id?: boolean,
 }
-export type AuditParam<P extends AuditProjection> = ParamProjection<types.Audit, AuditProjection, P>
+export type AuditParam<P extends AuditProjection> = T.ParamProjection<types.Audit, AuditProjection, P>
 
 export type AuditSortKeys = 'changes' | 'entityId' | 'id'
-export type AuditSort = OneKey<AuditSortKeys, SortDirection>
-export type AuditRawSort = () => Sort
+export type AuditSort = T.OneKey<AuditSortKeys, T.SortDirection>
+export type AuditRawSort = () => M.Sort
 
 export type AuditUpdate = {
   'changes'?: types.Scalars['String'] | null,
   'entityId'?: types.Scalars['ID'],
   'id'?: types.Scalars['ID']
 }
-export type AuditRawUpdate = () => UpdateFilter<Document>
+export type AuditRawUpdate = () => M.UpdateFilter<M.Document>
 
 export type AuditInsert = {
   changes?: null | types.Scalars['String'],
   entityId: types.Scalars['ID'],
 }
 
-type AuditDAOGenerics<MetadataType, OperationMetadataType> = MongoDBDAOGenerics<types.Audit, 'id', 'ID', AuditFilter, AuditRawFilter, AuditRelations, AuditProjection, AuditSort, AuditRawSort, AuditInsert, AuditUpdate, AuditRawUpdate, AuditExcludedFields, AuditRelationFields, MetadataType, OperationMetadataType, types.Scalars, 'audit', DAOContext<MetadataType, OperationMetadataType>>
-export type AuditDAOParams<MetadataType, OperationMetadataType> = Omit<MongoDBDAOParams<AuditDAOGenerics<MetadataType, OperationMetadataType>>, 'idGenerator' | 'idField' | 'schema' | 'idScalar' | 'idGeneration'>
-export type InMemoryAuditDAOParams<MetadataType, OperationMetadataType> = Omit<InMemoryDAOParams<AuditDAOGenerics<MetadataType, OperationMetadataType>>, 'idGenerator' | 'idField' | 'schema' | 'idScalar' | 'idGeneration'>
+type AuditDAOGenerics<MetadataType, OperationMetadataType> = T.MongoDBDAOGenerics<types.Audit, 'id', 'ID', AuditFilter, AuditRawFilter, AuditRelations, AuditProjection, AuditSort, AuditRawSort, AuditInsert, AuditUpdate, AuditRawUpdate, AuditExcludedFields, AuditRelationFields, MetadataType, OperationMetadataType, types.Scalars, 'audit', DAOContext<MetadataType, OperationMetadataType>>
+export type AuditDAOParams<MetadataType, OperationMetadataType> = Omit<T.MongoDBDAOParams<AuditDAOGenerics<MetadataType, OperationMetadataType>>, 'idGenerator' | 'idField' | 'schema' | 'idScalar' | 'idGeneration'>
+export type InMemoryAuditDAOParams<MetadataType, OperationMetadataType> = Omit<T.InMemoryDAOParams<AuditDAOGenerics<MetadataType, OperationMetadataType>>, 'idGenerator' | 'idField' | 'schema' | 'idScalar' | 'idGeneration'>
 
-export class AuditDAO<MetadataType, OperationMetadataType> extends AbstractMongoDBDAO<AuditDAOGenerics<MetadataType, OperationMetadataType>> {  
+export class AuditDAO<MetadataType, OperationMetadataType> extends T.AbstractMongoDBDAO<AuditDAOGenerics<MetadataType, OperationMetadataType>> {  
   
   public static projection<P extends AuditProjection>(p: P) {
     return p
   }
-  public static mergeProjection<P1 extends AuditProjection, P2 extends AuditProjection>(p1: P1, p2: P2): SelectProjection<AuditProjection, P1, P2> {
-    return mergeProjections(p1, p2) as SelectProjection<AuditProjection, P1, P2>
+  public static mergeProjection<P1 extends AuditProjection, P2 extends AuditProjection>(p1: P1, p2: P2): T.SelectProjection<AuditProjection, P1, P2> {
+    return T.mergeProjections(p1, p2) as T.SelectProjection<AuditProjection, P1, P2>
   }
   
   public constructor(params: AuditDAOParams<MetadataType, OperationMetadataType>){
@@ -185,7 +184,7 @@ export class AuditDAO<MetadataType, OperationMetadataType> extends AbstractMongo
       ...params, 
       idField: 'id', 
       schema: auditSchema(), 
-      relations: overrideRelations(
+      relations: T.overrideRelations(
         [
           
         ]
@@ -196,13 +195,13 @@ export class AuditDAO<MetadataType, OperationMetadataType> extends AbstractMongo
   }
   }
 
-export class InMemoryAuditDAO<MetadataType, OperationMetadataType> extends AbstractInMemoryDAO<AuditDAOGenerics<MetadataType, OperationMetadataType>> {  
+export class InMemoryAuditDAO<MetadataType, OperationMetadataType> extends T.AbstractInMemoryDAO<AuditDAOGenerics<MetadataType, OperationMetadataType>> {  
   
   public static projection<P extends AuditProjection>(p: P) {
     return p
   }
-  public static mergeProjection<P1 extends AuditProjection, P2 extends AuditProjection>(p1: P1, p2: P2): SelectProjection<AuditProjection, P1, P2> {
-    return mergeProjections(p1, p2) as SelectProjection<AuditProjection, P1, P2>
+  public static mergeProjection<P1 extends AuditProjection, P2 extends AuditProjection>(p1: P1, p2: P2): T.SelectProjection<AuditProjection, P1, P2> {
+    return T.mergeProjections(p1, p2) as T.SelectProjection<AuditProjection, P1, P2>
   }
   
   public constructor(params: InMemoryAuditDAOParams<MetadataType, OperationMetadataType>){
@@ -210,7 +209,7 @@ export class InMemoryAuditDAO<MetadataType, OperationMetadataType> extends Abstr
       ...params, 
       idField: 'id', 
       schema: auditSchema(), 
-      relations: overrideRelations(
+      relations: T.overrideRelations(
         [
           
         ]
@@ -227,7 +226,7 @@ export class InMemoryAuditDAO<MetadataType, OperationMetadataType> extends Abstr
 //---------------------------------- AUDITABLE -----------------------------------
 //--------------------------------------------------------------------------------
 
-export function auditableSchema(): Schema<types.Scalars> {
+export function auditableSchema(): T.Schema<types.Scalars> {
   return {
     'createdBy': {
       scalar: 'String', 
@@ -264,7 +263,7 @@ export type AuditableProjection = {
   state?: boolean,
   versions?: AuditProjection | boolean,
 }
-export type AuditableParam<P extends AuditableProjection> = ParamProjection<types.Auditable, AuditableProjection, P>
+export type AuditableParam<P extends AuditableProjection> = T.ParamProjection<types.Auditable, AuditableProjection, P>
 
 export type AuditableInsert = {
   createdBy: types.Scalars['String'],
@@ -284,7 +283,7 @@ export type AuditableInsert = {
 export type CityExcludedFields = 'computedAddressName' | 'computedName'
 export type CityRelationFields = never
 
-export function citySchema(): Schema<types.Scalars> {
+export function citySchema(): T.Schema<types.Scalars> {
   return {
     'addressId': {
       scalar: 'ID', 
@@ -302,12 +301,12 @@ export function citySchema(): Schema<types.Scalars> {
 }
 
 type CityFilterFields = {
-  'addressId'?: types.Scalars['ID'] | null | EqualityOperators<types.Scalars['ID']> | ElementOperators,
-  'id'?: types.Scalars['ID'] | null | EqualityOperators<types.Scalars['ID']> | ElementOperators,
-  'name'?: types.Scalars['String'] | null | EqualityOperators<types.Scalars['String']> | ElementOperators | StringOperators
+  'addressId'?: types.Scalars['ID'] | null | T.EqualityOperators<types.Scalars['ID']> | T.ElementOperators,
+  'id'?: types.Scalars['ID'] | null | T.EqualityOperators<types.Scalars['ID']> | T.ElementOperators,
+  'name'?: types.Scalars['String'] | null | T.EqualityOperators<types.Scalars['String']> | T.ElementOperators | T.StringOperators
 }
-export type CityFilter = CityFilterFields & LogicalOperators<CityFilterFields | CityRawFilter>
-export type CityRawFilter = () => Filter<Document>
+export type CityFilter = CityFilterFields & T.LogicalOperators<CityFilterFields | CityRawFilter>
+export type CityRawFilter = () => M.Filter<M.Document>
 
 export type CityRelations = Record<never, string>
 
@@ -318,18 +317,18 @@ export type CityProjection = {
   id?: boolean,
   name?: boolean,
 }
-export type CityParam<P extends CityProjection> = ParamProjection<types.City, CityProjection, P>
+export type CityParam<P extends CityProjection> = T.ParamProjection<types.City, CityProjection, P>
 
 export type CitySortKeys = 'addressId' | 'id' | 'name'
-export type CitySort = OneKey<CitySortKeys, SortDirection>
-export type CityRawSort = () => Sort
+export type CitySort = T.OneKey<CitySortKeys, T.SortDirection>
+export type CityRawSort = () => M.Sort
 
 export type CityUpdate = {
   'addressId'?: types.Scalars['ID'],
   'id'?: types.Scalars['ID'],
   'name'?: types.Scalars['String']
 }
-export type CityRawUpdate = () => UpdateFilter<Document>
+export type CityRawUpdate = () => M.UpdateFilter<M.Document>
 
 export type CityInsert = {
   addressId: types.Scalars['ID'],
@@ -337,17 +336,17 @@ export type CityInsert = {
   name: types.Scalars['String'],
 }
 
-type CityDAOGenerics<MetadataType, OperationMetadataType> = MongoDBDAOGenerics<types.City, 'id', 'ID', CityFilter, CityRawFilter, CityRelations, CityProjection, CitySort, CityRawSort, CityInsert, CityUpdate, CityRawUpdate, CityExcludedFields, CityRelationFields, MetadataType, OperationMetadataType, types.Scalars, 'city', DAOContext<MetadataType, OperationMetadataType>>
-export type CityDAOParams<MetadataType, OperationMetadataType> = Omit<MongoDBDAOParams<CityDAOGenerics<MetadataType, OperationMetadataType>>, 'idField' | 'schema' | 'idScalar' | 'idGeneration'>
-export type InMemoryCityDAOParams<MetadataType, OperationMetadataType> = Omit<InMemoryDAOParams<CityDAOGenerics<MetadataType, OperationMetadataType>>, 'idField' | 'schema' | 'idScalar' | 'idGeneration'>
+type CityDAOGenerics<MetadataType, OperationMetadataType> = T.MongoDBDAOGenerics<types.City, 'id', 'ID', CityFilter, CityRawFilter, CityRelations, CityProjection, CitySort, CityRawSort, CityInsert, CityUpdate, CityRawUpdate, CityExcludedFields, CityRelationFields, MetadataType, OperationMetadataType, types.Scalars, 'city', DAOContext<MetadataType, OperationMetadataType>>
+export type CityDAOParams<MetadataType, OperationMetadataType> = Omit<T.MongoDBDAOParams<CityDAOGenerics<MetadataType, OperationMetadataType>>, 'idField' | 'schema' | 'idScalar' | 'idGeneration'>
+export type InMemoryCityDAOParams<MetadataType, OperationMetadataType> = Omit<T.InMemoryDAOParams<CityDAOGenerics<MetadataType, OperationMetadataType>>, 'idField' | 'schema' | 'idScalar' | 'idGeneration'>
 
-export class CityDAO<MetadataType, OperationMetadataType> extends AbstractMongoDBDAO<CityDAOGenerics<MetadataType, OperationMetadataType>> {  
+export class CityDAO<MetadataType, OperationMetadataType> extends T.AbstractMongoDBDAO<CityDAOGenerics<MetadataType, OperationMetadataType>> {  
   
   public static projection<P extends CityProjection>(p: P) {
     return p
   }
-  public static mergeProjection<P1 extends CityProjection, P2 extends CityProjection>(p1: P1, p2: P2): SelectProjection<CityProjection, P1, P2> {
-    return mergeProjections(p1, p2) as SelectProjection<CityProjection, P1, P2>
+  public static mergeProjection<P1 extends CityProjection, P2 extends CityProjection>(p1: P1, p2: P2): T.SelectProjection<CityProjection, P1, P2> {
+    return T.mergeProjections(p1, p2) as T.SelectProjection<CityProjection, P1, P2>
   }
   
   public constructor(params: CityDAOParams<MetadataType, OperationMetadataType>){
@@ -355,7 +354,7 @@ export class CityDAO<MetadataType, OperationMetadataType> extends AbstractMongoD
       ...params, 
       idField: 'id', 
       schema: citySchema(), 
-      relations: overrideRelations(
+      relations: T.overrideRelations(
         [
           
         ]
@@ -366,13 +365,13 @@ export class CityDAO<MetadataType, OperationMetadataType> extends AbstractMongoD
   }
   }
 
-export class InMemoryCityDAO<MetadataType, OperationMetadataType> extends AbstractInMemoryDAO<CityDAOGenerics<MetadataType, OperationMetadataType>> {  
+export class InMemoryCityDAO<MetadataType, OperationMetadataType> extends T.AbstractInMemoryDAO<CityDAOGenerics<MetadataType, OperationMetadataType>> {  
   
   public static projection<P extends CityProjection>(p: P) {
     return p
   }
-  public static mergeProjection<P1 extends CityProjection, P2 extends CityProjection>(p1: P1, p2: P2): SelectProjection<CityProjection, P1, P2> {
-    return mergeProjections(p1, p2) as SelectProjection<CityProjection, P1, P2>
+  public static mergeProjection<P1 extends CityProjection, P2 extends CityProjection>(p1: P1, p2: P2): T.SelectProjection<CityProjection, P1, P2> {
+    return T.mergeProjections(p1, p2) as T.SelectProjection<CityProjection, P1, P2>
   }
   
   public constructor(params: InMemoryCityDAOParams<MetadataType, OperationMetadataType>){
@@ -380,7 +379,7 @@ export class InMemoryCityDAO<MetadataType, OperationMetadataType> extends Abstra
       ...params, 
       idField: 'id', 
       schema: citySchema(), 
-      relations: overrideRelations(
+      relations: T.overrideRelations(
         [
           
         ]
@@ -400,7 +399,7 @@ export class InMemoryCityDAO<MetadataType, OperationMetadataType> extends Abstra
 export type DefaultFieldsEntityExcludedFields = never
 export type DefaultFieldsEntityRelationFields = never
 
-export function defaultFieldsEntitySchema(): Schema<types.Scalars> {
+export function defaultFieldsEntitySchema(): T.Schema<types.Scalars> {
   return {
     'creationDate': {
       scalar: 'Int', 
@@ -432,15 +431,15 @@ export function defaultFieldsEntitySchema(): Schema<types.Scalars> {
 }
 
 type DefaultFieldsEntityFilterFields = {
-  'creationDate'?: types.Scalars['Int'] | null | EqualityOperators<types.Scalars['Int']> | ElementOperators | QuantityOperators<types.Scalars['Int']>,
-  'id'?: types.Scalars['ID'] | null | EqualityOperators<types.Scalars['ID']> | ElementOperators,
-  'live'?: types.Scalars['Live'] | null | EqualityOperators<types.Scalars['Live']> | ElementOperators,
-  'name'?: types.Scalars['String'] | null | EqualityOperators<types.Scalars['String']> | ElementOperators | StringOperators,
-  'opt1'?: types.Scalars['Live'] | null | EqualityOperators<types.Scalars['Live']> | ElementOperators,
-  'opt2'?: types.Scalars['Live'] | null | EqualityOperators<types.Scalars['Live']> | ElementOperators
+  'creationDate'?: types.Scalars['Int'] | null | T.EqualityOperators<types.Scalars['Int']> | T.ElementOperators | T.QuantityOperators<types.Scalars['Int']>,
+  'id'?: types.Scalars['ID'] | null | T.EqualityOperators<types.Scalars['ID']> | T.ElementOperators,
+  'live'?: types.Scalars['Live'] | null | T.EqualityOperators<types.Scalars['Live']> | T.ElementOperators,
+  'name'?: types.Scalars['String'] | null | T.EqualityOperators<types.Scalars['String']> | T.ElementOperators | T.StringOperators,
+  'opt1'?: types.Scalars['Live'] | null | T.EqualityOperators<types.Scalars['Live']> | T.ElementOperators,
+  'opt2'?: types.Scalars['Live'] | null | T.EqualityOperators<types.Scalars['Live']> | T.ElementOperators
 }
-export type DefaultFieldsEntityFilter = DefaultFieldsEntityFilterFields & LogicalOperators<DefaultFieldsEntityFilterFields | DefaultFieldsEntityRawFilter>
-export type DefaultFieldsEntityRawFilter = () => Filter<Document>
+export type DefaultFieldsEntityFilter = DefaultFieldsEntityFilterFields & T.LogicalOperators<DefaultFieldsEntityFilterFields | DefaultFieldsEntityRawFilter>
+export type DefaultFieldsEntityRawFilter = () => M.Filter<M.Document>
 
 export type DefaultFieldsEntityRelations = Record<never, string>
 
@@ -452,11 +451,11 @@ export type DefaultFieldsEntityProjection = {
   opt1?: boolean,
   opt2?: boolean,
 }
-export type DefaultFieldsEntityParam<P extends DefaultFieldsEntityProjection> = ParamProjection<types.DefaultFieldsEntity, DefaultFieldsEntityProjection, P>
+export type DefaultFieldsEntityParam<P extends DefaultFieldsEntityProjection> = T.ParamProjection<types.DefaultFieldsEntity, DefaultFieldsEntityProjection, P>
 
 export type DefaultFieldsEntitySortKeys = 'creationDate' | 'id' | 'live' | 'name' | 'opt1' | 'opt2'
-export type DefaultFieldsEntitySort = OneKey<DefaultFieldsEntitySortKeys, SortDirection>
-export type DefaultFieldsEntityRawSort = () => Sort
+export type DefaultFieldsEntitySort = T.OneKey<DefaultFieldsEntitySortKeys, T.SortDirection>
+export type DefaultFieldsEntityRawSort = () => M.Sort
 
 export type DefaultFieldsEntityUpdate = {
   'creationDate'?: types.Scalars['Int'],
@@ -466,7 +465,7 @@ export type DefaultFieldsEntityUpdate = {
   'opt1'?: types.Scalars['Live'] | null,
   'opt2'?: types.Scalars['Live'] | null
 }
-export type DefaultFieldsEntityRawUpdate = () => UpdateFilter<Document>
+export type DefaultFieldsEntityRawUpdate = () => M.UpdateFilter<M.Document>
 
 export type DefaultFieldsEntityInsert = {
   creationDate?: null | types.Scalars['Int'],
@@ -477,17 +476,17 @@ export type DefaultFieldsEntityInsert = {
   opt2?: null | types.Scalars['Live'],
 }
 
-type DefaultFieldsEntityDAOGenerics<MetadataType, OperationMetadataType> = MongoDBDAOGenerics<types.DefaultFieldsEntity, 'id', 'ID', DefaultFieldsEntityFilter, DefaultFieldsEntityRawFilter, DefaultFieldsEntityRelations, DefaultFieldsEntityProjection, DefaultFieldsEntitySort, DefaultFieldsEntityRawSort, DefaultFieldsEntityInsert, DefaultFieldsEntityUpdate, DefaultFieldsEntityRawUpdate, DefaultFieldsEntityExcludedFields, DefaultFieldsEntityRelationFields, MetadataType, OperationMetadataType, types.Scalars, 'defaultFieldsEntity', DAOContext<MetadataType, OperationMetadataType>>
-export type DefaultFieldsEntityDAOParams<MetadataType, OperationMetadataType> = Omit<MongoDBDAOParams<DefaultFieldsEntityDAOGenerics<MetadataType, OperationMetadataType>>, 'idGenerator' | 'idField' | 'schema' | 'idScalar' | 'idGeneration'>
-export type InMemoryDefaultFieldsEntityDAOParams<MetadataType, OperationMetadataType> = Omit<InMemoryDAOParams<DefaultFieldsEntityDAOGenerics<MetadataType, OperationMetadataType>>, 'idGenerator' | 'idField' | 'schema' | 'idScalar' | 'idGeneration'>
+type DefaultFieldsEntityDAOGenerics<MetadataType, OperationMetadataType> = T.MongoDBDAOGenerics<types.DefaultFieldsEntity, 'id', 'ID', DefaultFieldsEntityFilter, DefaultFieldsEntityRawFilter, DefaultFieldsEntityRelations, DefaultFieldsEntityProjection, DefaultFieldsEntitySort, DefaultFieldsEntityRawSort, DefaultFieldsEntityInsert, DefaultFieldsEntityUpdate, DefaultFieldsEntityRawUpdate, DefaultFieldsEntityExcludedFields, DefaultFieldsEntityRelationFields, MetadataType, OperationMetadataType, types.Scalars, 'defaultFieldsEntity', DAOContext<MetadataType, OperationMetadataType>>
+export type DefaultFieldsEntityDAOParams<MetadataType, OperationMetadataType> = Omit<T.MongoDBDAOParams<DefaultFieldsEntityDAOGenerics<MetadataType, OperationMetadataType>>, 'idGenerator' | 'idField' | 'schema' | 'idScalar' | 'idGeneration'>
+export type InMemoryDefaultFieldsEntityDAOParams<MetadataType, OperationMetadataType> = Omit<T.InMemoryDAOParams<DefaultFieldsEntityDAOGenerics<MetadataType, OperationMetadataType>>, 'idGenerator' | 'idField' | 'schema' | 'idScalar' | 'idGeneration'>
 
-export class DefaultFieldsEntityDAO<MetadataType, OperationMetadataType> extends AbstractMongoDBDAO<DefaultFieldsEntityDAOGenerics<MetadataType, OperationMetadataType>> {  
+export class DefaultFieldsEntityDAO<MetadataType, OperationMetadataType> extends T.AbstractMongoDBDAO<DefaultFieldsEntityDAOGenerics<MetadataType, OperationMetadataType>> {  
   
   public static projection<P extends DefaultFieldsEntityProjection>(p: P) {
     return p
   }
-  public static mergeProjection<P1 extends DefaultFieldsEntityProjection, P2 extends DefaultFieldsEntityProjection>(p1: P1, p2: P2): SelectProjection<DefaultFieldsEntityProjection, P1, P2> {
-    return mergeProjections(p1, p2) as SelectProjection<DefaultFieldsEntityProjection, P1, P2>
+  public static mergeProjection<P1 extends DefaultFieldsEntityProjection, P2 extends DefaultFieldsEntityProjection>(p1: P1, p2: P2): T.SelectProjection<DefaultFieldsEntityProjection, P1, P2> {
+    return T.mergeProjections(p1, p2) as T.SelectProjection<DefaultFieldsEntityProjection, P1, P2>
   }
   
   public constructor(params: DefaultFieldsEntityDAOParams<MetadataType, OperationMetadataType>){
@@ -495,7 +494,7 @@ export class DefaultFieldsEntityDAO<MetadataType, OperationMetadataType> extends
       ...params, 
       idField: 'id', 
       schema: defaultFieldsEntitySchema(), 
-      relations: overrideRelations(
+      relations: T.overrideRelations(
         [
           
         ]
@@ -506,13 +505,13 @@ export class DefaultFieldsEntityDAO<MetadataType, OperationMetadataType> extends
   }
   }
 
-export class InMemoryDefaultFieldsEntityDAO<MetadataType, OperationMetadataType> extends AbstractInMemoryDAO<DefaultFieldsEntityDAOGenerics<MetadataType, OperationMetadataType>> {  
+export class InMemoryDefaultFieldsEntityDAO<MetadataType, OperationMetadataType> extends T.AbstractInMemoryDAO<DefaultFieldsEntityDAOGenerics<MetadataType, OperationMetadataType>> {  
   
   public static projection<P extends DefaultFieldsEntityProjection>(p: P) {
     return p
   }
-  public static mergeProjection<P1 extends DefaultFieldsEntityProjection, P2 extends DefaultFieldsEntityProjection>(p1: P1, p2: P2): SelectProjection<DefaultFieldsEntityProjection, P1, P2> {
-    return mergeProjections(p1, p2) as SelectProjection<DefaultFieldsEntityProjection, P1, P2>
+  public static mergeProjection<P1 extends DefaultFieldsEntityProjection, P2 extends DefaultFieldsEntityProjection>(p1: P1, p2: P2): T.SelectProjection<DefaultFieldsEntityProjection, P1, P2> {
+    return T.mergeProjections(p1, p2) as T.SelectProjection<DefaultFieldsEntityProjection, P1, P2>
   }
   
   public constructor(params: InMemoryDefaultFieldsEntityDAOParams<MetadataType, OperationMetadataType>){
@@ -520,7 +519,7 @@ export class InMemoryDefaultFieldsEntityDAO<MetadataType, OperationMetadataType>
       ...params, 
       idField: 'id', 
       schema: defaultFieldsEntitySchema(), 
-      relations: overrideRelations(
+      relations: T.overrideRelations(
         [
           
         ]
@@ -540,7 +539,7 @@ export class InMemoryDefaultFieldsEntityDAO<MetadataType, OperationMetadataType>
 export type DeviceExcludedFields = never
 export type DeviceRelationFields = 'user'
 
-export function deviceSchema(): Schema<types.Scalars> {
+export function deviceSchema(): T.Schema<types.Scalars> {
   return {
     'id': {
       scalar: 'ID', 
@@ -557,12 +556,12 @@ export function deviceSchema(): Schema<types.Scalars> {
 }
 
 type DeviceFilterFields = {
-  'id'?: types.Scalars['ID'] | null | EqualityOperators<types.Scalars['ID']> | ElementOperators,
-  'name'?: types.Scalars['String'] | null | EqualityOperators<types.Scalars['String']> | ElementOperators | StringOperators,
-  'userId'?: types.Scalars['ID'] | null | EqualityOperators<types.Scalars['ID']> | ElementOperators
+  'id'?: types.Scalars['ID'] | null | T.EqualityOperators<types.Scalars['ID']> | T.ElementOperators,
+  'name'?: types.Scalars['String'] | null | T.EqualityOperators<types.Scalars['String']> | T.ElementOperators | T.StringOperators,
+  'userId'?: types.Scalars['ID'] | null | T.EqualityOperators<types.Scalars['ID']> | T.ElementOperators
 }
-export type DeviceFilter = DeviceFilterFields & LogicalOperators<DeviceFilterFields | DeviceRawFilter>
-export type DeviceRawFilter = () => Filter<Document>
+export type DeviceFilter = DeviceFilterFields & T.LogicalOperators<DeviceFilterFields | DeviceRawFilter>
+export type DeviceRawFilter = () => M.Filter<M.Document>
 
 export type DeviceRelations = Record<never, string>
 
@@ -572,18 +571,18 @@ export type DeviceProjection = {
   user?: UserProjection | boolean,
   userId?: boolean,
 }
-export type DeviceParam<P extends DeviceProjection> = ParamProjection<types.Device, DeviceProjection, P>
+export type DeviceParam<P extends DeviceProjection> = T.ParamProjection<types.Device, DeviceProjection, P>
 
 export type DeviceSortKeys = 'id' | 'name' | 'userId'
-export type DeviceSort = OneKey<DeviceSortKeys, SortDirection>
-export type DeviceRawSort = () => Sort
+export type DeviceSort = T.OneKey<DeviceSortKeys, T.SortDirection>
+export type DeviceRawSort = () => M.Sort
 
 export type DeviceUpdate = {
   'id'?: types.Scalars['ID'],
   'name'?: types.Scalars['String'],
   'userId'?: types.Scalars['ID'] | null
 }
-export type DeviceRawUpdate = () => UpdateFilter<Document>
+export type DeviceRawUpdate = () => M.UpdateFilter<M.Document>
 
 export type DeviceInsert = {
   id?: null | types.Scalars['ID'],
@@ -591,17 +590,17 @@ export type DeviceInsert = {
   userId?: null | types.Scalars['ID'],
 }
 
-type DeviceDAOGenerics<MetadataType, OperationMetadataType> = MongoDBDAOGenerics<types.Device, 'id', 'ID', DeviceFilter, DeviceRawFilter, DeviceRelations, DeviceProjection, DeviceSort, DeviceRawSort, DeviceInsert, DeviceUpdate, DeviceRawUpdate, DeviceExcludedFields, DeviceRelationFields, MetadataType, OperationMetadataType, types.Scalars, 'device', DAOContext<MetadataType, OperationMetadataType>>
-export type DeviceDAOParams<MetadataType, OperationMetadataType> = Omit<MongoDBDAOParams<DeviceDAOGenerics<MetadataType, OperationMetadataType>>, 'idField' | 'schema' | 'idScalar' | 'idGeneration'>
-export type InMemoryDeviceDAOParams<MetadataType, OperationMetadataType> = Omit<InMemoryDAOParams<DeviceDAOGenerics<MetadataType, OperationMetadataType>>, 'idField' | 'schema' | 'idScalar' | 'idGeneration'>
+type DeviceDAOGenerics<MetadataType, OperationMetadataType> = T.MongoDBDAOGenerics<types.Device, 'id', 'ID', DeviceFilter, DeviceRawFilter, DeviceRelations, DeviceProjection, DeviceSort, DeviceRawSort, DeviceInsert, DeviceUpdate, DeviceRawUpdate, DeviceExcludedFields, DeviceRelationFields, MetadataType, OperationMetadataType, types.Scalars, 'device', DAOContext<MetadataType, OperationMetadataType>>
+export type DeviceDAOParams<MetadataType, OperationMetadataType> = Omit<T.MongoDBDAOParams<DeviceDAOGenerics<MetadataType, OperationMetadataType>>, 'idField' | 'schema' | 'idScalar' | 'idGeneration'>
+export type InMemoryDeviceDAOParams<MetadataType, OperationMetadataType> = Omit<T.InMemoryDAOParams<DeviceDAOGenerics<MetadataType, OperationMetadataType>>, 'idField' | 'schema' | 'idScalar' | 'idGeneration'>
 
-export class DeviceDAO<MetadataType, OperationMetadataType> extends AbstractMongoDBDAO<DeviceDAOGenerics<MetadataType, OperationMetadataType>> {  
+export class DeviceDAO<MetadataType, OperationMetadataType> extends T.AbstractMongoDBDAO<DeviceDAOGenerics<MetadataType, OperationMetadataType>> {  
   
   public static projection<P extends DeviceProjection>(p: P) {
     return p
   }
-  public static mergeProjection<P1 extends DeviceProjection, P2 extends DeviceProjection>(p1: P1, p2: P2): SelectProjection<DeviceProjection, P1, P2> {
-    return mergeProjections(p1, p2) as SelectProjection<DeviceProjection, P1, P2>
+  public static mergeProjection<P1 extends DeviceProjection, P2 extends DeviceProjection>(p1: P1, p2: P2): T.SelectProjection<DeviceProjection, P1, P2> {
+    return T.mergeProjections(p1, p2) as T.SelectProjection<DeviceProjection, P1, P2>
   }
   
   public constructor(params: DeviceDAOParams<MetadataType, OperationMetadataType>){
@@ -609,7 +608,7 @@ export class DeviceDAO<MetadataType, OperationMetadataType> extends AbstractMong
       ...params, 
       idField: 'id', 
       schema: deviceSchema(), 
-      relations: overrideRelations(
+      relations: T.overrideRelations(
         [
           { type: '1-1', reference: 'inner', field: 'user', refFrom: 'userId', refTo: 'id', dao: 'user', required: false }
         ]
@@ -620,13 +619,13 @@ export class DeviceDAO<MetadataType, OperationMetadataType> extends AbstractMong
   }
   }
 
-export class InMemoryDeviceDAO<MetadataType, OperationMetadataType> extends AbstractInMemoryDAO<DeviceDAOGenerics<MetadataType, OperationMetadataType>> {  
+export class InMemoryDeviceDAO<MetadataType, OperationMetadataType> extends T.AbstractInMemoryDAO<DeviceDAOGenerics<MetadataType, OperationMetadataType>> {  
   
   public static projection<P extends DeviceProjection>(p: P) {
     return p
   }
-  public static mergeProjection<P1 extends DeviceProjection, P2 extends DeviceProjection>(p1: P1, p2: P2): SelectProjection<DeviceProjection, P1, P2> {
-    return mergeProjections(p1, p2) as SelectProjection<DeviceProjection, P1, P2>
+  public static mergeProjection<P1 extends DeviceProjection, P2 extends DeviceProjection>(p1: P1, p2: P2): T.SelectProjection<DeviceProjection, P1, P2> {
+    return T.mergeProjections(p1, p2) as T.SelectProjection<DeviceProjection, P1, P2>
   }
   
   public constructor(params: InMemoryDeviceDAOParams<MetadataType, OperationMetadataType>){
@@ -634,7 +633,7 @@ export class InMemoryDeviceDAO<MetadataType, OperationMetadataType> extends Abst
       ...params, 
       idField: 'id', 
       schema: deviceSchema(), 
-      relations: overrideRelations(
+      relations: T.overrideRelations(
         [
           { type: '1-1', reference: 'inner', field: 'user', refFrom: 'userId', refTo: 'id', dao: 'user', required: false }
         ]
@@ -654,7 +653,7 @@ export class InMemoryDeviceDAO<MetadataType, OperationMetadataType> extends Abst
 export type DogExcludedFields = never
 export type DogRelationFields = 'owner'
 
-export function dogSchema(): Schema<types.Scalars> {
+export function dogSchema(): T.Schema<types.Scalars> {
   return {
     'id': {
       scalar: 'ID', 
@@ -672,12 +671,12 @@ export function dogSchema(): Schema<types.Scalars> {
 }
 
 type DogFilterFields = {
-  'id'?: types.Scalars['ID'] | null | EqualityOperators<types.Scalars['ID']> | ElementOperators,
-  'name'?: types.Scalars['String'] | null | EqualityOperators<types.Scalars['String']> | ElementOperators | StringOperators,
-  'ownerId'?: types.Scalars['ID'] | null | EqualityOperators<types.Scalars['ID']> | ElementOperators
+  'id'?: types.Scalars['ID'] | null | T.EqualityOperators<types.Scalars['ID']> | T.ElementOperators,
+  'name'?: types.Scalars['String'] | null | T.EqualityOperators<types.Scalars['String']> | T.ElementOperators | T.StringOperators,
+  'ownerId'?: types.Scalars['ID'] | null | T.EqualityOperators<types.Scalars['ID']> | T.ElementOperators
 }
-export type DogFilter = DogFilterFields & LogicalOperators<DogFilterFields | DogRawFilter>
-export type DogRawFilter = () => Filter<Document>
+export type DogFilter = DogFilterFields & T.LogicalOperators<DogFilterFields | DogRawFilter>
+export type DogRawFilter = () => M.Filter<M.Document>
 
 export type DogRelations = Record<never, string>
 
@@ -687,18 +686,18 @@ export type DogProjection = {
   owner?: UserProjection | boolean,
   ownerId?: boolean,
 }
-export type DogParam<P extends DogProjection> = ParamProjection<types.Dog, DogProjection, P>
+export type DogParam<P extends DogProjection> = T.ParamProjection<types.Dog, DogProjection, P>
 
 export type DogSortKeys = 'id' | 'name' | 'ownerId'
-export type DogSort = OneKey<DogSortKeys, SortDirection>
-export type DogRawSort = () => Sort
+export type DogSort = T.OneKey<DogSortKeys, T.SortDirection>
+export type DogRawSort = () => M.Sort
 
 export type DogUpdate = {
   'id'?: types.Scalars['ID'],
   'name'?: types.Scalars['String'],
   'ownerId'?: types.Scalars['ID']
 }
-export type DogRawUpdate = () => UpdateFilter<Document>
+export type DogRawUpdate = () => M.UpdateFilter<M.Document>
 
 export type DogInsert = {
   id?: null | types.Scalars['ID'],
@@ -706,17 +705,17 @@ export type DogInsert = {
   ownerId: types.Scalars['ID'],
 }
 
-type DogDAOGenerics<MetadataType, OperationMetadataType> = MongoDBDAOGenerics<types.Dog, 'id', 'ID', DogFilter, DogRawFilter, DogRelations, DogProjection, DogSort, DogRawSort, DogInsert, DogUpdate, DogRawUpdate, DogExcludedFields, DogRelationFields, MetadataType, OperationMetadataType, types.Scalars, 'dog', DAOContext<MetadataType, OperationMetadataType>>
-export type DogDAOParams<MetadataType, OperationMetadataType> = Omit<MongoDBDAOParams<DogDAOGenerics<MetadataType, OperationMetadataType>>, 'idField' | 'schema' | 'idScalar' | 'idGeneration'>
-export type InMemoryDogDAOParams<MetadataType, OperationMetadataType> = Omit<InMemoryDAOParams<DogDAOGenerics<MetadataType, OperationMetadataType>>, 'idField' | 'schema' | 'idScalar' | 'idGeneration'>
+type DogDAOGenerics<MetadataType, OperationMetadataType> = T.MongoDBDAOGenerics<types.Dog, 'id', 'ID', DogFilter, DogRawFilter, DogRelations, DogProjection, DogSort, DogRawSort, DogInsert, DogUpdate, DogRawUpdate, DogExcludedFields, DogRelationFields, MetadataType, OperationMetadataType, types.Scalars, 'dog', DAOContext<MetadataType, OperationMetadataType>>
+export type DogDAOParams<MetadataType, OperationMetadataType> = Omit<T.MongoDBDAOParams<DogDAOGenerics<MetadataType, OperationMetadataType>>, 'idField' | 'schema' | 'idScalar' | 'idGeneration'>
+export type InMemoryDogDAOParams<MetadataType, OperationMetadataType> = Omit<T.InMemoryDAOParams<DogDAOGenerics<MetadataType, OperationMetadataType>>, 'idField' | 'schema' | 'idScalar' | 'idGeneration'>
 
-export class DogDAO<MetadataType, OperationMetadataType> extends AbstractMongoDBDAO<DogDAOGenerics<MetadataType, OperationMetadataType>> {  
+export class DogDAO<MetadataType, OperationMetadataType> extends T.AbstractMongoDBDAO<DogDAOGenerics<MetadataType, OperationMetadataType>> {  
   
   public static projection<P extends DogProjection>(p: P) {
     return p
   }
-  public static mergeProjection<P1 extends DogProjection, P2 extends DogProjection>(p1: P1, p2: P2): SelectProjection<DogProjection, P1, P2> {
-    return mergeProjections(p1, p2) as SelectProjection<DogProjection, P1, P2>
+  public static mergeProjection<P1 extends DogProjection, P2 extends DogProjection>(p1: P1, p2: P2): T.SelectProjection<DogProjection, P1, P2> {
+    return T.mergeProjections(p1, p2) as T.SelectProjection<DogProjection, P1, P2>
   }
   
   public constructor(params: DogDAOParams<MetadataType, OperationMetadataType>){
@@ -724,7 +723,7 @@ export class DogDAO<MetadataType, OperationMetadataType> extends AbstractMongoDB
       ...params, 
       idField: 'id', 
       schema: dogSchema(), 
-      relations: overrideRelations(
+      relations: T.overrideRelations(
         [
           { type: '1-1', reference: 'inner', field: 'owner', refFrom: 'ownerId', refTo: 'id', dao: 'user', required: false }
         ]
@@ -735,13 +734,13 @@ export class DogDAO<MetadataType, OperationMetadataType> extends AbstractMongoDB
   }
   }
 
-export class InMemoryDogDAO<MetadataType, OperationMetadataType> extends AbstractInMemoryDAO<DogDAOGenerics<MetadataType, OperationMetadataType>> {  
+export class InMemoryDogDAO<MetadataType, OperationMetadataType> extends T.AbstractInMemoryDAO<DogDAOGenerics<MetadataType, OperationMetadataType>> {  
   
   public static projection<P extends DogProjection>(p: P) {
     return p
   }
-  public static mergeProjection<P1 extends DogProjection, P2 extends DogProjection>(p1: P1, p2: P2): SelectProjection<DogProjection, P1, P2> {
-    return mergeProjections(p1, p2) as SelectProjection<DogProjection, P1, P2>
+  public static mergeProjection<P1 extends DogProjection, P2 extends DogProjection>(p1: P1, p2: P2): T.SelectProjection<DogProjection, P1, P2> {
+    return T.mergeProjections(p1, p2) as T.SelectProjection<DogProjection, P1, P2>
   }
   
   public constructor(params: InMemoryDogDAOParams<MetadataType, OperationMetadataType>){
@@ -749,7 +748,7 @@ export class InMemoryDogDAO<MetadataType, OperationMetadataType> extends Abstrac
       ...params, 
       idField: 'id', 
       schema: dogSchema(), 
-      relations: overrideRelations(
+      relations: T.overrideRelations(
         [
           { type: '1-1', reference: 'inner', field: 'owner', refFrom: 'ownerId', refTo: 'id', dao: 'user', required: false }
         ]
@@ -766,7 +765,7 @@ export class InMemoryDogDAO<MetadataType, OperationMetadataType> extends Abstrac
 //--------------------------------- EMBEDDEDUSER ---------------------------------
 //--------------------------------------------------------------------------------
 
-export function embeddedUserSchema(): Schema<types.Scalars> {
+export function embeddedUserSchema(): T.Schema<types.Scalars> {
   return {
     'e': { embedded: embeddedUser2Schema(), array: true },
     'userId': {
@@ -784,7 +783,7 @@ export type EmbeddedUserProjection = {
   user?: UserProjection | boolean,
   userId?: boolean,
 }
-export type EmbeddedUserParam<P extends EmbeddedUserProjection> = ParamProjection<types.EmbeddedUser, EmbeddedUserProjection, P>
+export type EmbeddedUserParam<P extends EmbeddedUserProjection> = T.ParamProjection<types.EmbeddedUser, EmbeddedUserProjection, P>
 
 export type EmbeddedUserInsert = {
   e?: null | EmbeddedUser2Insert[],
@@ -797,7 +796,7 @@ export type EmbeddedUserInsert = {
 //-------------------------------- EMBEDDEDUSER2 ---------------------------------
 //--------------------------------------------------------------------------------
 
-export function embeddedUser2Schema(): Schema<types.Scalars> {
+export function embeddedUser2Schema(): T.Schema<types.Scalars> {
   return {
     'userId': {
       scalar: 'ID', 
@@ -810,7 +809,7 @@ export type EmbeddedUser2Projection = {
   user?: UserProjection | boolean,
   userId?: boolean,
 }
-export type EmbeddedUser2Param<P extends EmbeddedUser2Projection> = ParamProjection<types.EmbeddedUser2, EmbeddedUser2Projection, P>
+export type EmbeddedUser2Param<P extends EmbeddedUser2Projection> = T.ParamProjection<types.EmbeddedUser2, EmbeddedUser2Projection, P>
 
 export type EmbeddedUser2Insert = {
   userId: types.Scalars['ID'],
@@ -822,7 +821,7 @@ export type EmbeddedUser2Insert = {
 //-------------------------------- EMBEDDEDUSER3 ---------------------------------
 //--------------------------------------------------------------------------------
 
-export function embeddedUser3Schema(): Schema<types.Scalars> {
+export function embeddedUser3Schema(): T.Schema<types.Scalars> {
   return {
     'value': {
       scalar: 'Int'
@@ -834,7 +833,7 @@ export type EmbeddedUser3Projection = {
   user?: UserProjection | boolean,
   value?: boolean,
 }
-export type EmbeddedUser3Param<P extends EmbeddedUser3Projection> = ParamProjection<types.EmbeddedUser3, EmbeddedUser3Projection, P>
+export type EmbeddedUser3Param<P extends EmbeddedUser3Projection> = T.ParamProjection<types.EmbeddedUser3, EmbeddedUser3Projection, P>
 
 export type EmbeddedUser3Insert = {
   value?: null | types.Scalars['Int'],
@@ -846,7 +845,7 @@ export type EmbeddedUser3Insert = {
 //-------------------------------- EMBEDDEDUSER4 ---------------------------------
 //--------------------------------------------------------------------------------
 
-export function embeddedUser4Schema(): Schema<types.Scalars> {
+export function embeddedUser4Schema(): T.Schema<types.Scalars> {
   return {
     'e': { embedded: embeddedUser5Schema() }
   }
@@ -858,7 +857,7 @@ export type EmbeddedUser4Projection = {
   } | boolean,
   user?: UserProjection | boolean,
 }
-export type EmbeddedUser4Param<P extends EmbeddedUser4Projection> = ParamProjection<types.EmbeddedUser4, EmbeddedUser4Projection, P>
+export type EmbeddedUser4Param<P extends EmbeddedUser4Projection> = T.ParamProjection<types.EmbeddedUser4, EmbeddedUser4Projection, P>
 
 export type EmbeddedUser4Insert = {
   e?: null | EmbeddedUser5Insert,
@@ -870,7 +869,7 @@ export type EmbeddedUser4Insert = {
 //-------------------------------- EMBEDDEDUSER5 ---------------------------------
 //--------------------------------------------------------------------------------
 
-export function embeddedUser5Schema(): Schema<types.Scalars> {
+export function embeddedUser5Schema(): T.Schema<types.Scalars> {
   return {
     'userId': {
       scalar: 'ID'
@@ -881,7 +880,7 @@ export function embeddedUser5Schema(): Schema<types.Scalars> {
 export type EmbeddedUser5Projection = {
   userId?: boolean,
 }
-export type EmbeddedUser5Param<P extends EmbeddedUser5Projection> = ParamProjection<types.EmbeddedUser5, EmbeddedUser5Projection, P>
+export type EmbeddedUser5Param<P extends EmbeddedUser5Projection> = T.ParamProjection<types.EmbeddedUser5, EmbeddedUser5Projection, P>
 
 export type EmbeddedUser5Insert = {
   userId?: null | types.Scalars['ID'],
@@ -896,7 +895,7 @@ export type EmbeddedUser5Insert = {
 export type HotelExcludedFields = never
 export type HotelRelationFields = never
 
-export function hotelSchema(): Schema<types.Scalars> {
+export function hotelSchema(): T.Schema<types.Scalars> {
   return {
     'audit': { embedded: auditableSchema(), required: true, defaultGenerationStrategy: 'middleware' },
     'embeddedUser3': { embedded: embeddedUser3Schema() },
@@ -921,25 +920,25 @@ export function hotelSchema(): Schema<types.Scalars> {
 }
 
 type HotelFilterFields = {
-  'audit.createdBy'?: types.Scalars['String'] | null | EqualityOperators<types.Scalars['String']> | ElementOperators | StringOperators,
-  'audit.createdOn'?: types.Scalars['Int'] | null | EqualityOperators<types.Scalars['Int']> | ElementOperators | QuantityOperators<types.Scalars['Int']>,
-  'audit.deletedOn'?: types.Scalars['Int'] | null | EqualityOperators<types.Scalars['Int']> | ElementOperators | QuantityOperators<types.Scalars['Int']>,
-  'audit.modifiedBy'?: types.Scalars['String'] | null | EqualityOperators<types.Scalars['String']> | ElementOperators | StringOperators,
-  'audit.modifiedOn'?: types.Scalars['Int'] | null | EqualityOperators<types.Scalars['Int']> | ElementOperators | QuantityOperators<types.Scalars['Int']>,
-  'audit.state'?: types.State | null | EqualityOperators<types.State> | ElementOperators | StringOperators,
-  'embeddedUser3.value'?: types.Scalars['Int'] | null | EqualityOperators<types.Scalars['Int']> | ElementOperators | QuantityOperators<types.Scalars['Int']>,
-  'embeddedUser4.e.userId'?: types.Scalars['ID'] | null | EqualityOperators<types.Scalars['ID']> | ElementOperators,
-  'embeddedUsers.e.userId'?: types.Scalars['ID'] | null | EqualityOperators<types.Scalars['ID']> | ElementOperators,
-  'embeddedUsers.userId'?: types.Scalars['ID'] | null | EqualityOperators<types.Scalars['ID']> | ElementOperators,
-  'embeddedUsers3.value'?: types.Scalars['Int'] | null | EqualityOperators<types.Scalars['Int']> | ElementOperators | QuantityOperators<types.Scalars['Int']>,
-  'embeddedUsers4.e.userId'?: types.Scalars['ID'] | null | EqualityOperators<types.Scalars['ID']> | ElementOperators,
-  'id'?: types.Scalars['ID'] | null | EqualityOperators<types.Scalars['ID']> | ElementOperators,
-  'name'?: types.Scalars['String'] | null | EqualityOperators<types.Scalars['String']> | ElementOperators | StringOperators,
-  'userId'?: types.Scalars['ID'] | null | EqualityOperators<types.Scalars['ID']> | ElementOperators,
-  'users.usersId'?: types.Scalars['ID'][] | null | EqualityOperators<types.Scalars['ID'][]> | ElementOperators
+  'audit.createdBy'?: types.Scalars['String'] | null | T.EqualityOperators<types.Scalars['String']> | T.ElementOperators | T.StringOperators,
+  'audit.createdOn'?: types.Scalars['Int'] | null | T.EqualityOperators<types.Scalars['Int']> | T.ElementOperators | T.QuantityOperators<types.Scalars['Int']>,
+  'audit.deletedOn'?: types.Scalars['Int'] | null | T.EqualityOperators<types.Scalars['Int']> | T.ElementOperators | T.QuantityOperators<types.Scalars['Int']>,
+  'audit.modifiedBy'?: types.Scalars['String'] | null | T.EqualityOperators<types.Scalars['String']> | T.ElementOperators | T.StringOperators,
+  'audit.modifiedOn'?: types.Scalars['Int'] | null | T.EqualityOperators<types.Scalars['Int']> | T.ElementOperators | T.QuantityOperators<types.Scalars['Int']>,
+  'audit.state'?: types.State | null | T.EqualityOperators<types.State> | T.ElementOperators | T.StringOperators,
+  'embeddedUser3.value'?: types.Scalars['Int'] | null | T.EqualityOperators<types.Scalars['Int']> | T.ElementOperators | T.QuantityOperators<types.Scalars['Int']>,
+  'embeddedUser4.e.userId'?: types.Scalars['ID'] | null | T.EqualityOperators<types.Scalars['ID']> | T.ElementOperators,
+  'embeddedUsers.e.userId'?: types.Scalars['ID'] | null | T.EqualityOperators<types.Scalars['ID']> | T.ElementOperators,
+  'embeddedUsers.userId'?: types.Scalars['ID'] | null | T.EqualityOperators<types.Scalars['ID']> | T.ElementOperators,
+  'embeddedUsers3.value'?: types.Scalars['Int'] | null | T.EqualityOperators<types.Scalars['Int']> | T.ElementOperators | T.QuantityOperators<types.Scalars['Int']>,
+  'embeddedUsers4.e.userId'?: types.Scalars['ID'] | null | T.EqualityOperators<types.Scalars['ID']> | T.ElementOperators,
+  'id'?: types.Scalars['ID'] | null | T.EqualityOperators<types.Scalars['ID']> | T.ElementOperators,
+  'name'?: types.Scalars['String'] | null | T.EqualityOperators<types.Scalars['String']> | T.ElementOperators | T.StringOperators,
+  'userId'?: types.Scalars['ID'] | null | T.EqualityOperators<types.Scalars['ID']> | T.ElementOperators,
+  'users.usersId'?: types.Scalars['ID'][] | null | T.EqualityOperators<types.Scalars['ID'][]> | T.ElementOperators
 }
-export type HotelFilter = HotelFilterFields & LogicalOperators<HotelFilterFields | HotelRawFilter>
-export type HotelRawFilter = () => Filter<Document>
+export type HotelFilter = HotelFilterFields & T.LogicalOperators<HotelFilterFields | HotelRawFilter>
+export type HotelRawFilter = () => M.Filter<M.Document>
 
 export type HotelRelations = Record<never, string>
 
@@ -989,11 +988,11 @@ export type HotelProjection = {
     usersId?: boolean,
   } | boolean,
 }
-export type HotelParam<P extends HotelProjection> = ParamProjection<types.Hotel, HotelProjection, P>
+export type HotelParam<P extends HotelProjection> = T.ParamProjection<types.Hotel, HotelProjection, P>
 
 export type HotelSortKeys = 'audit.createdBy' | 'audit.createdOn' | 'audit.deletedOn' | 'audit.modifiedBy' | 'audit.modifiedOn' | 'audit.state' | 'embeddedUser3.value' | 'embeddedUser4.e.userId' | 'embeddedUsers.e.userId' | 'embeddedUsers.userId' | 'embeddedUsers3.value' | 'embeddedUsers4.e.userId' | 'id' | 'name' | 'userId' | 'users.usersId'
-export type HotelSort = OneKey<HotelSortKeys, SortDirection>
-export type HotelRawSort = () => Sort
+export type HotelSort = T.OneKey<HotelSortKeys, T.SortDirection>
+export type HotelRawSort = () => M.Sort
 
 export type HotelUpdate = {
   'audit'?: AuditableInsert,
@@ -1017,7 +1016,7 @@ export type HotelUpdate = {
   'users'?: UserCollectionInsert | null,
   'users.usersId'?: types.Scalars['ID'][]
 }
-export type HotelRawUpdate = () => UpdateFilter<Document>
+export type HotelRawUpdate = () => M.UpdateFilter<M.Document>
 
 export type HotelInsert = {
   audit?: null | AuditableInsert,
@@ -1031,17 +1030,17 @@ export type HotelInsert = {
   users?: null | UserCollectionInsert,
 }
 
-type HotelDAOGenerics<MetadataType, OperationMetadataType> = MongoDBDAOGenerics<types.Hotel, 'id', 'ID', HotelFilter, HotelRawFilter, HotelRelations, HotelProjection, HotelSort, HotelRawSort, HotelInsert, HotelUpdate, HotelRawUpdate, HotelExcludedFields, HotelRelationFields, MetadataType, OperationMetadataType, types.Scalars, 'hotel', DAOContext<MetadataType, OperationMetadataType>>
-export type HotelDAOParams<MetadataType, OperationMetadataType> = Omit<MongoDBDAOParams<HotelDAOGenerics<MetadataType, OperationMetadataType>>, 'idGenerator' | 'idField' | 'schema' | 'idScalar' | 'idGeneration'>
-export type InMemoryHotelDAOParams<MetadataType, OperationMetadataType> = Omit<InMemoryDAOParams<HotelDAOGenerics<MetadataType, OperationMetadataType>>, 'idGenerator' | 'idField' | 'schema' | 'idScalar' | 'idGeneration'>
+type HotelDAOGenerics<MetadataType, OperationMetadataType> = T.MongoDBDAOGenerics<types.Hotel, 'id', 'ID', HotelFilter, HotelRawFilter, HotelRelations, HotelProjection, HotelSort, HotelRawSort, HotelInsert, HotelUpdate, HotelRawUpdate, HotelExcludedFields, HotelRelationFields, MetadataType, OperationMetadataType, types.Scalars, 'hotel', DAOContext<MetadataType, OperationMetadataType>>
+export type HotelDAOParams<MetadataType, OperationMetadataType> = Omit<T.MongoDBDAOParams<HotelDAOGenerics<MetadataType, OperationMetadataType>>, 'idGenerator' | 'idField' | 'schema' | 'idScalar' | 'idGeneration'>
+export type InMemoryHotelDAOParams<MetadataType, OperationMetadataType> = Omit<T.InMemoryDAOParams<HotelDAOGenerics<MetadataType, OperationMetadataType>>, 'idGenerator' | 'idField' | 'schema' | 'idScalar' | 'idGeneration'>
 
-export class HotelDAO<MetadataType, OperationMetadataType> extends AbstractMongoDBDAO<HotelDAOGenerics<MetadataType, OperationMetadataType>> {  
+export class HotelDAO<MetadataType, OperationMetadataType> extends T.AbstractMongoDBDAO<HotelDAOGenerics<MetadataType, OperationMetadataType>> {  
   
   public static projection<P extends HotelProjection>(p: P) {
     return p
   }
-  public static mergeProjection<P1 extends HotelProjection, P2 extends HotelProjection>(p1: P1, p2: P2): SelectProjection<HotelProjection, P1, P2> {
-    return mergeProjections(p1, p2) as SelectProjection<HotelProjection, P1, P2>
+  public static mergeProjection<P1 extends HotelProjection, P2 extends HotelProjection>(p1: P1, p2: P2): T.SelectProjection<HotelProjection, P1, P2> {
+    return T.mergeProjections(p1, p2) as T.SelectProjection<HotelProjection, P1, P2>
   }
   
   public constructor(params: HotelDAOParams<MetadataType, OperationMetadataType>){
@@ -1049,7 +1048,7 @@ export class HotelDAO<MetadataType, OperationMetadataType> extends AbstractMongo
       ...params, 
       idField: 'id', 
       schema: hotelSchema(), 
-      relations: overrideRelations(
+      relations: T.overrideRelations(
         [
           { type: '1-n', reference: 'foreign', field: 'audit.versions', refFrom: 'entityId', refTo: 'id', dao: 'audit', required: true },
           { type: '1-1', reference: 'inner', field: 'embeddedUser3.user', refFrom: 'userId', refTo: 'id', dao: 'user', required: false },
@@ -1067,13 +1066,13 @@ export class HotelDAO<MetadataType, OperationMetadataType> extends AbstractMongo
   }
   }
 
-export class InMemoryHotelDAO<MetadataType, OperationMetadataType> extends AbstractInMemoryDAO<HotelDAOGenerics<MetadataType, OperationMetadataType>> {  
+export class InMemoryHotelDAO<MetadataType, OperationMetadataType> extends T.AbstractInMemoryDAO<HotelDAOGenerics<MetadataType, OperationMetadataType>> {  
   
   public static projection<P extends HotelProjection>(p: P) {
     return p
   }
-  public static mergeProjection<P1 extends HotelProjection, P2 extends HotelProjection>(p1: P1, p2: P2): SelectProjection<HotelProjection, P1, P2> {
-    return mergeProjections(p1, p2) as SelectProjection<HotelProjection, P1, P2>
+  public static mergeProjection<P1 extends HotelProjection, P2 extends HotelProjection>(p1: P1, p2: P2): T.SelectProjection<HotelProjection, P1, P2> {
+    return T.mergeProjections(p1, p2) as T.SelectProjection<HotelProjection, P1, P2>
   }
   
   public constructor(params: InMemoryHotelDAOParams<MetadataType, OperationMetadataType>){
@@ -1081,7 +1080,7 @@ export class InMemoryHotelDAO<MetadataType, OperationMetadataType> extends Abstr
       ...params, 
       idField: 'id', 
       schema: hotelSchema(), 
-      relations: overrideRelations(
+      relations: T.overrideRelations(
         [
           { type: '1-n', reference: 'foreign', field: 'audit.versions', refFrom: 'entityId', refTo: 'id', dao: 'audit', required: true },
           { type: '1-1', reference: 'inner', field: 'embeddedUser3.user', refFrom: 'userId', refTo: 'id', dao: 'user', required: false },
@@ -1108,7 +1107,7 @@ export class InMemoryHotelDAO<MetadataType, OperationMetadataType> extends Abstr
 export type MockedEntityExcludedFields = never
 export type MockedEntityRelationFields = 'user'
 
-export function mockedEntitySchema(): Schema<types.Scalars> {
+export function mockedEntitySchema(): T.Schema<types.Scalars> {
   return {
     'id': {
       scalar: 'MongoID', 
@@ -1127,11 +1126,11 @@ export function mockedEntitySchema(): Schema<types.Scalars> {
 }
 
 type MockedEntityFilterFields = {
-  'id'?: types.Scalars['MongoID'] | null | EqualityOperators<types.Scalars['MongoID']> | ElementOperators,
-  'name'?: types.Scalars['String'] | null | EqualityOperators<types.Scalars['String']> | ElementOperators | StringOperators,
-  'userId'?: types.Scalars['ID'] | null | EqualityOperators<types.Scalars['ID']> | ElementOperators
+  'id'?: types.Scalars['MongoID'] | null | T.EqualityOperators<types.Scalars['MongoID']> | T.ElementOperators,
+  'name'?: types.Scalars['String'] | null | T.EqualityOperators<types.Scalars['String']> | T.ElementOperators | T.StringOperators,
+  'userId'?: types.Scalars['ID'] | null | T.EqualityOperators<types.Scalars['ID']> | T.ElementOperators
 }
-export type MockedEntityFilter = MockedEntityFilterFields & LogicalOperators<MockedEntityFilterFields | MockedEntityRawFilter>
+export type MockedEntityFilter = MockedEntityFilterFields & T.LogicalOperators<MockedEntityFilterFields | MockedEntityRawFilter>
 export type MockedEntityRawFilter = never
 
 export type MockedEntityRelations = Record<never, string>
@@ -1142,10 +1141,10 @@ export type MockedEntityProjection = {
   user?: UserProjection | boolean,
   userId?: boolean,
 }
-export type MockedEntityParam<P extends MockedEntityProjection> = ParamProjection<types.MockedEntity, MockedEntityProjection, P>
+export type MockedEntityParam<P extends MockedEntityProjection> = T.ParamProjection<types.MockedEntity, MockedEntityProjection, P>
 
 export type MockedEntitySortKeys = 'id' | 'name' | 'userId'
-export type MockedEntitySort = OneKey<MockedEntitySortKeys, SortDirection>
+export type MockedEntitySort = T.OneKey<MockedEntitySortKeys, T.SortDirection>
 export type MockedEntityRawSort = never
 
 export type MockedEntityUpdate = {
@@ -1160,17 +1159,17 @@ export type MockedEntityInsert = {
   userId: types.Scalars['ID'],
 }
 
-type MockedEntityDAOGenerics<MetadataType, OperationMetadataType> = InMemoryDAOGenerics<types.MockedEntity, 'id', 'MongoID', MockedEntityFilter, MockedEntityRawFilter, MockedEntityRelations, MockedEntityProjection, MockedEntitySort, MockedEntityRawSort, MockedEntityInsert, MockedEntityUpdate, MockedEntityRawUpdate, MockedEntityExcludedFields, MockedEntityRelationFields, MetadataType, OperationMetadataType, types.Scalars, 'mockedEntity', DAOContext<MetadataType, OperationMetadataType>>
-export type MockedEntityDAOParams<MetadataType, OperationMetadataType> = Omit<InMemoryDAOParams<MockedEntityDAOGenerics<MetadataType, OperationMetadataType>>, 'idGenerator' | 'idField' | 'schema' | 'idScalar' | 'idGeneration'>
-export type InMemoryMockedEntityDAOParams<MetadataType, OperationMetadataType> = Omit<InMemoryDAOParams<MockedEntityDAOGenerics<MetadataType, OperationMetadataType>>, 'idGenerator' | 'idField' | 'schema' | 'idScalar' | 'idGeneration'>
+type MockedEntityDAOGenerics<MetadataType, OperationMetadataType> = T.InMemoryDAOGenerics<types.MockedEntity, 'id', 'MongoID', MockedEntityFilter, MockedEntityRawFilter, MockedEntityRelations, MockedEntityProjection, MockedEntitySort, MockedEntityRawSort, MockedEntityInsert, MockedEntityUpdate, MockedEntityRawUpdate, MockedEntityExcludedFields, MockedEntityRelationFields, MetadataType, OperationMetadataType, types.Scalars, 'mockedEntity', DAOContext<MetadataType, OperationMetadataType>>
+export type MockedEntityDAOParams<MetadataType, OperationMetadataType> = Omit<T.InMemoryDAOParams<MockedEntityDAOGenerics<MetadataType, OperationMetadataType>>, 'idGenerator' | 'idField' | 'schema' | 'idScalar' | 'idGeneration'>
+export type InMemoryMockedEntityDAOParams<MetadataType, OperationMetadataType> = Omit<T.InMemoryDAOParams<MockedEntityDAOGenerics<MetadataType, OperationMetadataType>>, 'idGenerator' | 'idField' | 'schema' | 'idScalar' | 'idGeneration'>
 
-export class MockedEntityDAO<MetadataType, OperationMetadataType> extends AbstractInMemoryDAO<MockedEntityDAOGenerics<MetadataType, OperationMetadataType>> {  
+export class MockedEntityDAO<MetadataType, OperationMetadataType> extends T.AbstractInMemoryDAO<MockedEntityDAOGenerics<MetadataType, OperationMetadataType>> {  
   
   public static projection<P extends MockedEntityProjection>(p: P) {
     return p
   }
-  public static mergeProjection<P1 extends MockedEntityProjection, P2 extends MockedEntityProjection>(p1: P1, p2: P2): SelectProjection<MockedEntityProjection, P1, P2> {
-    return mergeProjections(p1, p2) as SelectProjection<MockedEntityProjection, P1, P2>
+  public static mergeProjection<P1 extends MockedEntityProjection, P2 extends MockedEntityProjection>(p1: P1, p2: P2): T.SelectProjection<MockedEntityProjection, P1, P2> {
+    return T.mergeProjections(p1, p2) as T.SelectProjection<MockedEntityProjection, P1, P2>
   }
   
   public constructor(params: MockedEntityDAOParams<MetadataType, OperationMetadataType>){
@@ -1178,7 +1177,7 @@ export class MockedEntityDAO<MetadataType, OperationMetadataType> extends Abstra
       ...params, 
       idField: 'id', 
       schema: mockedEntitySchema(), 
-      relations: overrideRelations(
+      relations: T.overrideRelations(
         [
           { type: '1-1', reference: 'inner', field: 'user', refFrom: 'userId', refTo: 'id', dao: 'user', required: true }
         ]
@@ -1189,13 +1188,13 @@ export class MockedEntityDAO<MetadataType, OperationMetadataType> extends Abstra
   }
   }
 
-export class InMemoryMockedEntityDAO<MetadataType, OperationMetadataType> extends AbstractInMemoryDAO<MockedEntityDAOGenerics<MetadataType, OperationMetadataType>> {  
+export class InMemoryMockedEntityDAO<MetadataType, OperationMetadataType> extends T.AbstractInMemoryDAO<MockedEntityDAOGenerics<MetadataType, OperationMetadataType>> {  
   
   public static projection<P extends MockedEntityProjection>(p: P) {
     return p
   }
-  public static mergeProjection<P1 extends MockedEntityProjection, P2 extends MockedEntityProjection>(p1: P1, p2: P2): SelectProjection<MockedEntityProjection, P1, P2> {
-    return mergeProjections(p1, p2) as SelectProjection<MockedEntityProjection, P1, P2>
+  public static mergeProjection<P1 extends MockedEntityProjection, P2 extends MockedEntityProjection>(p1: P1, p2: P2): T.SelectProjection<MockedEntityProjection, P1, P2> {
+    return T.mergeProjections(p1, p2) as T.SelectProjection<MockedEntityProjection, P1, P2>
   }
   
   public constructor(params: InMemoryMockedEntityDAOParams<MetadataType, OperationMetadataType>){
@@ -1203,7 +1202,7 @@ export class InMemoryMockedEntityDAO<MetadataType, OperationMetadataType> extend
       ...params, 
       idField: 'id', 
       schema: mockedEntitySchema(), 
-      relations: overrideRelations(
+      relations: T.overrideRelations(
         [
           { type: '1-1', reference: 'inner', field: 'user', refFrom: 'userId', refTo: 'id', dao: 'user', required: true }
         ]
@@ -1223,7 +1222,7 @@ export class InMemoryMockedEntityDAO<MetadataType, OperationMetadataType> extend
 export type OrganizationExcludedFields = 'computedName'
 export type OrganizationRelationFields = never
 
-export function organizationSchema(): Schema<types.Scalars> {
+export function organizationSchema(): T.Schema<types.Scalars> {
   return {
     'address': { embedded: addressSchema() },
     'id': {
@@ -1241,13 +1240,13 @@ export function organizationSchema(): Schema<types.Scalars> {
 }
 
 type OrganizationFilterFields = {
-  'address.id'?: types.Scalars['ID'] | null | EqualityOperators<types.Scalars['ID']> | ElementOperators,
-  'id'?: types.Scalars['ID'] | null | EqualityOperators<types.Scalars['ID']> | ElementOperators,
-  'name'?: types.Scalars['String'] | null | EqualityOperators<types.Scalars['String']> | ElementOperators | StringOperators,
-  'vatNumber'?: types.Scalars['String'] | null | EqualityOperators<types.Scalars['String']> | ElementOperators | StringOperators
+  'address.id'?: types.Scalars['ID'] | null | T.EqualityOperators<types.Scalars['ID']> | T.ElementOperators,
+  'id'?: types.Scalars['ID'] | null | T.EqualityOperators<types.Scalars['ID']> | T.ElementOperators,
+  'name'?: types.Scalars['String'] | null | T.EqualityOperators<types.Scalars['String']> | T.ElementOperators | T.StringOperators,
+  'vatNumber'?: types.Scalars['String'] | null | T.EqualityOperators<types.Scalars['String']> | T.ElementOperators | T.StringOperators
 }
-export type OrganizationFilter = OrganizationFilterFields & LogicalOperators<OrganizationFilterFields | OrganizationRawFilter>
-export type OrganizationRawFilter = () => Filter<Document>
+export type OrganizationFilter = OrganizationFilterFields & T.LogicalOperators<OrganizationFilterFields | OrganizationRawFilter>
+export type OrganizationRawFilter = () => M.Filter<M.Document>
 
 export type OrganizationRelations = Record<never, string>
 
@@ -1261,11 +1260,11 @@ export type OrganizationProjection = {
   name?: boolean,
   vatNumber?: boolean,
 }
-export type OrganizationParam<P extends OrganizationProjection> = ParamProjection<types.Organization, OrganizationProjection, P>
+export type OrganizationParam<P extends OrganizationProjection> = T.ParamProjection<types.Organization, OrganizationProjection, P>
 
 export type OrganizationSortKeys = 'address.id' | 'id' | 'name' | 'vatNumber'
-export type OrganizationSort = OneKey<OrganizationSortKeys, SortDirection>
-export type OrganizationRawSort = () => Sort
+export type OrganizationSort = T.OneKey<OrganizationSortKeys, T.SortDirection>
+export type OrganizationRawSort = () => M.Sort
 
 export type OrganizationUpdate = {
   'address'?: AddressInsert | null,
@@ -1274,7 +1273,7 @@ export type OrganizationUpdate = {
   'name'?: types.Scalars['String'],
   'vatNumber'?: types.Scalars['String'] | null
 }
-export type OrganizationRawUpdate = () => UpdateFilter<Document>
+export type OrganizationRawUpdate = () => M.UpdateFilter<M.Document>
 
 export type OrganizationInsert = {
   address?: null | AddressInsert,
@@ -1283,17 +1282,17 @@ export type OrganizationInsert = {
   vatNumber?: null | types.Scalars['String'],
 }
 
-type OrganizationDAOGenerics<MetadataType, OperationMetadataType> = MongoDBDAOGenerics<types.Organization, 'id', 'ID', OrganizationFilter, OrganizationRawFilter, OrganizationRelations, OrganizationProjection, OrganizationSort, OrganizationRawSort, OrganizationInsert, OrganizationUpdate, OrganizationRawUpdate, OrganizationExcludedFields, OrganizationRelationFields, MetadataType, OperationMetadataType, types.Scalars, 'organization', DAOContext<MetadataType, OperationMetadataType>>
-export type OrganizationDAOParams<MetadataType, OperationMetadataType> = Omit<MongoDBDAOParams<OrganizationDAOGenerics<MetadataType, OperationMetadataType>>, 'idField' | 'schema' | 'idScalar' | 'idGeneration'>
-export type InMemoryOrganizationDAOParams<MetadataType, OperationMetadataType> = Omit<InMemoryDAOParams<OrganizationDAOGenerics<MetadataType, OperationMetadataType>>, 'idField' | 'schema' | 'idScalar' | 'idGeneration'>
+type OrganizationDAOGenerics<MetadataType, OperationMetadataType> = T.MongoDBDAOGenerics<types.Organization, 'id', 'ID', OrganizationFilter, OrganizationRawFilter, OrganizationRelations, OrganizationProjection, OrganizationSort, OrganizationRawSort, OrganizationInsert, OrganizationUpdate, OrganizationRawUpdate, OrganizationExcludedFields, OrganizationRelationFields, MetadataType, OperationMetadataType, types.Scalars, 'organization', DAOContext<MetadataType, OperationMetadataType>>
+export type OrganizationDAOParams<MetadataType, OperationMetadataType> = Omit<T.MongoDBDAOParams<OrganizationDAOGenerics<MetadataType, OperationMetadataType>>, 'idField' | 'schema' | 'idScalar' | 'idGeneration'>
+export type InMemoryOrganizationDAOParams<MetadataType, OperationMetadataType> = Omit<T.InMemoryDAOParams<OrganizationDAOGenerics<MetadataType, OperationMetadataType>>, 'idField' | 'schema' | 'idScalar' | 'idGeneration'>
 
-export class OrganizationDAO<MetadataType, OperationMetadataType> extends AbstractMongoDBDAO<OrganizationDAOGenerics<MetadataType, OperationMetadataType>> {  
+export class OrganizationDAO<MetadataType, OperationMetadataType> extends T.AbstractMongoDBDAO<OrganizationDAOGenerics<MetadataType, OperationMetadataType>> {  
   
   public static projection<P extends OrganizationProjection>(p: P) {
     return p
   }
-  public static mergeProjection<P1 extends OrganizationProjection, P2 extends OrganizationProjection>(p1: P1, p2: P2): SelectProjection<OrganizationProjection, P1, P2> {
-    return mergeProjections(p1, p2) as SelectProjection<OrganizationProjection, P1, P2>
+  public static mergeProjection<P1 extends OrganizationProjection, P2 extends OrganizationProjection>(p1: P1, p2: P2): T.SelectProjection<OrganizationProjection, P1, P2> {
+    return T.mergeProjections(p1, p2) as T.SelectProjection<OrganizationProjection, P1, P2>
   }
   
   public constructor(params: OrganizationDAOParams<MetadataType, OperationMetadataType>){
@@ -1301,7 +1300,7 @@ export class OrganizationDAO<MetadataType, OperationMetadataType> extends Abstra
       ...params, 
       idField: 'id', 
       schema: organizationSchema(), 
-      relations: overrideRelations(
+      relations: T.overrideRelations(
         [
           { type: '1-n', reference: 'foreign', field: 'address.cities', refFrom: 'addressId', refTo: 'address.id', dao: 'city', required: false }
         ]
@@ -1312,13 +1311,13 @@ export class OrganizationDAO<MetadataType, OperationMetadataType> extends Abstra
   }
   }
 
-export class InMemoryOrganizationDAO<MetadataType, OperationMetadataType> extends AbstractInMemoryDAO<OrganizationDAOGenerics<MetadataType, OperationMetadataType>> {  
+export class InMemoryOrganizationDAO<MetadataType, OperationMetadataType> extends T.AbstractInMemoryDAO<OrganizationDAOGenerics<MetadataType, OperationMetadataType>> {  
   
   public static projection<P extends OrganizationProjection>(p: P) {
     return p
   }
-  public static mergeProjection<P1 extends OrganizationProjection, P2 extends OrganizationProjection>(p1: P1, p2: P2): SelectProjection<OrganizationProjection, P1, P2> {
-    return mergeProjections(p1, p2) as SelectProjection<OrganizationProjection, P1, P2>
+  public static mergeProjection<P1 extends OrganizationProjection, P2 extends OrganizationProjection>(p1: P1, p2: P2): T.SelectProjection<OrganizationProjection, P1, P2> {
+    return T.mergeProjections(p1, p2) as T.SelectProjection<OrganizationProjection, P1, P2>
   }
   
   public constructor(params: InMemoryOrganizationDAOParams<MetadataType, OperationMetadataType>){
@@ -1326,7 +1325,7 @@ export class InMemoryOrganizationDAO<MetadataType, OperationMetadataType> extend
       ...params, 
       idField: 'id', 
       schema: organizationSchema(), 
-      relations: overrideRelations(
+      relations: T.overrideRelations(
         [
           { type: '1-n', reference: 'foreign', field: 'address.cities', refFrom: 'addressId', refTo: 'address.id', dao: 'city', required: false }
         ]
@@ -1346,7 +1345,7 @@ export class InMemoryOrganizationDAO<MetadataType, OperationMetadataType> extend
 export type PostExcludedFields = never
 export type PostRelationFields = 'author'
 
-export function postSchema(): Schema<types.Scalars> {
+export function postSchema(): T.Schema<types.Scalars> {
   return {
     'authorId': {
       scalar: 'ID', 
@@ -1376,17 +1375,17 @@ export function postSchema(): Schema<types.Scalars> {
 }
 
 type PostFilterFields = {
-  'authorId'?: types.Scalars['ID'] | null | EqualityOperators<types.Scalars['ID']> | ElementOperators,
-  'body'?: types.Scalars['String'] | null | EqualityOperators<types.Scalars['String']> | ElementOperators | StringOperators,
-  'clicks'?: types.Scalars['Int'] | null | EqualityOperators<types.Scalars['Int']> | ElementOperators | QuantityOperators<types.Scalars['Int']>,
-  'id'?: types.Scalars['ID'] | null | EqualityOperators<types.Scalars['ID']> | ElementOperators,
-  'metadata.region'?: types.Scalars['String'] | null | EqualityOperators<types.Scalars['String']> | ElementOperators | StringOperators,
-  'metadata.visible'?: types.Scalars['Boolean'] | null | EqualityOperators<types.Scalars['Boolean']> | ElementOperators,
-  'title'?: types.Scalars['String'] | null | EqualityOperators<types.Scalars['String']> | ElementOperators | StringOperators,
-  'views'?: types.Scalars['Int'] | null | EqualityOperators<types.Scalars['Int']> | ElementOperators | QuantityOperators<types.Scalars['Int']>
+  'authorId'?: types.Scalars['ID'] | null | T.EqualityOperators<types.Scalars['ID']> | T.ElementOperators,
+  'body'?: types.Scalars['String'] | null | T.EqualityOperators<types.Scalars['String']> | T.ElementOperators | T.StringOperators,
+  'clicks'?: types.Scalars['Int'] | null | T.EqualityOperators<types.Scalars['Int']> | T.ElementOperators | T.QuantityOperators<types.Scalars['Int']>,
+  'id'?: types.Scalars['ID'] | null | T.EqualityOperators<types.Scalars['ID']> | T.ElementOperators,
+  'metadata.region'?: types.Scalars['String'] | null | T.EqualityOperators<types.Scalars['String']> | T.ElementOperators | T.StringOperators,
+  'metadata.visible'?: types.Scalars['Boolean'] | null | T.EqualityOperators<types.Scalars['Boolean']> | T.ElementOperators,
+  'title'?: types.Scalars['String'] | null | T.EqualityOperators<types.Scalars['String']> | T.ElementOperators | T.StringOperators,
+  'views'?: types.Scalars['Int'] | null | T.EqualityOperators<types.Scalars['Int']> | T.ElementOperators | T.QuantityOperators<types.Scalars['Int']>
 }
-export type PostFilter = PostFilterFields & LogicalOperators<PostFilterFields | PostRawFilter>
-export type PostRawFilter = () => Filter<Document>
+export type PostFilter = PostFilterFields & T.LogicalOperators<PostFilterFields | PostRawFilter>
+export type PostRawFilter = () => M.Filter<M.Document>
 
 export type PostRelations = Record<never, string>
 
@@ -1403,11 +1402,11 @@ export type PostProjection = {
   title?: boolean,
   views?: boolean,
 }
-export type PostParam<P extends PostProjection> = ParamProjection<types.Post, PostProjection, P>
+export type PostParam<P extends PostProjection> = T.ParamProjection<types.Post, PostProjection, P>
 
 export type PostSortKeys = 'authorId' | 'body' | 'clicks' | 'id' | 'metadata.region' | 'metadata.visible' | 'title' | 'views'
-export type PostSort = OneKey<PostSortKeys, SortDirection>
-export type PostRawSort = () => Sort
+export type PostSort = T.OneKey<PostSortKeys, T.SortDirection>
+export type PostRawSort = () => M.Sort
 
 export type PostUpdate = {
   'authorId'?: types.Scalars['ID'],
@@ -1420,7 +1419,7 @@ export type PostUpdate = {
   'title'?: types.Scalars['String'],
   'views'?: types.Scalars['Int']
 }
-export type PostRawUpdate = () => UpdateFilter<Document>
+export type PostRawUpdate = () => M.UpdateFilter<M.Document>
 
 export type PostInsert = {
   authorId: types.Scalars['ID'],
@@ -1432,17 +1431,17 @@ export type PostInsert = {
   views: types.Scalars['Int'],
 }
 
-type PostDAOGenerics<MetadataType, OperationMetadataType> = MongoDBDAOGenerics<types.Post, 'id', 'ID', PostFilter, PostRawFilter, PostRelations, PostProjection, PostSort, PostRawSort, PostInsert, PostUpdate, PostRawUpdate, PostExcludedFields, PostRelationFields, MetadataType, OperationMetadataType, types.Scalars, 'post', DAOContext<MetadataType, OperationMetadataType>>
-export type PostDAOParams<MetadataType, OperationMetadataType> = Omit<MongoDBDAOParams<PostDAOGenerics<MetadataType, OperationMetadataType>>, 'idField' | 'schema' | 'idScalar' | 'idGeneration'>
-export type InMemoryPostDAOParams<MetadataType, OperationMetadataType> = Omit<InMemoryDAOParams<PostDAOGenerics<MetadataType, OperationMetadataType>>, 'idField' | 'schema' | 'idScalar' | 'idGeneration'>
+type PostDAOGenerics<MetadataType, OperationMetadataType> = T.MongoDBDAOGenerics<types.Post, 'id', 'ID', PostFilter, PostRawFilter, PostRelations, PostProjection, PostSort, PostRawSort, PostInsert, PostUpdate, PostRawUpdate, PostExcludedFields, PostRelationFields, MetadataType, OperationMetadataType, types.Scalars, 'post', DAOContext<MetadataType, OperationMetadataType>>
+export type PostDAOParams<MetadataType, OperationMetadataType> = Omit<T.MongoDBDAOParams<PostDAOGenerics<MetadataType, OperationMetadataType>>, 'idField' | 'schema' | 'idScalar' | 'idGeneration'>
+export type InMemoryPostDAOParams<MetadataType, OperationMetadataType> = Omit<T.InMemoryDAOParams<PostDAOGenerics<MetadataType, OperationMetadataType>>, 'idField' | 'schema' | 'idScalar' | 'idGeneration'>
 
-export class PostDAO<MetadataType, OperationMetadataType> extends AbstractMongoDBDAO<PostDAOGenerics<MetadataType, OperationMetadataType>> {  
+export class PostDAO<MetadataType, OperationMetadataType> extends T.AbstractMongoDBDAO<PostDAOGenerics<MetadataType, OperationMetadataType>> {  
   
   public static projection<P extends PostProjection>(p: P) {
     return p
   }
-  public static mergeProjection<P1 extends PostProjection, P2 extends PostProjection>(p1: P1, p2: P2): SelectProjection<PostProjection, P1, P2> {
-    return mergeProjections(p1, p2) as SelectProjection<PostProjection, P1, P2>
+  public static mergeProjection<P1 extends PostProjection, P2 extends PostProjection>(p1: P1, p2: P2): T.SelectProjection<PostProjection, P1, P2> {
+    return T.mergeProjections(p1, p2) as T.SelectProjection<PostProjection, P1, P2>
   }
   
   public constructor(params: PostDAOParams<MetadataType, OperationMetadataType>){
@@ -1450,7 +1449,7 @@ export class PostDAO<MetadataType, OperationMetadataType> extends AbstractMongoD
       ...params, 
       idField: 'id', 
       schema: postSchema(), 
-      relations: overrideRelations(
+      relations: T.overrideRelations(
         [
           { type: '1-1', reference: 'inner', field: 'author', refFrom: 'authorId', refTo: 'id', dao: 'user', required: true }
         ]
@@ -1461,13 +1460,13 @@ export class PostDAO<MetadataType, OperationMetadataType> extends AbstractMongoD
   }
   }
 
-export class InMemoryPostDAO<MetadataType, OperationMetadataType> extends AbstractInMemoryDAO<PostDAOGenerics<MetadataType, OperationMetadataType>> {  
+export class InMemoryPostDAO<MetadataType, OperationMetadataType> extends T.AbstractInMemoryDAO<PostDAOGenerics<MetadataType, OperationMetadataType>> {  
   
   public static projection<P extends PostProjection>(p: P) {
     return p
   }
-  public static mergeProjection<P1 extends PostProjection, P2 extends PostProjection>(p1: P1, p2: P2): SelectProjection<PostProjection, P1, P2> {
-    return mergeProjections(p1, p2) as SelectProjection<PostProjection, P1, P2>
+  public static mergeProjection<P1 extends PostProjection, P2 extends PostProjection>(p1: P1, p2: P2): T.SelectProjection<PostProjection, P1, P2> {
+    return T.mergeProjections(p1, p2) as T.SelectProjection<PostProjection, P1, P2>
   }
   
   public constructor(params: InMemoryPostDAOParams<MetadataType, OperationMetadataType>){
@@ -1475,7 +1474,7 @@ export class InMemoryPostDAO<MetadataType, OperationMetadataType> extends Abstra
       ...params, 
       idField: 'id', 
       schema: postSchema(), 
-      relations: overrideRelations(
+      relations: T.overrideRelations(
         [
           { type: '1-1', reference: 'inner', field: 'author', refFrom: 'authorId', refTo: 'id', dao: 'user', required: true }
         ]
@@ -1492,7 +1491,7 @@ export class InMemoryPostDAO<MetadataType, OperationMetadataType> extends Abstra
 //--------------------------------- POSTMETADATA ---------------------------------
 //--------------------------------------------------------------------------------
 
-export function postMetadataSchema(): Schema<types.Scalars> {
+export function postMetadataSchema(): T.Schema<types.Scalars> {
   return {
     'region': {
       scalar: 'String', 
@@ -1509,7 +1508,7 @@ export type PostMetadataProjection = {
   region?: boolean,
   visible?: boolean,
 }
-export type PostMetadataParam<P extends PostMetadataProjection> = ParamProjection<types.PostMetadata, PostMetadataProjection, P>
+export type PostMetadataParam<P extends PostMetadataProjection> = T.ParamProjection<types.PostMetadata, PostMetadataProjection, P>
 
 export type PostMetadataInsert = {
   region: types.Scalars['String'],
@@ -1525,7 +1524,7 @@ export type PostMetadataInsert = {
 export type UserExcludedFields = never
 export type UserRelationFields = 'dogs' | 'friends'
 
-export function userSchema(): Schema<types.Scalars> {
+export function userSchema(): T.Schema<types.Scalars> {
   return {
     'amount': {
       scalar: 'Decimal'
@@ -1572,31 +1571,31 @@ export function userSchema(): Schema<types.Scalars> {
 }
 
 type UserFilterFields = {
-  'amount'?: types.Scalars['Decimal'] | null | EqualityOperators<types.Scalars['Decimal']> | ElementOperators,
-  'amounts'?: types.Scalars['Decimal'][] | null | EqualityOperators<types.Scalars['Decimal'][]> | ElementOperators,
-  'credentials.password'?: types.Scalars['Password'] | null | EqualityOperators<types.Scalars['Password']> | ElementOperators,
-  'credentials.username'?: types.Scalars['String'] | null | EqualityOperators<types.Scalars['String']> | ElementOperators | StringOperators,
-  'embeddedPost.authorId'?: types.Scalars['ID'] | null | EqualityOperators<types.Scalars['ID']> | ElementOperators,
-  'embeddedPost.body'?: types.Scalars['String'] | null | EqualityOperators<types.Scalars['String']> | ElementOperators | StringOperators,
-  'embeddedPost.clicks'?: types.Scalars['Int'] | null | EqualityOperators<types.Scalars['Int']> | ElementOperators | QuantityOperators<types.Scalars['Int']>,
-  'embeddedPost.id'?: types.Scalars['ID'] | null | EqualityOperators<types.Scalars['ID']> | ElementOperators,
-  'embeddedPost.metadata.region'?: types.Scalars['String'] | null | EqualityOperators<types.Scalars['String']> | ElementOperators | StringOperators,
-  'embeddedPost.metadata.visible'?: types.Scalars['Boolean'] | null | EqualityOperators<types.Scalars['Boolean']> | ElementOperators,
-  'embeddedPost.title'?: types.Scalars['String'] | null | EqualityOperators<types.Scalars['String']> | ElementOperators | StringOperators,
-  'embeddedPost.views'?: types.Scalars['Int'] | null | EqualityOperators<types.Scalars['Int']> | ElementOperators | QuantityOperators<types.Scalars['Int']>,
-  'firstName'?: types.Scalars['String'] | null | EqualityOperators<types.Scalars['String']> | ElementOperators | StringOperators,
-  'friendsId'?: types.Scalars['ID'][] | null | EqualityOperators<types.Scalars['ID'][]> | ElementOperators,
-  'id'?: types.Scalars['ID'] | null | EqualityOperators<types.Scalars['ID']> | ElementOperators,
-  'int'?: types.Scalars['Int'] | null | EqualityOperators<types.Scalars['Int']> | ElementOperators | QuantityOperators<types.Scalars['Int']>,
-  'lastName'?: types.Scalars['String'] | null | EqualityOperators<types.Scalars['String']> | ElementOperators | StringOperators,
-  'live'?: types.Scalars['Boolean'] | null | EqualityOperators<types.Scalars['Boolean']> | ElementOperators,
-  'localization'?: types.Scalars['Coordinates'] | null | EqualityOperators<types.Scalars['Coordinates']> | ElementOperators,
-  'title'?: types.Scalars['LocalizedString'] | null | EqualityOperators<types.Scalars['LocalizedString']> | ElementOperators,
-  'usernamePasswordCredentials.password'?: types.Scalars['Password'] | null | EqualityOperators<types.Scalars['Password']> | ElementOperators,
-  'usernamePasswordCredentials.username'?: types.Scalars['String'] | null | EqualityOperators<types.Scalars['String']> | ElementOperators | StringOperators
+  'amount'?: types.Scalars['Decimal'] | null | T.EqualityOperators<types.Scalars['Decimal']> | T.ElementOperators,
+  'amounts'?: types.Scalars['Decimal'][] | null | T.EqualityOperators<types.Scalars['Decimal'][]> | T.ElementOperators,
+  'credentials.password'?: types.Scalars['Password'] | null | T.EqualityOperators<types.Scalars['Password']> | T.ElementOperators,
+  'credentials.username'?: types.Scalars['String'] | null | T.EqualityOperators<types.Scalars['String']> | T.ElementOperators | T.StringOperators,
+  'embeddedPost.authorId'?: types.Scalars['ID'] | null | T.EqualityOperators<types.Scalars['ID']> | T.ElementOperators,
+  'embeddedPost.body'?: types.Scalars['String'] | null | T.EqualityOperators<types.Scalars['String']> | T.ElementOperators | T.StringOperators,
+  'embeddedPost.clicks'?: types.Scalars['Int'] | null | T.EqualityOperators<types.Scalars['Int']> | T.ElementOperators | T.QuantityOperators<types.Scalars['Int']>,
+  'embeddedPost.id'?: types.Scalars['ID'] | null | T.EqualityOperators<types.Scalars['ID']> | T.ElementOperators,
+  'embeddedPost.metadata.region'?: types.Scalars['String'] | null | T.EqualityOperators<types.Scalars['String']> | T.ElementOperators | T.StringOperators,
+  'embeddedPost.metadata.visible'?: types.Scalars['Boolean'] | null | T.EqualityOperators<types.Scalars['Boolean']> | T.ElementOperators,
+  'embeddedPost.title'?: types.Scalars['String'] | null | T.EqualityOperators<types.Scalars['String']> | T.ElementOperators | T.StringOperators,
+  'embeddedPost.views'?: types.Scalars['Int'] | null | T.EqualityOperators<types.Scalars['Int']> | T.ElementOperators | T.QuantityOperators<types.Scalars['Int']>,
+  'firstName'?: types.Scalars['String'] | null | T.EqualityOperators<types.Scalars['String']> | T.ElementOperators | T.StringOperators,
+  'friendsId'?: types.Scalars['ID'][] | null | T.EqualityOperators<types.Scalars['ID'][]> | T.ElementOperators,
+  'id'?: types.Scalars['ID'] | null | T.EqualityOperators<types.Scalars['ID']> | T.ElementOperators,
+  'int'?: types.Scalars['Int'] | null | T.EqualityOperators<types.Scalars['Int']> | T.ElementOperators | T.QuantityOperators<types.Scalars['Int']>,
+  'lastName'?: types.Scalars['String'] | null | T.EqualityOperators<types.Scalars['String']> | T.ElementOperators | T.StringOperators,
+  'live'?: types.Scalars['Boolean'] | null | T.EqualityOperators<types.Scalars['Boolean']> | T.ElementOperators,
+  'localization'?: types.Scalars['Coordinates'] | null | T.EqualityOperators<types.Scalars['Coordinates']> | T.ElementOperators,
+  'title'?: types.Scalars['LocalizedString'] | null | T.EqualityOperators<types.Scalars['LocalizedString']> | T.ElementOperators,
+  'usernamePasswordCredentials.password'?: types.Scalars['Password'] | null | T.EqualityOperators<types.Scalars['Password']> | T.ElementOperators,
+  'usernamePasswordCredentials.username'?: types.Scalars['String'] | null | T.EqualityOperators<types.Scalars['String']> | T.ElementOperators | T.StringOperators
 }
-export type UserFilter = UserFilterFields & LogicalOperators<UserFilterFields | UserRawFilter>
-export type UserRawFilter = () => Filter<Document>
+export type UserFilter = UserFilterFields & T.LogicalOperators<UserFilterFields | UserRawFilter>
+export type UserRawFilter = () => M.Filter<M.Document>
 
 export type UserRelations = {
   dogs?: {
@@ -1650,11 +1649,11 @@ export type UserProjection = {
     username?: boolean,
   } | boolean,
 }
-export type UserParam<P extends UserProjection> = ParamProjection<types.User, UserProjection, P>
+export type UserParam<P extends UserProjection> = T.ParamProjection<types.User, UserProjection, P>
 
 export type UserSortKeys = 'amount' | 'amounts' | 'credentials.password' | 'credentials.username' | 'embeddedPost.authorId' | 'embeddedPost.body' | 'embeddedPost.clicks' | 'embeddedPost.id' | 'embeddedPost.metadata.region' | 'embeddedPost.metadata.visible' | 'embeddedPost.title' | 'embeddedPost.views' | 'firstName' | 'friendsId' | 'id' | 'int' | 'lastName' | 'live' | 'localization' | 'title' | 'usernamePasswordCredentials.password' | 'usernamePasswordCredentials.username'
-export type UserSort = OneKey<UserSortKeys, SortDirection>
-export type UserRawSort = () => Sort
+export type UserSort = T.OneKey<UserSortKeys, T.SortDirection>
+export type UserRawSort = () => M.Sort
 
 export type UserUpdate = {
   'amount'?: types.Scalars['Decimal'] | null,
@@ -1682,7 +1681,7 @@ export type UserUpdate = {
   'usernamePasswordCredentials.password'?: types.Scalars['Password'],
   'usernamePasswordCredentials.username'?: types.Scalars['String']
 }
-export type UserRawUpdate = () => UpdateFilter<Document>
+export type UserRawUpdate = () => M.UpdateFilter<M.Document>
 
 export type UserInsert = {
   amount?: null | types.Scalars['Decimal'],
@@ -1700,17 +1699,17 @@ export type UserInsert = {
   usernamePasswordCredentials?: null | UsernamePasswordCredentialsInsert,
 }
 
-type UserDAOGenerics<MetadataType, OperationMetadataType> = MongoDBDAOGenerics<types.User, 'id', 'ID', UserFilter, UserRawFilter, UserRelations, UserProjection, UserSort, UserRawSort, UserInsert, UserUpdate, UserRawUpdate, UserExcludedFields, UserRelationFields, MetadataType, OperationMetadataType, types.Scalars, 'user', DAOContext<MetadataType, OperationMetadataType>>
-export type UserDAOParams<MetadataType, OperationMetadataType> = Omit<MongoDBDAOParams<UserDAOGenerics<MetadataType, OperationMetadataType>>, 'idField' | 'schema' | 'idScalar' | 'idGeneration'>
-export type InMemoryUserDAOParams<MetadataType, OperationMetadataType> = Omit<InMemoryDAOParams<UserDAOGenerics<MetadataType, OperationMetadataType>>, 'idField' | 'schema' | 'idScalar' | 'idGeneration'>
+type UserDAOGenerics<MetadataType, OperationMetadataType> = T.MongoDBDAOGenerics<types.User, 'id', 'ID', UserFilter, UserRawFilter, UserRelations, UserProjection, UserSort, UserRawSort, UserInsert, UserUpdate, UserRawUpdate, UserExcludedFields, UserRelationFields, MetadataType, OperationMetadataType, types.Scalars, 'user', DAOContext<MetadataType, OperationMetadataType>>
+export type UserDAOParams<MetadataType, OperationMetadataType> = Omit<T.MongoDBDAOParams<UserDAOGenerics<MetadataType, OperationMetadataType>>, 'idField' | 'schema' | 'idScalar' | 'idGeneration'>
+export type InMemoryUserDAOParams<MetadataType, OperationMetadataType> = Omit<T.InMemoryDAOParams<UserDAOGenerics<MetadataType, OperationMetadataType>>, 'idField' | 'schema' | 'idScalar' | 'idGeneration'>
 
-export class UserDAO<MetadataType, OperationMetadataType> extends AbstractMongoDBDAO<UserDAOGenerics<MetadataType, OperationMetadataType>> {  
+export class UserDAO<MetadataType, OperationMetadataType> extends T.AbstractMongoDBDAO<UserDAOGenerics<MetadataType, OperationMetadataType>> {  
   
   public static projection<P extends UserProjection>(p: P) {
     return p
   }
-  public static mergeProjection<P1 extends UserProjection, P2 extends UserProjection>(p1: P1, p2: P2): SelectProjection<UserProjection, P1, P2> {
-    return mergeProjections(p1, p2) as SelectProjection<UserProjection, P1, P2>
+  public static mergeProjection<P1 extends UserProjection, P2 extends UserProjection>(p1: P1, p2: P2): T.SelectProjection<UserProjection, P1, P2> {
+    return T.mergeProjections(p1, p2) as T.SelectProjection<UserProjection, P1, P2>
   }
   
   public constructor(params: UserDAOParams<MetadataType, OperationMetadataType>){
@@ -1718,7 +1717,7 @@ export class UserDAO<MetadataType, OperationMetadataType> extends AbstractMongoD
       ...params, 
       idField: 'id', 
       schema: userSchema(), 
-      relations: overrideRelations(
+      relations: T.overrideRelations(
         [
           { type: '1-n', reference: 'foreign', field: 'dogs', refFrom: 'ownerId', refTo: 'id', dao: 'dog', required: false },
           { type: '1-1', reference: 'inner', field: 'embeddedPost.author', refFrom: 'embeddedPost.authorId', refTo: 'id', dao: 'user', required: true },
@@ -1731,13 +1730,13 @@ export class UserDAO<MetadataType, OperationMetadataType> extends AbstractMongoD
   }
   }
 
-export class InMemoryUserDAO<MetadataType, OperationMetadataType> extends AbstractInMemoryDAO<UserDAOGenerics<MetadataType, OperationMetadataType>> {  
+export class InMemoryUserDAO<MetadataType, OperationMetadataType> extends T.AbstractInMemoryDAO<UserDAOGenerics<MetadataType, OperationMetadataType>> {  
   
   public static projection<P extends UserProjection>(p: P) {
     return p
   }
-  public static mergeProjection<P1 extends UserProjection, P2 extends UserProjection>(p1: P1, p2: P2): SelectProjection<UserProjection, P1, P2> {
-    return mergeProjections(p1, p2) as SelectProjection<UserProjection, P1, P2>
+  public static mergeProjection<P1 extends UserProjection, P2 extends UserProjection>(p1: P1, p2: P2): T.SelectProjection<UserProjection, P1, P2> {
+    return T.mergeProjections(p1, p2) as T.SelectProjection<UserProjection, P1, P2>
   }
   
   public constructor(params: InMemoryUserDAOParams<MetadataType, OperationMetadataType>){
@@ -1745,7 +1744,7 @@ export class InMemoryUserDAO<MetadataType, OperationMetadataType> extends Abstra
       ...params, 
       idField: 'id', 
       schema: userSchema(), 
-      relations: overrideRelations(
+      relations: T.overrideRelations(
         [
           { type: '1-n', reference: 'foreign', field: 'dogs', refFrom: 'ownerId', refTo: 'id', dao: 'dog', required: false },
           { type: '1-1', reference: 'inner', field: 'embeddedPost.author', refFrom: 'embeddedPost.authorId', refTo: 'id', dao: 'user', required: true },
@@ -1764,7 +1763,7 @@ export class InMemoryUserDAO<MetadataType, OperationMetadataType> extends Abstra
 //-------------------------------- USERCOLLECTION --------------------------------
 //--------------------------------------------------------------------------------
 
-export function userCollectionSchema(): Schema<types.Scalars> {
+export function userCollectionSchema(): T.Schema<types.Scalars> {
   return {
     'usersId': {
       scalar: 'ID', 
@@ -1778,7 +1777,7 @@ export type UserCollectionProjection = {
   users?: UserProjection | boolean,
   usersId?: boolean,
 }
-export type UserCollectionParam<P extends UserCollectionProjection> = ParamProjection<types.UserCollection, UserCollectionProjection, P>
+export type UserCollectionParam<P extends UserCollectionProjection> = T.ParamProjection<types.UserCollection, UserCollectionProjection, P>
 
 export type UserCollectionInsert = {
   usersId: types.Scalars['ID'][],
@@ -1790,7 +1789,7 @@ export type UserCollectionInsert = {
 //------------------------- USERNAMEPASSWORDCREDENTIALS --------------------------
 //--------------------------------------------------------------------------------
 
-export function usernamePasswordCredentialsSchema(): Schema<types.Scalars> {
+export function usernamePasswordCredentialsSchema(): T.Schema<types.Scalars> {
   return {
     'password': {
       scalar: 'Password', 
@@ -1809,7 +1808,7 @@ export type UsernamePasswordCredentialsProjection = {
   password?: boolean,
   username?: boolean,
 }
-export type UsernamePasswordCredentialsParam<P extends UsernamePasswordCredentialsProjection> = ParamProjection<types.UsernamePasswordCredentials, UsernamePasswordCredentialsProjection, P>
+export type UsernamePasswordCredentialsParam<P extends UsernamePasswordCredentialsProjection> = T.ParamProjection<types.UsernamePasswordCredentials, UsernamePasswordCredentialsProjection, P>
 
 export type UsernamePasswordCredentialsInsert = {
   password: types.Scalars['Password'],
@@ -1833,15 +1832,15 @@ export type DAOContextParams<MetadataType, OperationMetadataType, Permissions ex
     post?: Pick<Partial<PostDAOParams<MetadataType, OperationMetadataType>>, 'idGenerator' | 'middlewares' | 'metadata'>,
     user?: Pick<Partial<UserDAOParams<MetadataType, OperationMetadataType>>, 'idGenerator' | 'middlewares' | 'metadata'>
   },
-  mongodb: Record<'default', Db | 'mock'>,
-  scalars?: UserInputDriverDataTypeAdapterMap<types.Scalars, 'mongo'>,
-  log?: LogInput<'address' | 'audit' | 'city' | 'defaultFieldsEntity' | 'device' | 'dog' | 'hotel' | 'mockedEntity' | 'organization' | 'post' | 'user'>,
-  security?: DAOContextSecurtyPolicy<DAOGenericsMap<MetadataType, OperationMetadataType>, OperationMetadataType, Permissions, SecurityDomain>
+  mongodb: Record<'default', M.Db | 'mock'>,
+  scalars?: T.UserInputDriverDataTypeAdapterMap<types.Scalars, 'mongo'>,
+  log?: T.LogInput<'address' | 'audit' | 'city' | 'defaultFieldsEntity' | 'device' | 'dog' | 'hotel' | 'mockedEntity' | 'organization' | 'post' | 'user'>,
+  security?: T.DAOContextSecurtyPolicy<DAOGenericsMap<MetadataType, OperationMetadataType>, OperationMetadataType, Permissions, SecurityDomain>
 }
 
-type DAOContextMiddleware<MetadataType = never, OperationMetadataType = never> = DAOMiddleware<DAOGenericsUnion<MetadataType, OperationMetadataType>>
+type DAOContextMiddleware<MetadataType = never, OperationMetadataType = never> = T.DAOMiddleware<DAOGenericsUnion<MetadataType, OperationMetadataType>>
 
-export class DAOContext<MetadataType = never, OperationMetadataType = never, Permissions extends string = never, SecurityDomain extends object = never> extends AbstractDAOContext<'default', never, types.Scalars, MetadataType>  {
+export class DAOContext<MetadataType = never, OperationMetadataType = never, Permissions extends string = never, SecurityDomain extends object = never> extends T.AbstractDAOContext<'default', never, types.Scalars, MetadataType>  {
 
   private _address: AddressDAO<MetadataType, OperationMetadataType> | undefined
   private _audit: AuditDAO<MetadataType, OperationMetadataType> | undefined
@@ -1858,85 +1857,85 @@ export class DAOContext<MetadataType = never, OperationMetadataType = never, Per
   private params: DAOContextParams<MetadataType, OperationMetadataType, Permissions, SecurityDomain>
   
   private overrides: DAOContextParams<MetadataType, OperationMetadataType, Permissions, SecurityDomain>['overrides']
-  private mongodb: Record<'default', Db | 'mock'>
+  private mongodb: Record<'default', M.Db | 'mock'>
   
   private middlewares: (DAOContextMiddleware<MetadataType, OperationMetadataType> | GroupMiddleware<any, MetadataType, OperationMetadataType>)[]
   
-  private logger?: LogFunction<'address' | 'audit' | 'city' | 'defaultFieldsEntity' | 'device' | 'dog' | 'hotel' | 'mockedEntity' | 'organization' | 'post' | 'user'>
+  private logger?: T.LogFunction<'address' | 'audit' | 'city' | 'defaultFieldsEntity' | 'device' | 'dog' | 'hotel' | 'mockedEntity' | 'organization' | 'post' | 'user'>
   
   get address(): AddressDAO<MetadataType, OperationMetadataType> {
     if(!this._address) {
       const db = this.mongodb.default
-      this._address = db === 'mock' ? (new InMemoryAddressDAO({ daoContext: this, datasource: null, metadata: this.metadata, ...this.overrides?.address, middlewares: [...(this.overrides?.address?.middlewares || []), ...selectMiddleware('address', this.middlewares) as DAOMiddleware<AddressDAOGenerics<MetadataType, OperationMetadataType>>[]], name: 'address', logger: this.logger }) as unknown as AddressDAO<MetadataType, OperationMetadataType>) : new AddressDAO({ daoContext: this, datasource: 'default', metadata: this.metadata, ...this.overrides?.address, collection: db.collection('addresses'), middlewares: [...(this.overrides?.address?.middlewares || []), ...selectMiddleware('address', this.middlewares) as DAOMiddleware<AddressDAOGenerics<MetadataType, OperationMetadataType>>[]], name: 'address', logger: this.logger })
+      this._address = db === 'mock' ? (new InMemoryAddressDAO({ daoContext: this, datasource: null, metadata: this.metadata, ...this.overrides?.address, middlewares: [...(this.overrides?.address?.middlewares || []), ...selectMiddleware('address', this.middlewares) as T.DAOMiddleware<AddressDAOGenerics<MetadataType, OperationMetadataType>>[]], name: 'address', logger: this.logger }) as unknown as AddressDAO<MetadataType, OperationMetadataType>) : new AddressDAO({ daoContext: this, datasource: 'default', metadata: this.metadata, ...this.overrides?.address, collection: db.collection('addresses'), middlewares: [...(this.overrides?.address?.middlewares || []), ...selectMiddleware('address', this.middlewares) as T.DAOMiddleware<AddressDAOGenerics<MetadataType, OperationMetadataType>>[]], name: 'address', logger: this.logger })
     }
     return this._address
   }
   get audit(): AuditDAO<MetadataType, OperationMetadataType> {
     if(!this._audit) {
       const db = this.mongodb.default
-      this._audit = db === 'mock' ? (new InMemoryAuditDAO({ daoContext: this, datasource: null, metadata: this.metadata, ...this.overrides?.audit, middlewares: [...(this.overrides?.audit?.middlewares || []), ...selectMiddleware('audit', this.middlewares) as DAOMiddleware<AuditDAOGenerics<MetadataType, OperationMetadataType>>[]], name: 'audit', logger: this.logger }) as unknown as AuditDAO<MetadataType, OperationMetadataType>) : new AuditDAO({ daoContext: this, datasource: 'default', metadata: this.metadata, ...this.overrides?.audit, collection: db.collection('audits'), middlewares: [...(this.overrides?.audit?.middlewares || []), ...selectMiddleware('audit', this.middlewares) as DAOMiddleware<AuditDAOGenerics<MetadataType, OperationMetadataType>>[]], name: 'audit', logger: this.logger })
+      this._audit = db === 'mock' ? (new InMemoryAuditDAO({ daoContext: this, datasource: null, metadata: this.metadata, ...this.overrides?.audit, middlewares: [...(this.overrides?.audit?.middlewares || []), ...selectMiddleware('audit', this.middlewares) as T.DAOMiddleware<AuditDAOGenerics<MetadataType, OperationMetadataType>>[]], name: 'audit', logger: this.logger }) as unknown as AuditDAO<MetadataType, OperationMetadataType>) : new AuditDAO({ daoContext: this, datasource: 'default', metadata: this.metadata, ...this.overrides?.audit, collection: db.collection('audits'), middlewares: [...(this.overrides?.audit?.middlewares || []), ...selectMiddleware('audit', this.middlewares) as T.DAOMiddleware<AuditDAOGenerics<MetadataType, OperationMetadataType>>[]], name: 'audit', logger: this.logger })
     }
     return this._audit
   }
   get city(): CityDAO<MetadataType, OperationMetadataType> {
     if(!this._city) {
       const db = this.mongodb.default
-      this._city = db === 'mock' ? (new InMemoryCityDAO({ daoContext: this, datasource: null, metadata: this.metadata, ...this.overrides?.city, middlewares: [...(this.overrides?.city?.middlewares || []), ...selectMiddleware('city', this.middlewares) as DAOMiddleware<CityDAOGenerics<MetadataType, OperationMetadataType>>[]], name: 'city', logger: this.logger }) as unknown as CityDAO<MetadataType, OperationMetadataType>) : new CityDAO({ daoContext: this, datasource: 'default', metadata: this.metadata, ...this.overrides?.city, collection: db.collection('citys'), middlewares: [...(this.overrides?.city?.middlewares || []), ...selectMiddleware('city', this.middlewares) as DAOMiddleware<CityDAOGenerics<MetadataType, OperationMetadataType>>[]], name: 'city', logger: this.logger })
+      this._city = db === 'mock' ? (new InMemoryCityDAO({ daoContext: this, datasource: null, metadata: this.metadata, ...this.overrides?.city, middlewares: [...(this.overrides?.city?.middlewares || []), ...selectMiddleware('city', this.middlewares) as T.DAOMiddleware<CityDAOGenerics<MetadataType, OperationMetadataType>>[]], name: 'city', logger: this.logger }) as unknown as CityDAO<MetadataType, OperationMetadataType>) : new CityDAO({ daoContext: this, datasource: 'default', metadata: this.metadata, ...this.overrides?.city, collection: db.collection('citys'), middlewares: [...(this.overrides?.city?.middlewares || []), ...selectMiddleware('city', this.middlewares) as T.DAOMiddleware<CityDAOGenerics<MetadataType, OperationMetadataType>>[]], name: 'city', logger: this.logger })
     }
     return this._city
   }
   get defaultFieldsEntity(): DefaultFieldsEntityDAO<MetadataType, OperationMetadataType> {
     if(!this._defaultFieldsEntity) {
       const db = this.mongodb.default
-      this._defaultFieldsEntity = db === 'mock' ? (new InMemoryDefaultFieldsEntityDAO({ daoContext: this, datasource: null, metadata: this.metadata, ...this.overrides?.defaultFieldsEntity, middlewares: [...(this.overrides?.defaultFieldsEntity?.middlewares || []), ...selectMiddleware('defaultFieldsEntity', this.middlewares) as DAOMiddleware<DefaultFieldsEntityDAOGenerics<MetadataType, OperationMetadataType>>[]], name: 'defaultFieldsEntity', logger: this.logger }) as unknown as DefaultFieldsEntityDAO<MetadataType, OperationMetadataType>) : new DefaultFieldsEntityDAO({ daoContext: this, datasource: 'default', metadata: this.metadata, ...this.overrides?.defaultFieldsEntity, collection: db.collection('defaultFieldsEntitys'), middlewares: [...(this.overrides?.defaultFieldsEntity?.middlewares || []), ...selectMiddleware('defaultFieldsEntity', this.middlewares) as DAOMiddleware<DefaultFieldsEntityDAOGenerics<MetadataType, OperationMetadataType>>[]], name: 'defaultFieldsEntity', logger: this.logger })
+      this._defaultFieldsEntity = db === 'mock' ? (new InMemoryDefaultFieldsEntityDAO({ daoContext: this, datasource: null, metadata: this.metadata, ...this.overrides?.defaultFieldsEntity, middlewares: [...(this.overrides?.defaultFieldsEntity?.middlewares || []), ...selectMiddleware('defaultFieldsEntity', this.middlewares) as T.DAOMiddleware<DefaultFieldsEntityDAOGenerics<MetadataType, OperationMetadataType>>[]], name: 'defaultFieldsEntity', logger: this.logger }) as unknown as DefaultFieldsEntityDAO<MetadataType, OperationMetadataType>) : new DefaultFieldsEntityDAO({ daoContext: this, datasource: 'default', metadata: this.metadata, ...this.overrides?.defaultFieldsEntity, collection: db.collection('defaultFieldsEntitys'), middlewares: [...(this.overrides?.defaultFieldsEntity?.middlewares || []), ...selectMiddleware('defaultFieldsEntity', this.middlewares) as T.DAOMiddleware<DefaultFieldsEntityDAOGenerics<MetadataType, OperationMetadataType>>[]], name: 'defaultFieldsEntity', logger: this.logger })
     }
     return this._defaultFieldsEntity
   }
   get device(): DeviceDAO<MetadataType, OperationMetadataType> {
     if(!this._device) {
       const db = this.mongodb.default
-      this._device = db === 'mock' ? (new InMemoryDeviceDAO({ daoContext: this, datasource: null, metadata: this.metadata, ...this.overrides?.device, middlewares: [...(this.overrides?.device?.middlewares || []), ...selectMiddleware('device', this.middlewares) as DAOMiddleware<DeviceDAOGenerics<MetadataType, OperationMetadataType>>[]], name: 'device', logger: this.logger }) as unknown as DeviceDAO<MetadataType, OperationMetadataType>) : new DeviceDAO({ daoContext: this, datasource: 'default', metadata: this.metadata, ...this.overrides?.device, collection: db.collection('devices'), middlewares: [...(this.overrides?.device?.middlewares || []), ...selectMiddleware('device', this.middlewares) as DAOMiddleware<DeviceDAOGenerics<MetadataType, OperationMetadataType>>[]], name: 'device', logger: this.logger })
+      this._device = db === 'mock' ? (new InMemoryDeviceDAO({ daoContext: this, datasource: null, metadata: this.metadata, ...this.overrides?.device, middlewares: [...(this.overrides?.device?.middlewares || []), ...selectMiddleware('device', this.middlewares) as T.DAOMiddleware<DeviceDAOGenerics<MetadataType, OperationMetadataType>>[]], name: 'device', logger: this.logger }) as unknown as DeviceDAO<MetadataType, OperationMetadataType>) : new DeviceDAO({ daoContext: this, datasource: 'default', metadata: this.metadata, ...this.overrides?.device, collection: db.collection('devices'), middlewares: [...(this.overrides?.device?.middlewares || []), ...selectMiddleware('device', this.middlewares) as T.DAOMiddleware<DeviceDAOGenerics<MetadataType, OperationMetadataType>>[]], name: 'device', logger: this.logger })
     }
     return this._device
   }
   get dog(): DogDAO<MetadataType, OperationMetadataType> {
     if(!this._dog) {
       const db = this.mongodb.default
-      this._dog = db === 'mock' ? (new InMemoryDogDAO({ daoContext: this, datasource: null, metadata: this.metadata, ...this.overrides?.dog, middlewares: [...(this.overrides?.dog?.middlewares || []), ...selectMiddleware('dog', this.middlewares) as DAOMiddleware<DogDAOGenerics<MetadataType, OperationMetadataType>>[]], name: 'dog', logger: this.logger }) as unknown as DogDAO<MetadataType, OperationMetadataType>) : new DogDAO({ daoContext: this, datasource: 'default', metadata: this.metadata, ...this.overrides?.dog, collection: db.collection('dogs'), middlewares: [...(this.overrides?.dog?.middlewares || []), ...selectMiddleware('dog', this.middlewares) as DAOMiddleware<DogDAOGenerics<MetadataType, OperationMetadataType>>[]], name: 'dog', logger: this.logger })
+      this._dog = db === 'mock' ? (new InMemoryDogDAO({ daoContext: this, datasource: null, metadata: this.metadata, ...this.overrides?.dog, middlewares: [...(this.overrides?.dog?.middlewares || []), ...selectMiddleware('dog', this.middlewares) as T.DAOMiddleware<DogDAOGenerics<MetadataType, OperationMetadataType>>[]], name: 'dog', logger: this.logger }) as unknown as DogDAO<MetadataType, OperationMetadataType>) : new DogDAO({ daoContext: this, datasource: 'default', metadata: this.metadata, ...this.overrides?.dog, collection: db.collection('dogs'), middlewares: [...(this.overrides?.dog?.middlewares || []), ...selectMiddleware('dog', this.middlewares) as T.DAOMiddleware<DogDAOGenerics<MetadataType, OperationMetadataType>>[]], name: 'dog', logger: this.logger })
     }
     return this._dog
   }
   get hotel(): HotelDAO<MetadataType, OperationMetadataType> {
     if(!this._hotel) {
       const db = this.mongodb.default
-      this._hotel = db === 'mock' ? (new InMemoryHotelDAO({ daoContext: this, datasource: null, metadata: this.metadata, ...this.overrides?.hotel, middlewares: [...(this.overrides?.hotel?.middlewares || []), ...selectMiddleware('hotel', this.middlewares) as DAOMiddleware<HotelDAOGenerics<MetadataType, OperationMetadataType>>[]], name: 'hotel', logger: this.logger }) as unknown as HotelDAO<MetadataType, OperationMetadataType>) : new HotelDAO({ daoContext: this, datasource: 'default', metadata: this.metadata, ...this.overrides?.hotel, collection: db.collection('hotels'), middlewares: [...(this.overrides?.hotel?.middlewares || []), ...selectMiddleware('hotel', this.middlewares) as DAOMiddleware<HotelDAOGenerics<MetadataType, OperationMetadataType>>[]], name: 'hotel', logger: this.logger })
+      this._hotel = db === 'mock' ? (new InMemoryHotelDAO({ daoContext: this, datasource: null, metadata: this.metadata, ...this.overrides?.hotel, middlewares: [...(this.overrides?.hotel?.middlewares || []), ...selectMiddleware('hotel', this.middlewares) as T.DAOMiddleware<HotelDAOGenerics<MetadataType, OperationMetadataType>>[]], name: 'hotel', logger: this.logger }) as unknown as HotelDAO<MetadataType, OperationMetadataType>) : new HotelDAO({ daoContext: this, datasource: 'default', metadata: this.metadata, ...this.overrides?.hotel, collection: db.collection('hotels'), middlewares: [...(this.overrides?.hotel?.middlewares || []), ...selectMiddleware('hotel', this.middlewares) as T.DAOMiddleware<HotelDAOGenerics<MetadataType, OperationMetadataType>>[]], name: 'hotel', logger: this.logger })
     }
     return this._hotel
   }
   get mockedEntity(): MockedEntityDAO<MetadataType, OperationMetadataType> {
     if(!this._mockedEntity) {
-      this._mockedEntity = new MockedEntityDAO({ daoContext: this, datasource: null, metadata: this.metadata, ...this.overrides?.mockedEntity, middlewares: [...(this.overrides?.mockedEntity?.middlewares || []), ...selectMiddleware('mockedEntity', this.middlewares) as DAOMiddleware<MockedEntityDAOGenerics<MetadataType, OperationMetadataType>>[]], name: 'mockedEntity', logger: this.logger })
+      this._mockedEntity = new MockedEntityDAO({ daoContext: this, datasource: null, metadata: this.metadata, ...this.overrides?.mockedEntity, middlewares: [...(this.overrides?.mockedEntity?.middlewares || []), ...selectMiddleware('mockedEntity', this.middlewares) as T.DAOMiddleware<MockedEntityDAOGenerics<MetadataType, OperationMetadataType>>[]], name: 'mockedEntity', logger: this.logger })
     }
     return this._mockedEntity
   }
   get organization(): OrganizationDAO<MetadataType, OperationMetadataType> {
     if(!this._organization) {
       const db = this.mongodb.default
-      this._organization = db === 'mock' ? (new InMemoryOrganizationDAO({ daoContext: this, datasource: null, metadata: this.metadata, ...this.overrides?.organization, middlewares: [...(this.overrides?.organization?.middlewares || []), ...selectMiddleware('organization', this.middlewares) as DAOMiddleware<OrganizationDAOGenerics<MetadataType, OperationMetadataType>>[]], name: 'organization', logger: this.logger }) as unknown as OrganizationDAO<MetadataType, OperationMetadataType>) : new OrganizationDAO({ daoContext: this, datasource: 'default', metadata: this.metadata, ...this.overrides?.organization, collection: db.collection('organizations'), middlewares: [...(this.overrides?.organization?.middlewares || []), ...selectMiddleware('organization', this.middlewares) as DAOMiddleware<OrganizationDAOGenerics<MetadataType, OperationMetadataType>>[]], name: 'organization', logger: this.logger })
+      this._organization = db === 'mock' ? (new InMemoryOrganizationDAO({ daoContext: this, datasource: null, metadata: this.metadata, ...this.overrides?.organization, middlewares: [...(this.overrides?.organization?.middlewares || []), ...selectMiddleware('organization', this.middlewares) as T.DAOMiddleware<OrganizationDAOGenerics<MetadataType, OperationMetadataType>>[]], name: 'organization', logger: this.logger }) as unknown as OrganizationDAO<MetadataType, OperationMetadataType>) : new OrganizationDAO({ daoContext: this, datasource: 'default', metadata: this.metadata, ...this.overrides?.organization, collection: db.collection('organizations'), middlewares: [...(this.overrides?.organization?.middlewares || []), ...selectMiddleware('organization', this.middlewares) as T.DAOMiddleware<OrganizationDAOGenerics<MetadataType, OperationMetadataType>>[]], name: 'organization', logger: this.logger })
     }
     return this._organization
   }
   get post(): PostDAO<MetadataType, OperationMetadataType> {
     if(!this._post) {
       const db = this.mongodb.default
-      this._post = db === 'mock' ? (new InMemoryPostDAO({ daoContext: this, datasource: null, metadata: this.metadata, ...this.overrides?.post, middlewares: [...(this.overrides?.post?.middlewares || []), ...selectMiddleware('post', this.middlewares) as DAOMiddleware<PostDAOGenerics<MetadataType, OperationMetadataType>>[]], name: 'post', logger: this.logger }) as unknown as PostDAO<MetadataType, OperationMetadataType>) : new PostDAO({ daoContext: this, datasource: 'default', metadata: this.metadata, ...this.overrides?.post, collection: db.collection('posts'), middlewares: [...(this.overrides?.post?.middlewares || []), ...selectMiddleware('post', this.middlewares) as DAOMiddleware<PostDAOGenerics<MetadataType, OperationMetadataType>>[]], name: 'post', logger: this.logger })
+      this._post = db === 'mock' ? (new InMemoryPostDAO({ daoContext: this, datasource: null, metadata: this.metadata, ...this.overrides?.post, middlewares: [...(this.overrides?.post?.middlewares || []), ...selectMiddleware('post', this.middlewares) as T.DAOMiddleware<PostDAOGenerics<MetadataType, OperationMetadataType>>[]], name: 'post', logger: this.logger }) as unknown as PostDAO<MetadataType, OperationMetadataType>) : new PostDAO({ daoContext: this, datasource: 'default', metadata: this.metadata, ...this.overrides?.post, collection: db.collection('posts'), middlewares: [...(this.overrides?.post?.middlewares || []), ...selectMiddleware('post', this.middlewares) as T.DAOMiddleware<PostDAOGenerics<MetadataType, OperationMetadataType>>[]], name: 'post', logger: this.logger })
     }
     return this._post
   }
   get user(): UserDAO<MetadataType, OperationMetadataType> {
     if(!this._user) {
       const db = this.mongodb.default
-      this._user = db === 'mock' ? (new InMemoryUserDAO({ daoContext: this, datasource: null, metadata: this.metadata, ...this.overrides?.user, middlewares: [...(this.overrides?.user?.middlewares || []), ...selectMiddleware('user', this.middlewares) as DAOMiddleware<UserDAOGenerics<MetadataType, OperationMetadataType>>[]], name: 'user', logger: this.logger }) as unknown as UserDAO<MetadataType, OperationMetadataType>) : new UserDAO({ daoContext: this, datasource: 'default', metadata: this.metadata, ...this.overrides?.user, collection: db.collection('users'), middlewares: [...(this.overrides?.user?.middlewares || []), ...selectMiddleware('user', this.middlewares) as DAOMiddleware<UserDAOGenerics<MetadataType, OperationMetadataType>>[]], name: 'user', logger: this.logger })
+      this._user = db === 'mock' ? (new InMemoryUserDAO({ daoContext: this, datasource: null, metadata: this.metadata, ...this.overrides?.user, middlewares: [...(this.overrides?.user?.middlewares || []), ...selectMiddleware('user', this.middlewares) as T.DAOMiddleware<UserDAOGenerics<MetadataType, OperationMetadataType>>[]], name: 'user', logger: this.logger }) as unknown as UserDAO<MetadataType, OperationMetadataType>) : new UserDAO({ daoContext: this, datasource: 'default', metadata: this.metadata, ...this.overrides?.user, collection: db.collection('users'), middlewares: [...(this.overrides?.user?.middlewares || []), ...selectMiddleware('user', this.middlewares) as T.DAOMiddleware<UserDAOGenerics<MetadataType, OperationMetadataType>>[]], name: 'user', logger: this.logger })
     }
     return this._user
   }
@@ -1944,21 +1943,21 @@ export class DAOContext<MetadataType = never, OperationMetadataType = never, Per
   constructor(params: DAOContextParams<MetadataType, OperationMetadataType, Permissions, SecurityDomain>) {
     super({
       ...params,
-      scalars: params.scalars ? userInputDataTypeAdapterToDataTypeAdapter(params.scalars, ['Coordinates', 'Decimal', 'JSON', 'Live', 'LocalizedString', 'MongoID', 'Password', 'ID', 'String', 'Boolean', 'Int', 'Float']) : undefined
+      scalars: params.scalars ? T.userInputDataTypeAdapterToDataTypeAdapter(params.scalars, ['Coordinates', 'Decimal', 'JSON', 'Live', 'LocalizedString', 'MongoID', 'Password', 'ID', 'String', 'Boolean', 'Int', 'Float']) : undefined
     })
     this.overrides = params.overrides
     this.mongodb = params.mongodb
     this.middlewares = params.middlewares || []
-    this.logger = logInputToLogger(params.log)
+    this.logger = T.logInputToLogger(params.log)
     if(params.security && params.security.applySecurity !== false) {
-      const securityMiddlewares = createSecurityPolicyMiddlewares(params.security)
+      const securityMiddlewares = T.createSecurityPolicyMiddlewares(params.security)
       const defaultMiddleware = securityMiddlewares.others ? [groupMiddleware.excludes(Object.fromEntries(Object.keys(securityMiddlewares.middlewares).map(k => [k, true])) as any, securityMiddlewares.others as any)] : []
       this.middlewares = [...(params.middlewares ?? []), ...defaultMiddleware, ...Object.entries(securityMiddlewares.middlewares).map(([name, middleware]) => groupMiddleware.includes({[name]: true} as any, middleware as any))]
     }
     this.params = params
   }
   
-  public async execQuery<T>(run: (dbs: { mongodb: Record<'default', Db | 'mock'> }, entities: { address: Collection<Document> | null, audit: Collection<Document> | null, city: Collection<Document> | null, defaultFieldsEntity: Collection<Document> | null, device: Collection<Document> | null, dog: Collection<Document> | null, hotel: Collection<Document> | null, organization: Collection<Document> | null, post: Collection<Document> | null, user: Collection<Document> | null }) => Promise<T>): Promise<T> {
+  public async execQuery<T>(run: (dbs: { mongodb: Record<'default', M.Db | 'mock'> }, entities: { address: M.Collection<M.Document> | null, audit: M.Collection<M.Document> | null, city: M.Collection<M.Document> | null, defaultFieldsEntity: M.Collection<M.Document> | null, device: M.Collection<M.Document> | null, dog: M.Collection<M.Document> | null, hotel: M.Collection<M.Document> | null, organization: M.Collection<M.Document> | null, post: M.Collection<M.Document> | null, user: M.Collection<M.Document> | null }) => Promise<T>): Promise<T> {
     return run({ mongodb: this.mongodb }, { address: this.mongodb.default === 'mock' ? null : this.mongodb.default.collection('addresses'), audit: this.mongodb.default === 'mock' ? null : this.mongodb.default.collection('audits'), city: this.mongodb.default === 'mock' ? null : this.mongodb.default.collection('citys'), defaultFieldsEntity: this.mongodb.default === 'mock' ? null : this.mongodb.default.collection('defaultFieldsEntitys'), device: this.mongodb.default === 'mock' ? null : this.mongodb.default.collection('devices'), dog: this.mongodb.default === 'mock' ? null : this.mongodb.default.collection('dogs'), hotel: this.mongodb.default === 'mock' ? null : this.mongodb.default.collection('hotels'), organization: this.mongodb.default === 'mock' ? null : this.mongodb.default.collection('organizations'), post: this.mongodb.default === 'mock' ? null : this.mongodb.default.collection('posts'), user: this.mongodb.default === 'mock' ? null : this.mongodb.default.collection('users') })
   }
   
@@ -1995,16 +1994,16 @@ type GroupMiddleware<N extends DAOName, MetadataType, OperationMetadataType> =
   | ExcludeGroupMiddleware<N, MetadataType, OperationMetadataType>
 type IncludeGroupMiddleware<N extends DAOName, MetadataType, OperationMetadataType> = {
   include: { [K in N]: true }
-  middleware: DAOMiddleware<DAOGenericsMap<MetadataType, OperationMetadataType>[N]>
+  middleware: T.DAOMiddleware<DAOGenericsMap<MetadataType, OperationMetadataType>[N]>
 }
 type ExcludeGroupMiddleware<N extends DAOName, MetadataType, OperationMetadataType> = {
   exclude: { [K in N]: true }
-  middleware: DAOMiddleware<DAOGenericsMap<MetadataType, OperationMetadataType>[Exclude<DAOName, N>]>
+  middleware: T.DAOMiddleware<DAOGenericsMap<MetadataType, OperationMetadataType>[Exclude<DAOName, N>]>
 }
 export const groupMiddleware = {
   includes<N extends DAOName, MetadataType, OperationMetadataType>(
     include: { [K in N]: true },
-    middleware: DAOMiddleware<DAOGenericsMap<MetadataType, OperationMetadataType>[N]>,
+    middleware: T.DAOMiddleware<DAOGenericsMap<MetadataType, OperationMetadataType>[N]>,
   ): IncludeGroupMiddleware<N, MetadataType, OperationMetadataType> {
     return { include, middleware }
   },

--- a/tests/multitenant/dao.mock.ts
+++ b/tests/multitenant/dao.mock.ts
@@ -1,7 +1,6 @@
-import { DAOMiddleware, Coordinates, UserInputDriverDataTypeAdapterMap, Schema, AbstractDAOContext, LogicalOperators, QuantityOperators, EqualityOperators, StringOperators, ElementOperators, OneKey, SortDirection, overrideRelations, userInputDataTypeAdapterToDataTypeAdapter, LogFunction, LogInput, logInputToLogger, ParamProjection, DAOGenerics, CRUDPermission, DAOContextSecurtyPolicy, createSecurityPolicyMiddlewares, SelectProjection, mergeProjections, AbstractInMemoryDAO, InMemoryDAOGenerics, InMemoryDAOParams } from '../../src'
+import * as T from '../../src'
 import * as types from './models.mock'
-import { MongoDBDAOGenerics, MongoDBDAOParams, AbstractMongoDBDAO } from '../../src'
-import { Collection, Db, Filter, Sort, UpdateFilter, Document } from 'mongodb'
+import * as M from 'mongodb'
 
 //--------------------------------------------------------------------------------
 //------------------------------------ HOTEL -------------------------------------
@@ -10,7 +9,7 @@ import { Collection, Db, Filter, Sort, UpdateFilter, Document } from 'mongodb'
 export type HotelExcludedFields = never
 export type HotelRelationFields = never
 
-export function hotelSchema(): Schema<types.Scalars> {
+export function hotelSchema(): T.Schema<types.Scalars> {
   return {
     'deletionDate': {
       scalar: 'Date'
@@ -36,14 +35,14 @@ export function hotelSchema(): Schema<types.Scalars> {
 }
 
 type HotelFilterFields = {
-  'deletionDate'?: types.Scalars['Date'] | null | EqualityOperators<types.Scalars['Date']> | ElementOperators,
-  'description'?: types.Scalars['String'] | null | EqualityOperators<types.Scalars['String']> | ElementOperators | StringOperators,
-  'id'?: types.Scalars['ID'] | null | EqualityOperators<types.Scalars['ID']> | ElementOperators,
-  'name'?: types.Scalars['String'] | null | EqualityOperators<types.Scalars['String']> | ElementOperators | StringOperators,
-  'tenantId'?: types.Scalars['TenantId'] | null | EqualityOperators<types.Scalars['TenantId']> | ElementOperators
+  'deletionDate'?: types.Scalars['Date'] | null | T.EqualityOperators<types.Scalars['Date']> | T.ElementOperators,
+  'description'?: types.Scalars['String'] | null | T.EqualityOperators<types.Scalars['String']> | T.ElementOperators | T.StringOperators,
+  'id'?: types.Scalars['ID'] | null | T.EqualityOperators<types.Scalars['ID']> | T.ElementOperators,
+  'name'?: types.Scalars['String'] | null | T.EqualityOperators<types.Scalars['String']> | T.ElementOperators | T.StringOperators,
+  'tenantId'?: types.Scalars['TenantId'] | null | T.EqualityOperators<types.Scalars['TenantId']> | T.ElementOperators
 }
-export type HotelFilter = HotelFilterFields & LogicalOperators<HotelFilterFields | HotelRawFilter>
-export type HotelRawFilter = () => Filter<Document>
+export type HotelFilter = HotelFilterFields & T.LogicalOperators<HotelFilterFields | HotelRawFilter>
+export type HotelRawFilter = () => M.Filter<M.Document>
 
 export type HotelRelations = Record<never, string>
 
@@ -54,11 +53,11 @@ export type HotelProjection = {
   name?: boolean,
   tenantId?: boolean,
 }
-export type HotelParam<P extends HotelProjection> = ParamProjection<types.Hotel, HotelProjection, P>
+export type HotelParam<P extends HotelProjection> = T.ParamProjection<types.Hotel, HotelProjection, P>
 
 export type HotelSortKeys = 'deletionDate' | 'description' | 'id' | 'name' | 'tenantId'
-export type HotelSort = OneKey<HotelSortKeys, SortDirection>
-export type HotelRawSort = () => Sort
+export type HotelSort = T.OneKey<HotelSortKeys, T.SortDirection>
+export type HotelRawSort = () => M.Sort
 
 export type HotelUpdate = {
   'deletionDate'?: types.Scalars['Date'] | null,
@@ -67,7 +66,7 @@ export type HotelUpdate = {
   'name'?: types.Scalars['String'],
   'tenantId'?: types.Scalars['TenantId']
 }
-export type HotelRawUpdate = () => UpdateFilter<Document>
+export type HotelRawUpdate = () => M.UpdateFilter<M.Document>
 
 export type HotelInsert = {
   deletionDate?: null | types.Scalars['Date'],
@@ -76,17 +75,17 @@ export type HotelInsert = {
   tenantId?: null | types.Scalars['TenantId'],
 }
 
-type HotelDAOGenerics<MetadataType, OperationMetadataType> = MongoDBDAOGenerics<types.Hotel, 'id', 'ID', HotelFilter, HotelRawFilter, HotelRelations, HotelProjection, HotelSort, HotelRawSort, HotelInsert, HotelUpdate, HotelRawUpdate, HotelExcludedFields, HotelRelationFields, MetadataType, OperationMetadataType, types.Scalars, 'hotel', DAOContext<MetadataType, OperationMetadataType>>
-export type HotelDAOParams<MetadataType, OperationMetadataType> = Omit<MongoDBDAOParams<HotelDAOGenerics<MetadataType, OperationMetadataType>>, 'idGenerator' | 'idField' | 'schema' | 'idScalar' | 'idGeneration'>
-export type InMemoryHotelDAOParams<MetadataType, OperationMetadataType> = Omit<InMemoryDAOParams<HotelDAOGenerics<MetadataType, OperationMetadataType>>, 'idGenerator' | 'idField' | 'schema' | 'idScalar' | 'idGeneration'>
+type HotelDAOGenerics<MetadataType, OperationMetadataType> = T.MongoDBDAOGenerics<types.Hotel, 'id', 'ID', HotelFilter, HotelRawFilter, HotelRelations, HotelProjection, HotelSort, HotelRawSort, HotelInsert, HotelUpdate, HotelRawUpdate, HotelExcludedFields, HotelRelationFields, MetadataType, OperationMetadataType, types.Scalars, 'hotel', DAOContext<MetadataType, OperationMetadataType>>
+export type HotelDAOParams<MetadataType, OperationMetadataType> = Omit<T.MongoDBDAOParams<HotelDAOGenerics<MetadataType, OperationMetadataType>>, 'idGenerator' | 'idField' | 'schema' | 'idScalar' | 'idGeneration'>
+export type InMemoryHotelDAOParams<MetadataType, OperationMetadataType> = Omit<T.InMemoryDAOParams<HotelDAOGenerics<MetadataType, OperationMetadataType>>, 'idGenerator' | 'idField' | 'schema' | 'idScalar' | 'idGeneration'>
 
-export class HotelDAO<MetadataType, OperationMetadataType> extends AbstractMongoDBDAO<HotelDAOGenerics<MetadataType, OperationMetadataType>> {  
+export class HotelDAO<MetadataType, OperationMetadataType> extends T.AbstractMongoDBDAO<HotelDAOGenerics<MetadataType, OperationMetadataType>> {  
   
   public static projection<P extends HotelProjection>(p: P) {
     return p
   }
-  public static mergeProjection<P1 extends HotelProjection, P2 extends HotelProjection>(p1: P1, p2: P2): SelectProjection<HotelProjection, P1, P2> {
-    return mergeProjections(p1, p2) as SelectProjection<HotelProjection, P1, P2>
+  public static mergeProjection<P1 extends HotelProjection, P2 extends HotelProjection>(p1: P1, p2: P2): T.SelectProjection<HotelProjection, P1, P2> {
+    return T.mergeProjections(p1, p2) as T.SelectProjection<HotelProjection, P1, P2>
   }
   
   public constructor(params: HotelDAOParams<MetadataType, OperationMetadataType>){
@@ -94,7 +93,7 @@ export class HotelDAO<MetadataType, OperationMetadataType> extends AbstractMongo
       ...params, 
       idField: 'id', 
       schema: hotelSchema(), 
-      relations: overrideRelations(
+      relations: T.overrideRelations(
         [
           
         ]
@@ -105,13 +104,13 @@ export class HotelDAO<MetadataType, OperationMetadataType> extends AbstractMongo
   }
   }
 
-export class InMemoryHotelDAO<MetadataType, OperationMetadataType> extends AbstractInMemoryDAO<HotelDAOGenerics<MetadataType, OperationMetadataType>> {  
+export class InMemoryHotelDAO<MetadataType, OperationMetadataType> extends T.AbstractInMemoryDAO<HotelDAOGenerics<MetadataType, OperationMetadataType>> {  
   
   public static projection<P extends HotelProjection>(p: P) {
     return p
   }
-  public static mergeProjection<P1 extends HotelProjection, P2 extends HotelProjection>(p1: P1, p2: P2): SelectProjection<HotelProjection, P1, P2> {
-    return mergeProjections(p1, p2) as SelectProjection<HotelProjection, P1, P2>
+  public static mergeProjection<P1 extends HotelProjection, P2 extends HotelProjection>(p1: P1, p2: P2): T.SelectProjection<HotelProjection, P1, P2> {
+    return T.mergeProjections(p1, p2) as T.SelectProjection<HotelProjection, P1, P2>
   }
   
   public constructor(params: InMemoryHotelDAOParams<MetadataType, OperationMetadataType>){
@@ -119,7 +118,7 @@ export class InMemoryHotelDAO<MetadataType, OperationMetadataType> extends Abstr
       ...params, 
       idField: 'id', 
       schema: hotelSchema(), 
-      relations: overrideRelations(
+      relations: T.overrideRelations(
         [
           
         ]
@@ -139,7 +138,7 @@ export class InMemoryHotelDAO<MetadataType, OperationMetadataType> extends Abstr
 export type ReservationExcludedFields = never
 export type ReservationRelationFields = 'room'
 
-export function reservationSchema(): Schema<types.Scalars> {
+export function reservationSchema(): T.Schema<types.Scalars> {
   return {
     'deletionDate': {
       scalar: 'Date'
@@ -166,14 +165,14 @@ export function reservationSchema(): Schema<types.Scalars> {
 }
 
 type ReservationFilterFields = {
-  'deletionDate'?: types.Scalars['Date'] | null | EqualityOperators<types.Scalars['Date']> | ElementOperators,
-  'id'?: types.Scalars['ID'] | null | EqualityOperators<types.Scalars['ID']> | ElementOperators,
-  'roomId'?: types.Scalars['ID'] | null | EqualityOperators<types.Scalars['ID']> | ElementOperators,
-  'tenantId'?: types.Scalars['TenantId'] | null | EqualityOperators<types.Scalars['TenantId']> | ElementOperators,
-  'userId'?: types.Scalars['ID'] | null | EqualityOperators<types.Scalars['ID']> | ElementOperators
+  'deletionDate'?: types.Scalars['Date'] | null | T.EqualityOperators<types.Scalars['Date']> | T.ElementOperators,
+  'id'?: types.Scalars['ID'] | null | T.EqualityOperators<types.Scalars['ID']> | T.ElementOperators,
+  'roomId'?: types.Scalars['ID'] | null | T.EqualityOperators<types.Scalars['ID']> | T.ElementOperators,
+  'tenantId'?: types.Scalars['TenantId'] | null | T.EqualityOperators<types.Scalars['TenantId']> | T.ElementOperators,
+  'userId'?: types.Scalars['ID'] | null | T.EqualityOperators<types.Scalars['ID']> | T.ElementOperators
 }
-export type ReservationFilter = ReservationFilterFields & LogicalOperators<ReservationFilterFields | ReservationRawFilter>
-export type ReservationRawFilter = () => Filter<Document>
+export type ReservationFilter = ReservationFilterFields & T.LogicalOperators<ReservationFilterFields | ReservationRawFilter>
+export type ReservationRawFilter = () => M.Filter<M.Document>
 
 export type ReservationRelations = Record<never, string>
 
@@ -185,11 +184,11 @@ export type ReservationProjection = {
   tenantId?: boolean,
   userId?: boolean,
 }
-export type ReservationParam<P extends ReservationProjection> = ParamProjection<types.Reservation, ReservationProjection, P>
+export type ReservationParam<P extends ReservationProjection> = T.ParamProjection<types.Reservation, ReservationProjection, P>
 
 export type ReservationSortKeys = 'deletionDate' | 'id' | 'roomId' | 'tenantId' | 'userId'
-export type ReservationSort = OneKey<ReservationSortKeys, SortDirection>
-export type ReservationRawSort = () => Sort
+export type ReservationSort = T.OneKey<ReservationSortKeys, T.SortDirection>
+export type ReservationRawSort = () => M.Sort
 
 export type ReservationUpdate = {
   'deletionDate'?: types.Scalars['Date'] | null,
@@ -198,7 +197,7 @@ export type ReservationUpdate = {
   'tenantId'?: types.Scalars['TenantId'],
   'userId'?: types.Scalars['ID']
 }
-export type ReservationRawUpdate = () => UpdateFilter<Document>
+export type ReservationRawUpdate = () => M.UpdateFilter<M.Document>
 
 export type ReservationInsert = {
   deletionDate?: null | types.Scalars['Date'],
@@ -207,17 +206,17 @@ export type ReservationInsert = {
   userId: types.Scalars['ID'],
 }
 
-type ReservationDAOGenerics<MetadataType, OperationMetadataType> = MongoDBDAOGenerics<types.Reservation, 'id', 'ID', ReservationFilter, ReservationRawFilter, ReservationRelations, ReservationProjection, ReservationSort, ReservationRawSort, ReservationInsert, ReservationUpdate, ReservationRawUpdate, ReservationExcludedFields, ReservationRelationFields, MetadataType, OperationMetadataType, types.Scalars, 'reservation', DAOContext<MetadataType, OperationMetadataType>>
-export type ReservationDAOParams<MetadataType, OperationMetadataType> = Omit<MongoDBDAOParams<ReservationDAOGenerics<MetadataType, OperationMetadataType>>, 'idGenerator' | 'idField' | 'schema' | 'idScalar' | 'idGeneration'>
-export type InMemoryReservationDAOParams<MetadataType, OperationMetadataType> = Omit<InMemoryDAOParams<ReservationDAOGenerics<MetadataType, OperationMetadataType>>, 'idGenerator' | 'idField' | 'schema' | 'idScalar' | 'idGeneration'>
+type ReservationDAOGenerics<MetadataType, OperationMetadataType> = T.MongoDBDAOGenerics<types.Reservation, 'id', 'ID', ReservationFilter, ReservationRawFilter, ReservationRelations, ReservationProjection, ReservationSort, ReservationRawSort, ReservationInsert, ReservationUpdate, ReservationRawUpdate, ReservationExcludedFields, ReservationRelationFields, MetadataType, OperationMetadataType, types.Scalars, 'reservation', DAOContext<MetadataType, OperationMetadataType>>
+export type ReservationDAOParams<MetadataType, OperationMetadataType> = Omit<T.MongoDBDAOParams<ReservationDAOGenerics<MetadataType, OperationMetadataType>>, 'idGenerator' | 'idField' | 'schema' | 'idScalar' | 'idGeneration'>
+export type InMemoryReservationDAOParams<MetadataType, OperationMetadataType> = Omit<T.InMemoryDAOParams<ReservationDAOGenerics<MetadataType, OperationMetadataType>>, 'idGenerator' | 'idField' | 'schema' | 'idScalar' | 'idGeneration'>
 
-export class ReservationDAO<MetadataType, OperationMetadataType> extends AbstractMongoDBDAO<ReservationDAOGenerics<MetadataType, OperationMetadataType>> {  
+export class ReservationDAO<MetadataType, OperationMetadataType> extends T.AbstractMongoDBDAO<ReservationDAOGenerics<MetadataType, OperationMetadataType>> {  
   
   public static projection<P extends ReservationProjection>(p: P) {
     return p
   }
-  public static mergeProjection<P1 extends ReservationProjection, P2 extends ReservationProjection>(p1: P1, p2: P2): SelectProjection<ReservationProjection, P1, P2> {
-    return mergeProjections(p1, p2) as SelectProjection<ReservationProjection, P1, P2>
+  public static mergeProjection<P1 extends ReservationProjection, P2 extends ReservationProjection>(p1: P1, p2: P2): T.SelectProjection<ReservationProjection, P1, P2> {
+    return T.mergeProjections(p1, p2) as T.SelectProjection<ReservationProjection, P1, P2>
   }
   
   public constructor(params: ReservationDAOParams<MetadataType, OperationMetadataType>){
@@ -225,7 +224,7 @@ export class ReservationDAO<MetadataType, OperationMetadataType> extends Abstrac
       ...params, 
       idField: 'id', 
       schema: reservationSchema(), 
-      relations: overrideRelations(
+      relations: T.overrideRelations(
         [
           { type: '1-1', reference: 'inner', field: 'room', refFrom: 'roomId', refTo: 'id', dao: 'room', required: false }
         ]
@@ -236,13 +235,13 @@ export class ReservationDAO<MetadataType, OperationMetadataType> extends Abstrac
   }
   }
 
-export class InMemoryReservationDAO<MetadataType, OperationMetadataType> extends AbstractInMemoryDAO<ReservationDAOGenerics<MetadataType, OperationMetadataType>> {  
+export class InMemoryReservationDAO<MetadataType, OperationMetadataType> extends T.AbstractInMemoryDAO<ReservationDAOGenerics<MetadataType, OperationMetadataType>> {  
   
   public static projection<P extends ReservationProjection>(p: P) {
     return p
   }
-  public static mergeProjection<P1 extends ReservationProjection, P2 extends ReservationProjection>(p1: P1, p2: P2): SelectProjection<ReservationProjection, P1, P2> {
-    return mergeProjections(p1, p2) as SelectProjection<ReservationProjection, P1, P2>
+  public static mergeProjection<P1 extends ReservationProjection, P2 extends ReservationProjection>(p1: P1, p2: P2): T.SelectProjection<ReservationProjection, P1, P2> {
+    return T.mergeProjections(p1, p2) as T.SelectProjection<ReservationProjection, P1, P2>
   }
   
   public constructor(params: InMemoryReservationDAOParams<MetadataType, OperationMetadataType>){
@@ -250,7 +249,7 @@ export class InMemoryReservationDAO<MetadataType, OperationMetadataType> extends
       ...params, 
       idField: 'id', 
       schema: reservationSchema(), 
-      relations: overrideRelations(
+      relations: T.overrideRelations(
         [
           { type: '1-1', reference: 'inner', field: 'room', refFrom: 'roomId', refTo: 'id', dao: 'room', required: false }
         ]
@@ -270,7 +269,7 @@ export class InMemoryReservationDAO<MetadataType, OperationMetadataType> extends
 export type RoomExcludedFields = never
 export type RoomRelationFields = 'hotel'
 
-export function roomSchema(): Schema<types.Scalars> {
+export function roomSchema(): T.Schema<types.Scalars> {
   return {
     'deletionDate': {
       scalar: 'Date'
@@ -297,14 +296,14 @@ export function roomSchema(): Schema<types.Scalars> {
 }
 
 type RoomFilterFields = {
-  'deletionDate'?: types.Scalars['Date'] | null | EqualityOperators<types.Scalars['Date']> | ElementOperators,
-  'hotelId'?: types.Scalars['ID'] | null | EqualityOperators<types.Scalars['ID']> | ElementOperators,
-  'id'?: types.Scalars['ID'] | null | EqualityOperators<types.Scalars['ID']> | ElementOperators,
-  'size'?: types.Scalars['String'] | null | EqualityOperators<types.Scalars['String']> | ElementOperators | StringOperators,
-  'tenantId'?: types.Scalars['TenantId'] | null | EqualityOperators<types.Scalars['TenantId']> | ElementOperators
+  'deletionDate'?: types.Scalars['Date'] | null | T.EqualityOperators<types.Scalars['Date']> | T.ElementOperators,
+  'hotelId'?: types.Scalars['ID'] | null | T.EqualityOperators<types.Scalars['ID']> | T.ElementOperators,
+  'id'?: types.Scalars['ID'] | null | T.EqualityOperators<types.Scalars['ID']> | T.ElementOperators,
+  'size'?: types.Scalars['String'] | null | T.EqualityOperators<types.Scalars['String']> | T.ElementOperators | T.StringOperators,
+  'tenantId'?: types.Scalars['TenantId'] | null | T.EqualityOperators<types.Scalars['TenantId']> | T.ElementOperators
 }
-export type RoomFilter = RoomFilterFields & LogicalOperators<RoomFilterFields | RoomRawFilter>
-export type RoomRawFilter = () => Filter<Document>
+export type RoomFilter = RoomFilterFields & T.LogicalOperators<RoomFilterFields | RoomRawFilter>
+export type RoomRawFilter = () => M.Filter<M.Document>
 
 export type RoomRelations = Record<never, string>
 
@@ -316,11 +315,11 @@ export type RoomProjection = {
   size?: boolean,
   tenantId?: boolean,
 }
-export type RoomParam<P extends RoomProjection> = ParamProjection<types.Room, RoomProjection, P>
+export type RoomParam<P extends RoomProjection> = T.ParamProjection<types.Room, RoomProjection, P>
 
 export type RoomSortKeys = 'deletionDate' | 'hotelId' | 'id' | 'size' | 'tenantId'
-export type RoomSort = OneKey<RoomSortKeys, SortDirection>
-export type RoomRawSort = () => Sort
+export type RoomSort = T.OneKey<RoomSortKeys, T.SortDirection>
+export type RoomRawSort = () => M.Sort
 
 export type RoomUpdate = {
   'deletionDate'?: types.Scalars['Date'] | null,
@@ -329,7 +328,7 @@ export type RoomUpdate = {
   'size'?: types.Scalars['String'],
   'tenantId'?: types.Scalars['TenantId']
 }
-export type RoomRawUpdate = () => UpdateFilter<Document>
+export type RoomRawUpdate = () => M.UpdateFilter<M.Document>
 
 export type RoomInsert = {
   deletionDate?: null | types.Scalars['Date'],
@@ -338,17 +337,17 @@ export type RoomInsert = {
   tenantId?: null | types.Scalars['TenantId'],
 }
 
-type RoomDAOGenerics<MetadataType, OperationMetadataType> = MongoDBDAOGenerics<types.Room, 'id', 'ID', RoomFilter, RoomRawFilter, RoomRelations, RoomProjection, RoomSort, RoomRawSort, RoomInsert, RoomUpdate, RoomRawUpdate, RoomExcludedFields, RoomRelationFields, MetadataType, OperationMetadataType, types.Scalars, 'room', DAOContext<MetadataType, OperationMetadataType>>
-export type RoomDAOParams<MetadataType, OperationMetadataType> = Omit<MongoDBDAOParams<RoomDAOGenerics<MetadataType, OperationMetadataType>>, 'idGenerator' | 'idField' | 'schema' | 'idScalar' | 'idGeneration'>
-export type InMemoryRoomDAOParams<MetadataType, OperationMetadataType> = Omit<InMemoryDAOParams<RoomDAOGenerics<MetadataType, OperationMetadataType>>, 'idGenerator' | 'idField' | 'schema' | 'idScalar' | 'idGeneration'>
+type RoomDAOGenerics<MetadataType, OperationMetadataType> = T.MongoDBDAOGenerics<types.Room, 'id', 'ID', RoomFilter, RoomRawFilter, RoomRelations, RoomProjection, RoomSort, RoomRawSort, RoomInsert, RoomUpdate, RoomRawUpdate, RoomExcludedFields, RoomRelationFields, MetadataType, OperationMetadataType, types.Scalars, 'room', DAOContext<MetadataType, OperationMetadataType>>
+export type RoomDAOParams<MetadataType, OperationMetadataType> = Omit<T.MongoDBDAOParams<RoomDAOGenerics<MetadataType, OperationMetadataType>>, 'idGenerator' | 'idField' | 'schema' | 'idScalar' | 'idGeneration'>
+export type InMemoryRoomDAOParams<MetadataType, OperationMetadataType> = Omit<T.InMemoryDAOParams<RoomDAOGenerics<MetadataType, OperationMetadataType>>, 'idGenerator' | 'idField' | 'schema' | 'idScalar' | 'idGeneration'>
 
-export class RoomDAO<MetadataType, OperationMetadataType> extends AbstractMongoDBDAO<RoomDAOGenerics<MetadataType, OperationMetadataType>> {  
+export class RoomDAO<MetadataType, OperationMetadataType> extends T.AbstractMongoDBDAO<RoomDAOGenerics<MetadataType, OperationMetadataType>> {  
   
   public static projection<P extends RoomProjection>(p: P) {
     return p
   }
-  public static mergeProjection<P1 extends RoomProjection, P2 extends RoomProjection>(p1: P1, p2: P2): SelectProjection<RoomProjection, P1, P2> {
-    return mergeProjections(p1, p2) as SelectProjection<RoomProjection, P1, P2>
+  public static mergeProjection<P1 extends RoomProjection, P2 extends RoomProjection>(p1: P1, p2: P2): T.SelectProjection<RoomProjection, P1, P2> {
+    return T.mergeProjections(p1, p2) as T.SelectProjection<RoomProjection, P1, P2>
   }
   
   public constructor(params: RoomDAOParams<MetadataType, OperationMetadataType>){
@@ -356,7 +355,7 @@ export class RoomDAO<MetadataType, OperationMetadataType> extends AbstractMongoD
       ...params, 
       idField: 'id', 
       schema: roomSchema(), 
-      relations: overrideRelations(
+      relations: T.overrideRelations(
         [
           { type: '1-1', reference: 'inner', field: 'hotel', refFrom: 'hotelId', refTo: 'id', dao: 'hotel', required: true }
         ]
@@ -367,13 +366,13 @@ export class RoomDAO<MetadataType, OperationMetadataType> extends AbstractMongoD
   }
   }
 
-export class InMemoryRoomDAO<MetadataType, OperationMetadataType> extends AbstractInMemoryDAO<RoomDAOGenerics<MetadataType, OperationMetadataType>> {  
+export class InMemoryRoomDAO<MetadataType, OperationMetadataType> extends T.AbstractInMemoryDAO<RoomDAOGenerics<MetadataType, OperationMetadataType>> {  
   
   public static projection<P extends RoomProjection>(p: P) {
     return p
   }
-  public static mergeProjection<P1 extends RoomProjection, P2 extends RoomProjection>(p1: P1, p2: P2): SelectProjection<RoomProjection, P1, P2> {
-    return mergeProjections(p1, p2) as SelectProjection<RoomProjection, P1, P2>
+  public static mergeProjection<P1 extends RoomProjection, P2 extends RoomProjection>(p1: P1, p2: P2): T.SelectProjection<RoomProjection, P1, P2> {
+    return T.mergeProjections(p1, p2) as T.SelectProjection<RoomProjection, P1, P2>
   }
   
   public constructor(params: InMemoryRoomDAOParams<MetadataType, OperationMetadataType>){
@@ -381,7 +380,7 @@ export class InMemoryRoomDAO<MetadataType, OperationMetadataType> extends Abstra
       ...params, 
       idField: 'id', 
       schema: roomSchema(), 
-      relations: overrideRelations(
+      relations: T.overrideRelations(
         [
           { type: '1-1', reference: 'inner', field: 'hotel', refFrom: 'hotelId', refTo: 'id', dao: 'hotel', required: true }
         ]
@@ -401,7 +400,7 @@ export class InMemoryRoomDAO<MetadataType, OperationMetadataType> extends Abstra
 export type TenantExcludedFields = never
 export type TenantRelationFields = never
 
-export function tenantSchema(): Schema<types.Scalars> {
+export function tenantSchema(): T.Schema<types.Scalars> {
   return {
     'id': {
       scalar: 'Int', 
@@ -415,11 +414,11 @@ export function tenantSchema(): Schema<types.Scalars> {
 }
 
 type TenantFilterFields = {
-  'id'?: types.Scalars['Int'] | null | EqualityOperators<types.Scalars['Int']> | ElementOperators | QuantityOperators<types.Scalars['Int']>,
-  'info'?: types.Scalars['String'] | null | EqualityOperators<types.Scalars['String']> | ElementOperators | StringOperators
+  'id'?: types.Scalars['Int'] | null | T.EqualityOperators<types.Scalars['Int']> | T.ElementOperators | T.QuantityOperators<types.Scalars['Int']>,
+  'info'?: types.Scalars['String'] | null | T.EqualityOperators<types.Scalars['String']> | T.ElementOperators | T.StringOperators
 }
-export type TenantFilter = TenantFilterFields & LogicalOperators<TenantFilterFields | TenantRawFilter>
-export type TenantRawFilter = () => Filter<Document>
+export type TenantFilter = TenantFilterFields & T.LogicalOperators<TenantFilterFields | TenantRawFilter>
+export type TenantRawFilter = () => M.Filter<M.Document>
 
 export type TenantRelations = Record<never, string>
 
@@ -427,34 +426,34 @@ export type TenantProjection = {
   id?: boolean,
   info?: boolean,
 }
-export type TenantParam<P extends TenantProjection> = ParamProjection<types.Tenant, TenantProjection, P>
+export type TenantParam<P extends TenantProjection> = T.ParamProjection<types.Tenant, TenantProjection, P>
 
 export type TenantSortKeys = 'id' | 'info'
-export type TenantSort = OneKey<TenantSortKeys, SortDirection>
-export type TenantRawSort = () => Sort
+export type TenantSort = T.OneKey<TenantSortKeys, T.SortDirection>
+export type TenantRawSort = () => M.Sort
 
 export type TenantUpdate = {
   'id'?: types.Scalars['Int'],
   'info'?: types.Scalars['String']
 }
-export type TenantRawUpdate = () => UpdateFilter<Document>
+export type TenantRawUpdate = () => M.UpdateFilter<M.Document>
 
 export type TenantInsert = {
   id: types.Scalars['Int'],
   info: types.Scalars['String'],
 }
 
-type TenantDAOGenerics<MetadataType, OperationMetadataType> = MongoDBDAOGenerics<types.Tenant, 'id', 'Int', TenantFilter, TenantRawFilter, TenantRelations, TenantProjection, TenantSort, TenantRawSort, TenantInsert, TenantUpdate, TenantRawUpdate, TenantExcludedFields, TenantRelationFields, MetadataType, OperationMetadataType, types.Scalars, 'tenant', DAOContext<MetadataType, OperationMetadataType>>
-export type TenantDAOParams<MetadataType, OperationMetadataType> = Omit<MongoDBDAOParams<TenantDAOGenerics<MetadataType, OperationMetadataType>>, 'idGenerator' | 'idField' | 'schema' | 'idScalar' | 'idGeneration'>
-export type InMemoryTenantDAOParams<MetadataType, OperationMetadataType> = Omit<InMemoryDAOParams<TenantDAOGenerics<MetadataType, OperationMetadataType>>, 'idGenerator' | 'idField' | 'schema' | 'idScalar' | 'idGeneration'>
+type TenantDAOGenerics<MetadataType, OperationMetadataType> = T.MongoDBDAOGenerics<types.Tenant, 'id', 'Int', TenantFilter, TenantRawFilter, TenantRelations, TenantProjection, TenantSort, TenantRawSort, TenantInsert, TenantUpdate, TenantRawUpdate, TenantExcludedFields, TenantRelationFields, MetadataType, OperationMetadataType, types.Scalars, 'tenant', DAOContext<MetadataType, OperationMetadataType>>
+export type TenantDAOParams<MetadataType, OperationMetadataType> = Omit<T.MongoDBDAOParams<TenantDAOGenerics<MetadataType, OperationMetadataType>>, 'idGenerator' | 'idField' | 'schema' | 'idScalar' | 'idGeneration'>
+export type InMemoryTenantDAOParams<MetadataType, OperationMetadataType> = Omit<T.InMemoryDAOParams<TenantDAOGenerics<MetadataType, OperationMetadataType>>, 'idGenerator' | 'idField' | 'schema' | 'idScalar' | 'idGeneration'>
 
-export class TenantDAO<MetadataType, OperationMetadataType> extends AbstractMongoDBDAO<TenantDAOGenerics<MetadataType, OperationMetadataType>> {  
+export class TenantDAO<MetadataType, OperationMetadataType> extends T.AbstractMongoDBDAO<TenantDAOGenerics<MetadataType, OperationMetadataType>> {  
   
   public static projection<P extends TenantProjection>(p: P) {
     return p
   }
-  public static mergeProjection<P1 extends TenantProjection, P2 extends TenantProjection>(p1: P1, p2: P2): SelectProjection<TenantProjection, P1, P2> {
-    return mergeProjections(p1, p2) as SelectProjection<TenantProjection, P1, P2>
+  public static mergeProjection<P1 extends TenantProjection, P2 extends TenantProjection>(p1: P1, p2: P2): T.SelectProjection<TenantProjection, P1, P2> {
+    return T.mergeProjections(p1, p2) as T.SelectProjection<TenantProjection, P1, P2>
   }
   
   public constructor(params: TenantDAOParams<MetadataType, OperationMetadataType>){
@@ -462,7 +461,7 @@ export class TenantDAO<MetadataType, OperationMetadataType> extends AbstractMong
       ...params, 
       idField: 'id', 
       schema: tenantSchema(), 
-      relations: overrideRelations(
+      relations: T.overrideRelations(
         [
           
         ]
@@ -473,13 +472,13 @@ export class TenantDAO<MetadataType, OperationMetadataType> extends AbstractMong
   }
   }
 
-export class InMemoryTenantDAO<MetadataType, OperationMetadataType> extends AbstractInMemoryDAO<TenantDAOGenerics<MetadataType, OperationMetadataType>> {  
+export class InMemoryTenantDAO<MetadataType, OperationMetadataType> extends T.AbstractInMemoryDAO<TenantDAOGenerics<MetadataType, OperationMetadataType>> {  
   
   public static projection<P extends TenantProjection>(p: P) {
     return p
   }
-  public static mergeProjection<P1 extends TenantProjection, P2 extends TenantProjection>(p1: P1, p2: P2): SelectProjection<TenantProjection, P1, P2> {
-    return mergeProjections(p1, p2) as SelectProjection<TenantProjection, P1, P2>
+  public static mergeProjection<P1 extends TenantProjection, P2 extends TenantProjection>(p1: P1, p2: P2): T.SelectProjection<TenantProjection, P1, P2> {
+    return T.mergeProjections(p1, p2) as T.SelectProjection<TenantProjection, P1, P2>
   }
   
   public constructor(params: InMemoryTenantDAOParams<MetadataType, OperationMetadataType>){
@@ -487,7 +486,7 @@ export class InMemoryTenantDAO<MetadataType, OperationMetadataType> extends Abst
       ...params, 
       idField: 'id', 
       schema: tenantSchema(), 
-      relations: overrideRelations(
+      relations: T.overrideRelations(
         [
           
         ]
@@ -507,7 +506,7 @@ export class InMemoryTenantDAO<MetadataType, OperationMetadataType> extends Abst
 export type UserExcludedFields = never
 export type UserRelationFields = 'reservations'
 
-export function userSchema(): Schema<types.Scalars> {
+export function userSchema(): T.Schema<types.Scalars> {
   return {
     'credentials': { embedded: usernamePasswordCredentialsSchema(), alias: 'cred' },
     'deletionDate': {
@@ -537,17 +536,17 @@ export function userSchema(): Schema<types.Scalars> {
 }
 
 type UserFilterFields = {
-  'credentials.password'?: types.Scalars['Password'] | null | EqualityOperators<types.Scalars['Password']> | ElementOperators,
-  'credentials.username'?: types.Scalars['Username'] | null | EqualityOperators<types.Scalars['Username']> | ElementOperators,
-  'deletionDate'?: types.Scalars['Date'] | null | EqualityOperators<types.Scalars['Date']> | ElementOperators,
-  'email'?: types.Scalars['Email'] | null | EqualityOperators<types.Scalars['Email']> | ElementOperators,
-  'firstName'?: types.Scalars['String'] | null | EqualityOperators<types.Scalars['String']> | ElementOperators | StringOperators,
-  'id'?: types.Scalars['ID'] | null | EqualityOperators<types.Scalars['ID']> | ElementOperators,
-  'lastName'?: types.Scalars['String'] | null | EqualityOperators<types.Scalars['String']> | ElementOperators | StringOperators,
-  'tenantId'?: types.Scalars['TenantId'] | null | EqualityOperators<types.Scalars['TenantId']> | ElementOperators
+  'credentials.password'?: types.Scalars['Password'] | null | T.EqualityOperators<types.Scalars['Password']> | T.ElementOperators,
+  'credentials.username'?: types.Scalars['Username'] | null | T.EqualityOperators<types.Scalars['Username']> | T.ElementOperators,
+  'deletionDate'?: types.Scalars['Date'] | null | T.EqualityOperators<types.Scalars['Date']> | T.ElementOperators,
+  'email'?: types.Scalars['Email'] | null | T.EqualityOperators<types.Scalars['Email']> | T.ElementOperators,
+  'firstName'?: types.Scalars['String'] | null | T.EqualityOperators<types.Scalars['String']> | T.ElementOperators | T.StringOperators,
+  'id'?: types.Scalars['ID'] | null | T.EqualityOperators<types.Scalars['ID']> | T.ElementOperators,
+  'lastName'?: types.Scalars['String'] | null | T.EqualityOperators<types.Scalars['String']> | T.ElementOperators | T.StringOperators,
+  'tenantId'?: types.Scalars['TenantId'] | null | T.EqualityOperators<types.Scalars['TenantId']> | T.ElementOperators
 }
-export type UserFilter = UserFilterFields & LogicalOperators<UserFilterFields | UserRawFilter>
-export type UserRawFilter = () => Filter<Document>
+export type UserFilter = UserFilterFields & T.LogicalOperators<UserFilterFields | UserRawFilter>
+export type UserRawFilter = () => M.Filter<M.Document>
 
 export type UserRelations = {
   reservations?: {
@@ -572,11 +571,11 @@ export type UserProjection = {
   reservations?: ReservationProjection | boolean,
   tenantId?: boolean,
 }
-export type UserParam<P extends UserProjection> = ParamProjection<types.User, UserProjection, P>
+export type UserParam<P extends UserProjection> = T.ParamProjection<types.User, UserProjection, P>
 
 export type UserSortKeys = 'credentials.password' | 'credentials.username' | 'deletionDate' | 'email' | 'firstName' | 'id' | 'lastName' | 'tenantId'
-export type UserSort = OneKey<UserSortKeys, SortDirection>
-export type UserRawSort = () => Sort
+export type UserSort = T.OneKey<UserSortKeys, T.SortDirection>
+export type UserRawSort = () => M.Sort
 
 export type UserUpdate = {
   'credentials'?: UsernamePasswordCredentialsInsert | null,
@@ -589,7 +588,7 @@ export type UserUpdate = {
   'lastName'?: types.Scalars['String'] | null,
   'tenantId'?: types.Scalars['TenantId']
 }
-export type UserRawUpdate = () => UpdateFilter<Document>
+export type UserRawUpdate = () => M.UpdateFilter<M.Document>
 
 export type UserInsert = {
   credentials?: null | UsernamePasswordCredentialsInsert,
@@ -600,17 +599,17 @@ export type UserInsert = {
   tenantId?: null | types.Scalars['TenantId'],
 }
 
-type UserDAOGenerics<MetadataType, OperationMetadataType> = MongoDBDAOGenerics<types.User, 'id', 'ID', UserFilter, UserRawFilter, UserRelations, UserProjection, UserSort, UserRawSort, UserInsert, UserUpdate, UserRawUpdate, UserExcludedFields, UserRelationFields, MetadataType, OperationMetadataType, types.Scalars, 'user', DAOContext<MetadataType, OperationMetadataType>>
-export type UserDAOParams<MetadataType, OperationMetadataType> = Omit<MongoDBDAOParams<UserDAOGenerics<MetadataType, OperationMetadataType>>, 'idGenerator' | 'idField' | 'schema' | 'idScalar' | 'idGeneration'>
-export type InMemoryUserDAOParams<MetadataType, OperationMetadataType> = Omit<InMemoryDAOParams<UserDAOGenerics<MetadataType, OperationMetadataType>>, 'idGenerator' | 'idField' | 'schema' | 'idScalar' | 'idGeneration'>
+type UserDAOGenerics<MetadataType, OperationMetadataType> = T.MongoDBDAOGenerics<types.User, 'id', 'ID', UserFilter, UserRawFilter, UserRelations, UserProjection, UserSort, UserRawSort, UserInsert, UserUpdate, UserRawUpdate, UserExcludedFields, UserRelationFields, MetadataType, OperationMetadataType, types.Scalars, 'user', DAOContext<MetadataType, OperationMetadataType>>
+export type UserDAOParams<MetadataType, OperationMetadataType> = Omit<T.MongoDBDAOParams<UserDAOGenerics<MetadataType, OperationMetadataType>>, 'idGenerator' | 'idField' | 'schema' | 'idScalar' | 'idGeneration'>
+export type InMemoryUserDAOParams<MetadataType, OperationMetadataType> = Omit<T.InMemoryDAOParams<UserDAOGenerics<MetadataType, OperationMetadataType>>, 'idGenerator' | 'idField' | 'schema' | 'idScalar' | 'idGeneration'>
 
-export class UserDAO<MetadataType, OperationMetadataType> extends AbstractMongoDBDAO<UserDAOGenerics<MetadataType, OperationMetadataType>> {  
+export class UserDAO<MetadataType, OperationMetadataType> extends T.AbstractMongoDBDAO<UserDAOGenerics<MetadataType, OperationMetadataType>> {  
   
   public static projection<P extends UserProjection>(p: P) {
     return p
   }
-  public static mergeProjection<P1 extends UserProjection, P2 extends UserProjection>(p1: P1, p2: P2): SelectProjection<UserProjection, P1, P2> {
-    return mergeProjections(p1, p2) as SelectProjection<UserProjection, P1, P2>
+  public static mergeProjection<P1 extends UserProjection, P2 extends UserProjection>(p1: P1, p2: P2): T.SelectProjection<UserProjection, P1, P2> {
+    return T.mergeProjections(p1, p2) as T.SelectProjection<UserProjection, P1, P2>
   }
   
   public constructor(params: UserDAOParams<MetadataType, OperationMetadataType>){
@@ -618,7 +617,7 @@ export class UserDAO<MetadataType, OperationMetadataType> extends AbstractMongoD
       ...params, 
       idField: 'id', 
       schema: userSchema(), 
-      relations: overrideRelations(
+      relations: T.overrideRelations(
         [
           { type: '1-n', reference: 'foreign', field: 'reservations', refFrom: 'userId', refTo: 'id', dao: 'reservation', required: true }
         ]
@@ -629,13 +628,13 @@ export class UserDAO<MetadataType, OperationMetadataType> extends AbstractMongoD
   }
   }
 
-export class InMemoryUserDAO<MetadataType, OperationMetadataType> extends AbstractInMemoryDAO<UserDAOGenerics<MetadataType, OperationMetadataType>> {  
+export class InMemoryUserDAO<MetadataType, OperationMetadataType> extends T.AbstractInMemoryDAO<UserDAOGenerics<MetadataType, OperationMetadataType>> {  
   
   public static projection<P extends UserProjection>(p: P) {
     return p
   }
-  public static mergeProjection<P1 extends UserProjection, P2 extends UserProjection>(p1: P1, p2: P2): SelectProjection<UserProjection, P1, P2> {
-    return mergeProjections(p1, p2) as SelectProjection<UserProjection, P1, P2>
+  public static mergeProjection<P1 extends UserProjection, P2 extends UserProjection>(p1: P1, p2: P2): T.SelectProjection<UserProjection, P1, P2> {
+    return T.mergeProjections(p1, p2) as T.SelectProjection<UserProjection, P1, P2>
   }
   
   public constructor(params: InMemoryUserDAOParams<MetadataType, OperationMetadataType>){
@@ -643,7 +642,7 @@ export class InMemoryUserDAO<MetadataType, OperationMetadataType> extends Abstra
       ...params, 
       idField: 'id', 
       schema: userSchema(), 
-      relations: overrideRelations(
+      relations: T.overrideRelations(
         [
           { type: '1-n', reference: 'foreign', field: 'reservations', refFrom: 'userId', refTo: 'id', dao: 'reservation', required: true }
         ]
@@ -660,7 +659,7 @@ export class InMemoryUserDAO<MetadataType, OperationMetadataType> extends Abstra
 //------------------------- USERNAMEPASSWORDCREDENTIALS --------------------------
 //--------------------------------------------------------------------------------
 
-export function usernamePasswordCredentialsSchema(): Schema<types.Scalars> {
+export function usernamePasswordCredentialsSchema(): T.Schema<types.Scalars> {
   return {
     'password': {
       scalar: 'Password', 
@@ -677,7 +676,7 @@ export type UsernamePasswordCredentialsProjection = {
   password?: boolean,
   username?: boolean,
 }
-export type UsernamePasswordCredentialsParam<P extends UsernamePasswordCredentialsProjection> = ParamProjection<types.UsernamePasswordCredentials, UsernamePasswordCredentialsProjection, P>
+export type UsernamePasswordCredentialsParam<P extends UsernamePasswordCredentialsProjection> = T.ParamProjection<types.UsernamePasswordCredentials, UsernamePasswordCredentialsProjection, P>
 
 export type UsernamePasswordCredentialsInsert = {
   password: types.Scalars['Password'],
@@ -695,15 +694,15 @@ export type DAOContextParams<MetadataType, OperationMetadataType, Permissions ex
     tenant?: Pick<Partial<TenantDAOParams<MetadataType, OperationMetadataType>>, 'middlewares' | 'metadata'>,
     user?: Pick<Partial<UserDAOParams<MetadataType, OperationMetadataType>>, 'middlewares' | 'metadata'>
   },
-  mongodb: Record<'default', Db | 'mock'>,
-  scalars?: UserInputDriverDataTypeAdapterMap<types.Scalars, 'mongo'>,
-  log?: LogInput<'hotel' | 'reservation' | 'room' | 'tenant' | 'user'>,
-  security?: DAOContextSecurtyPolicy<DAOGenericsMap<MetadataType, OperationMetadataType>, OperationMetadataType, Permissions, SecurityDomain>
+  mongodb: Record<'default', M.Db | 'mock'>,
+  scalars?: T.UserInputDriverDataTypeAdapterMap<types.Scalars, 'mongo'>,
+  log?: T.LogInput<'hotel' | 'reservation' | 'room' | 'tenant' | 'user'>,
+  security?: T.DAOContextSecurtyPolicy<DAOGenericsMap<MetadataType, OperationMetadataType>, OperationMetadataType, Permissions, SecurityDomain>
 }
 
-type DAOContextMiddleware<MetadataType = never, OperationMetadataType = never> = DAOMiddleware<DAOGenericsUnion<MetadataType, OperationMetadataType>>
+type DAOContextMiddleware<MetadataType = never, OperationMetadataType = never> = T.DAOMiddleware<DAOGenericsUnion<MetadataType, OperationMetadataType>>
 
-export class DAOContext<MetadataType = never, OperationMetadataType = never, Permissions extends string = never, SecurityDomain extends object = never> extends AbstractDAOContext<'default', never, types.Scalars, MetadataType>  {
+export class DAOContext<MetadataType = never, OperationMetadataType = never, Permissions extends string = never, SecurityDomain extends object = never> extends T.AbstractDAOContext<'default', never, types.Scalars, MetadataType>  {
 
   private _hotel: HotelDAO<MetadataType, OperationMetadataType> | undefined
   private _reservation: ReservationDAO<MetadataType, OperationMetadataType> | undefined
@@ -714,44 +713,44 @@ export class DAOContext<MetadataType = never, OperationMetadataType = never, Per
   private params: DAOContextParams<MetadataType, OperationMetadataType, Permissions, SecurityDomain>
   
   private overrides: DAOContextParams<MetadataType, OperationMetadataType, Permissions, SecurityDomain>['overrides']
-  private mongodb: Record<'default', Db | 'mock'>
+  private mongodb: Record<'default', M.Db | 'mock'>
   
   private middlewares: (DAOContextMiddleware<MetadataType, OperationMetadataType> | GroupMiddleware<any, MetadataType, OperationMetadataType>)[]
   
-  private logger?: LogFunction<'hotel' | 'reservation' | 'room' | 'tenant' | 'user'>
+  private logger?: T.LogFunction<'hotel' | 'reservation' | 'room' | 'tenant' | 'user'>
   
   get hotel(): HotelDAO<MetadataType, OperationMetadataType> {
     if(!this._hotel) {
       const db = this.mongodb.default
-      this._hotel = db === 'mock' ? (new InMemoryHotelDAO({ daoContext: this, datasource: null, metadata: this.metadata, ...this.overrides?.hotel, middlewares: [...(this.overrides?.hotel?.middlewares || []), ...selectMiddleware('hotel', this.middlewares) as DAOMiddleware<HotelDAOGenerics<MetadataType, OperationMetadataType>>[]], name: 'hotel', logger: this.logger }) as unknown as HotelDAO<MetadataType, OperationMetadataType>) : new HotelDAO({ daoContext: this, datasource: 'default', metadata: this.metadata, ...this.overrides?.hotel, collection: db.collection('hotels'), middlewares: [...(this.overrides?.hotel?.middlewares || []), ...selectMiddleware('hotel', this.middlewares) as DAOMiddleware<HotelDAOGenerics<MetadataType, OperationMetadataType>>[]], name: 'hotel', logger: this.logger })
+      this._hotel = db === 'mock' ? (new InMemoryHotelDAO({ daoContext: this, datasource: null, metadata: this.metadata, ...this.overrides?.hotel, middlewares: [...(this.overrides?.hotel?.middlewares || []), ...selectMiddleware('hotel', this.middlewares) as T.DAOMiddleware<HotelDAOGenerics<MetadataType, OperationMetadataType>>[]], name: 'hotel', logger: this.logger }) as unknown as HotelDAO<MetadataType, OperationMetadataType>) : new HotelDAO({ daoContext: this, datasource: 'default', metadata: this.metadata, ...this.overrides?.hotel, collection: db.collection('hotels'), middlewares: [...(this.overrides?.hotel?.middlewares || []), ...selectMiddleware('hotel', this.middlewares) as T.DAOMiddleware<HotelDAOGenerics<MetadataType, OperationMetadataType>>[]], name: 'hotel', logger: this.logger })
     }
     return this._hotel
   }
   get reservation(): ReservationDAO<MetadataType, OperationMetadataType> {
     if(!this._reservation) {
       const db = this.mongodb.default
-      this._reservation = db === 'mock' ? (new InMemoryReservationDAO({ daoContext: this, datasource: null, metadata: this.metadata, ...this.overrides?.reservation, middlewares: [...(this.overrides?.reservation?.middlewares || []), ...selectMiddleware('reservation', this.middlewares) as DAOMiddleware<ReservationDAOGenerics<MetadataType, OperationMetadataType>>[]], name: 'reservation', logger: this.logger }) as unknown as ReservationDAO<MetadataType, OperationMetadataType>) : new ReservationDAO({ daoContext: this, datasource: 'default', metadata: this.metadata, ...this.overrides?.reservation, collection: db.collection('reservations'), middlewares: [...(this.overrides?.reservation?.middlewares || []), ...selectMiddleware('reservation', this.middlewares) as DAOMiddleware<ReservationDAOGenerics<MetadataType, OperationMetadataType>>[]], name: 'reservation', logger: this.logger })
+      this._reservation = db === 'mock' ? (new InMemoryReservationDAO({ daoContext: this, datasource: null, metadata: this.metadata, ...this.overrides?.reservation, middlewares: [...(this.overrides?.reservation?.middlewares || []), ...selectMiddleware('reservation', this.middlewares) as T.DAOMiddleware<ReservationDAOGenerics<MetadataType, OperationMetadataType>>[]], name: 'reservation', logger: this.logger }) as unknown as ReservationDAO<MetadataType, OperationMetadataType>) : new ReservationDAO({ daoContext: this, datasource: 'default', metadata: this.metadata, ...this.overrides?.reservation, collection: db.collection('reservations'), middlewares: [...(this.overrides?.reservation?.middlewares || []), ...selectMiddleware('reservation', this.middlewares) as T.DAOMiddleware<ReservationDAOGenerics<MetadataType, OperationMetadataType>>[]], name: 'reservation', logger: this.logger })
     }
     return this._reservation
   }
   get room(): RoomDAO<MetadataType, OperationMetadataType> {
     if(!this._room) {
       const db = this.mongodb.default
-      this._room = db === 'mock' ? (new InMemoryRoomDAO({ daoContext: this, datasource: null, metadata: this.metadata, ...this.overrides?.room, middlewares: [...(this.overrides?.room?.middlewares || []), ...selectMiddleware('room', this.middlewares) as DAOMiddleware<RoomDAOGenerics<MetadataType, OperationMetadataType>>[]], name: 'room', logger: this.logger }) as unknown as RoomDAO<MetadataType, OperationMetadataType>) : new RoomDAO({ daoContext: this, datasource: 'default', metadata: this.metadata, ...this.overrides?.room, collection: db.collection('rooms'), middlewares: [...(this.overrides?.room?.middlewares || []), ...selectMiddleware('room', this.middlewares) as DAOMiddleware<RoomDAOGenerics<MetadataType, OperationMetadataType>>[]], name: 'room', logger: this.logger })
+      this._room = db === 'mock' ? (new InMemoryRoomDAO({ daoContext: this, datasource: null, metadata: this.metadata, ...this.overrides?.room, middlewares: [...(this.overrides?.room?.middlewares || []), ...selectMiddleware('room', this.middlewares) as T.DAOMiddleware<RoomDAOGenerics<MetadataType, OperationMetadataType>>[]], name: 'room', logger: this.logger }) as unknown as RoomDAO<MetadataType, OperationMetadataType>) : new RoomDAO({ daoContext: this, datasource: 'default', metadata: this.metadata, ...this.overrides?.room, collection: db.collection('rooms'), middlewares: [...(this.overrides?.room?.middlewares || []), ...selectMiddleware('room', this.middlewares) as T.DAOMiddleware<RoomDAOGenerics<MetadataType, OperationMetadataType>>[]], name: 'room', logger: this.logger })
     }
     return this._room
   }
   get tenant(): TenantDAO<MetadataType, OperationMetadataType> {
     if(!this._tenant) {
       const db = this.mongodb.default
-      this._tenant = db === 'mock' ? (new InMemoryTenantDAO({ daoContext: this, datasource: null, metadata: this.metadata, ...this.overrides?.tenant, middlewares: [...(this.overrides?.tenant?.middlewares || []), ...selectMiddleware('tenant', this.middlewares) as DAOMiddleware<TenantDAOGenerics<MetadataType, OperationMetadataType>>[]], name: 'tenant', logger: this.logger }) as unknown as TenantDAO<MetadataType, OperationMetadataType>) : new TenantDAO({ daoContext: this, datasource: 'default', metadata: this.metadata, ...this.overrides?.tenant, collection: db.collection('tenants'), middlewares: [...(this.overrides?.tenant?.middlewares || []), ...selectMiddleware('tenant', this.middlewares) as DAOMiddleware<TenantDAOGenerics<MetadataType, OperationMetadataType>>[]], name: 'tenant', logger: this.logger })
+      this._tenant = db === 'mock' ? (new InMemoryTenantDAO({ daoContext: this, datasource: null, metadata: this.metadata, ...this.overrides?.tenant, middlewares: [...(this.overrides?.tenant?.middlewares || []), ...selectMiddleware('tenant', this.middlewares) as T.DAOMiddleware<TenantDAOGenerics<MetadataType, OperationMetadataType>>[]], name: 'tenant', logger: this.logger }) as unknown as TenantDAO<MetadataType, OperationMetadataType>) : new TenantDAO({ daoContext: this, datasource: 'default', metadata: this.metadata, ...this.overrides?.tenant, collection: db.collection('tenants'), middlewares: [...(this.overrides?.tenant?.middlewares || []), ...selectMiddleware('tenant', this.middlewares) as T.DAOMiddleware<TenantDAOGenerics<MetadataType, OperationMetadataType>>[]], name: 'tenant', logger: this.logger })
     }
     return this._tenant
   }
   get user(): UserDAO<MetadataType, OperationMetadataType> {
     if(!this._user) {
       const db = this.mongodb.default
-      this._user = db === 'mock' ? (new InMemoryUserDAO({ daoContext: this, datasource: null, metadata: this.metadata, ...this.overrides?.user, middlewares: [...(this.overrides?.user?.middlewares || []), ...selectMiddleware('user', this.middlewares) as DAOMiddleware<UserDAOGenerics<MetadataType, OperationMetadataType>>[]], name: 'user', logger: this.logger }) as unknown as UserDAO<MetadataType, OperationMetadataType>) : new UserDAO({ daoContext: this, datasource: 'default', metadata: this.metadata, ...this.overrides?.user, collection: db.collection('users'), middlewares: [...(this.overrides?.user?.middlewares || []), ...selectMiddleware('user', this.middlewares) as DAOMiddleware<UserDAOGenerics<MetadataType, OperationMetadataType>>[]], name: 'user', logger: this.logger })
+      this._user = db === 'mock' ? (new InMemoryUserDAO({ daoContext: this, datasource: null, metadata: this.metadata, ...this.overrides?.user, middlewares: [...(this.overrides?.user?.middlewares || []), ...selectMiddleware('user', this.middlewares) as T.DAOMiddleware<UserDAOGenerics<MetadataType, OperationMetadataType>>[]], name: 'user', logger: this.logger }) as unknown as UserDAO<MetadataType, OperationMetadataType>) : new UserDAO({ daoContext: this, datasource: 'default', metadata: this.metadata, ...this.overrides?.user, collection: db.collection('users'), middlewares: [...(this.overrides?.user?.middlewares || []), ...selectMiddleware('user', this.middlewares) as T.DAOMiddleware<UserDAOGenerics<MetadataType, OperationMetadataType>>[]], name: 'user', logger: this.logger })
     }
     return this._user
   }
@@ -759,21 +758,21 @@ export class DAOContext<MetadataType = never, OperationMetadataType = never, Per
   constructor(params: DAOContextParams<MetadataType, OperationMetadataType, Permissions, SecurityDomain>) {
     super({
       ...params,
-      scalars: params.scalars ? userInputDataTypeAdapterToDataTypeAdapter(params.scalars, ['Date', 'Email', 'Password', 'TenantId', 'Username', 'ID', 'String', 'Boolean', 'Int', 'Float']) : undefined
+      scalars: params.scalars ? T.userInputDataTypeAdapterToDataTypeAdapter(params.scalars, ['Date', 'Email', 'Password', 'TenantId', 'Username', 'ID', 'String', 'Boolean', 'Int', 'Float']) : undefined
     })
     this.overrides = params.overrides
     this.mongodb = params.mongodb
     this.middlewares = params.middlewares || []
-    this.logger = logInputToLogger(params.log)
+    this.logger = T.logInputToLogger(params.log)
     if(params.security && params.security.applySecurity !== false) {
-      const securityMiddlewares = createSecurityPolicyMiddlewares(params.security)
+      const securityMiddlewares = T.createSecurityPolicyMiddlewares(params.security)
       const defaultMiddleware = securityMiddlewares.others ? [groupMiddleware.excludes(Object.fromEntries(Object.keys(securityMiddlewares.middlewares).map(k => [k, true])) as any, securityMiddlewares.others as any)] : []
       this.middlewares = [...(params.middlewares ?? []), ...defaultMiddleware, ...Object.entries(securityMiddlewares.middlewares).map(([name, middleware]) => groupMiddleware.includes({[name]: true} as any, middleware as any))]
     }
     this.params = params
   }
   
-  public async execQuery<T>(run: (dbs: { mongodb: Record<'default', Db | 'mock'> }, entities: { hotel: Collection<Document> | null, reservation: Collection<Document> | null, room: Collection<Document> | null, tenant: Collection<Document> | null, user: Collection<Document> | null }) => Promise<T>): Promise<T> {
+  public async execQuery<T>(run: (dbs: { mongodb: Record<'default', M.Db | 'mock'> }, entities: { hotel: M.Collection<M.Document> | null, reservation: M.Collection<M.Document> | null, room: M.Collection<M.Document> | null, tenant: M.Collection<M.Document> | null, user: M.Collection<M.Document> | null }) => Promise<T>): Promise<T> {
     return run({ mongodb: this.mongodb }, { hotel: this.mongodb.default === 'mock' ? null : this.mongodb.default.collection('hotels'), reservation: this.mongodb.default === 'mock' ? null : this.mongodb.default.collection('reservations'), room: this.mongodb.default === 'mock' ? null : this.mongodb.default.collection('rooms'), tenant: this.mongodb.default === 'mock' ? null : this.mongodb.default.collection('tenants'), user: this.mongodb.default === 'mock' ? null : this.mongodb.default.collection('users') })
   }
   
@@ -804,16 +803,16 @@ type GroupMiddleware<N extends DAOName, MetadataType, OperationMetadataType> =
   | ExcludeGroupMiddleware<N, MetadataType, OperationMetadataType>
 type IncludeGroupMiddleware<N extends DAOName, MetadataType, OperationMetadataType> = {
   include: { [K in N]: true }
-  middleware: DAOMiddleware<DAOGenericsMap<MetadataType, OperationMetadataType>[N]>
+  middleware: T.DAOMiddleware<DAOGenericsMap<MetadataType, OperationMetadataType>[N]>
 }
 type ExcludeGroupMiddleware<N extends DAOName, MetadataType, OperationMetadataType> = {
   exclude: { [K in N]: true }
-  middleware: DAOMiddleware<DAOGenericsMap<MetadataType, OperationMetadataType>[Exclude<DAOName, N>]>
+  middleware: T.DAOMiddleware<DAOGenericsMap<MetadataType, OperationMetadataType>[Exclude<DAOName, N>]>
 }
 export const groupMiddleware = {
   includes<N extends DAOName, MetadataType, OperationMetadataType>(
     include: { [K in N]: true },
-    middleware: DAOMiddleware<DAOGenericsMap<MetadataType, OperationMetadataType>[N]>,
+    middleware: T.DAOMiddleware<DAOGenericsMap<MetadataType, OperationMetadataType>[N]>,
   ): IncludeGroupMiddleware<N, MetadataType, OperationMetadataType> {
     return { include, middleware }
   },

--- a/tests/security/dao.mock.ts
+++ b/tests/security/dao.mock.ts
@@ -1,7 +1,6 @@
-import { DAOMiddleware, Coordinates, UserInputDriverDataTypeAdapterMap, Schema, AbstractDAOContext, LogicalOperators, QuantityOperators, EqualityOperators, StringOperators, ElementOperators, OneKey, SortDirection, overrideRelations, userInputDataTypeAdapterToDataTypeAdapter, LogFunction, LogInput, logInputToLogger, ParamProjection, DAOGenerics, CRUDPermission, DAOContextSecurtyPolicy, createSecurityPolicyMiddlewares, SelectProjection, mergeProjections, AbstractInMemoryDAO, InMemoryDAOGenerics, InMemoryDAOParams } from '../../src'
+import * as T from '../../src'
 import * as types from './models.mock'
-import { MongoDBDAOGenerics, MongoDBDAOParams, AbstractMongoDBDAO } from '../../src'
-import { Collection, Db, Filter, Sort, UpdateFilter, Document } from 'mongodb'
+import * as M from 'mongodb'
 
 //--------------------------------------------------------------------------------
 //------------------------------------ HOTEL -------------------------------------
@@ -10,7 +9,7 @@ import { Collection, Db, Filter, Sort, UpdateFilter, Document } from 'mongodb'
 export type HotelExcludedFields = never
 export type HotelRelationFields = never
 
-export function hotelSchema(): Schema<types.Scalars> {
+export function hotelSchema(): T.Schema<types.Scalars> {
   return {
     'description': {
       scalar: 'String'
@@ -35,14 +34,14 @@ export function hotelSchema(): Schema<types.Scalars> {
 }
 
 type HotelFilterFields = {
-  'description'?: types.Scalars['String'] | null | EqualityOperators<types.Scalars['String']> | ElementOperators | StringOperators,
-  'id'?: types.Scalars['ID'] | null | EqualityOperators<types.Scalars['ID']> | ElementOperators,
-  'name'?: types.Scalars['String'] | null | EqualityOperators<types.Scalars['String']> | ElementOperators | StringOperators,
-  'tenantId'?: types.Scalars['Int'] | null | EqualityOperators<types.Scalars['Int']> | ElementOperators | QuantityOperators<types.Scalars['Int']>,
-  'totalCustomers'?: types.Scalars['Int'] | null | EqualityOperators<types.Scalars['Int']> | ElementOperators | QuantityOperators<types.Scalars['Int']>
+  'description'?: types.Scalars['String'] | null | T.EqualityOperators<types.Scalars['String']> | T.ElementOperators | T.StringOperators,
+  'id'?: types.Scalars['ID'] | null | T.EqualityOperators<types.Scalars['ID']> | T.ElementOperators,
+  'name'?: types.Scalars['String'] | null | T.EqualityOperators<types.Scalars['String']> | T.ElementOperators | T.StringOperators,
+  'tenantId'?: types.Scalars['Int'] | null | T.EqualityOperators<types.Scalars['Int']> | T.ElementOperators | T.QuantityOperators<types.Scalars['Int']>,
+  'totalCustomers'?: types.Scalars['Int'] | null | T.EqualityOperators<types.Scalars['Int']> | T.ElementOperators | T.QuantityOperators<types.Scalars['Int']>
 }
-export type HotelFilter = HotelFilterFields & LogicalOperators<HotelFilterFields | HotelRawFilter>
-export type HotelRawFilter = () => Filter<Document>
+export type HotelFilter = HotelFilterFields & T.LogicalOperators<HotelFilterFields | HotelRawFilter>
+export type HotelRawFilter = () => M.Filter<M.Document>
 
 export type HotelRelations = Record<never, string>
 
@@ -53,11 +52,11 @@ export type HotelProjection = {
   tenantId?: boolean,
   totalCustomers?: boolean,
 }
-export type HotelParam<P extends HotelProjection> = ParamProjection<types.Hotel, HotelProjection, P>
+export type HotelParam<P extends HotelProjection> = T.ParamProjection<types.Hotel, HotelProjection, P>
 
 export type HotelSortKeys = 'description' | 'id' | 'name' | 'tenantId' | 'totalCustomers'
-export type HotelSort = OneKey<HotelSortKeys, SortDirection>
-export type HotelRawSort = () => Sort
+export type HotelSort = T.OneKey<HotelSortKeys, T.SortDirection>
+export type HotelRawSort = () => M.Sort
 
 export type HotelUpdate = {
   'description'?: types.Scalars['String'] | null,
@@ -66,7 +65,7 @@ export type HotelUpdate = {
   'tenantId'?: types.Scalars['Int'],
   'totalCustomers'?: types.Scalars['Int']
 }
-export type HotelRawUpdate = () => UpdateFilter<Document>
+export type HotelRawUpdate = () => M.UpdateFilter<M.Document>
 
 export type HotelInsert = {
   description?: null | types.Scalars['String'],
@@ -76,17 +75,17 @@ export type HotelInsert = {
   totalCustomers: types.Scalars['Int'],
 }
 
-type HotelDAOGenerics<MetadataType, OperationMetadataType> = MongoDBDAOGenerics<types.Hotel, 'id', 'ID', HotelFilter, HotelRawFilter, HotelRelations, HotelProjection, HotelSort, HotelRawSort, HotelInsert, HotelUpdate, HotelRawUpdate, HotelExcludedFields, HotelRelationFields, MetadataType, OperationMetadataType, types.Scalars, 'hotel', DAOContext<MetadataType, OperationMetadataType>>
-export type HotelDAOParams<MetadataType, OperationMetadataType> = Omit<MongoDBDAOParams<HotelDAOGenerics<MetadataType, OperationMetadataType>>, 'idField' | 'schema' | 'idScalar' | 'idGeneration'>
-export type InMemoryHotelDAOParams<MetadataType, OperationMetadataType> = Omit<InMemoryDAOParams<HotelDAOGenerics<MetadataType, OperationMetadataType>>, 'idField' | 'schema' | 'idScalar' | 'idGeneration'>
+type HotelDAOGenerics<MetadataType, OperationMetadataType> = T.MongoDBDAOGenerics<types.Hotel, 'id', 'ID', HotelFilter, HotelRawFilter, HotelRelations, HotelProjection, HotelSort, HotelRawSort, HotelInsert, HotelUpdate, HotelRawUpdate, HotelExcludedFields, HotelRelationFields, MetadataType, OperationMetadataType, types.Scalars, 'hotel', DAOContext<MetadataType, OperationMetadataType>>
+export type HotelDAOParams<MetadataType, OperationMetadataType> = Omit<T.MongoDBDAOParams<HotelDAOGenerics<MetadataType, OperationMetadataType>>, 'idField' | 'schema' | 'idScalar' | 'idGeneration'>
+export type InMemoryHotelDAOParams<MetadataType, OperationMetadataType> = Omit<T.InMemoryDAOParams<HotelDAOGenerics<MetadataType, OperationMetadataType>>, 'idField' | 'schema' | 'idScalar' | 'idGeneration'>
 
-export class HotelDAO<MetadataType, OperationMetadataType> extends AbstractMongoDBDAO<HotelDAOGenerics<MetadataType, OperationMetadataType>> {  
+export class HotelDAO<MetadataType, OperationMetadataType> extends T.AbstractMongoDBDAO<HotelDAOGenerics<MetadataType, OperationMetadataType>> {  
   
   public static projection<P extends HotelProjection>(p: P) {
     return p
   }
-  public static mergeProjection<P1 extends HotelProjection, P2 extends HotelProjection>(p1: P1, p2: P2): SelectProjection<HotelProjection, P1, P2> {
-    return mergeProjections(p1, p2) as SelectProjection<HotelProjection, P1, P2>
+  public static mergeProjection<P1 extends HotelProjection, P2 extends HotelProjection>(p1: P1, p2: P2): T.SelectProjection<HotelProjection, P1, P2> {
+    return T.mergeProjections(p1, p2) as T.SelectProjection<HotelProjection, P1, P2>
   }
   
   public constructor(params: HotelDAOParams<MetadataType, OperationMetadataType>){
@@ -94,7 +93,7 @@ export class HotelDAO<MetadataType, OperationMetadataType> extends AbstractMongo
       ...params, 
       idField: 'id', 
       schema: hotelSchema(), 
-      relations: overrideRelations(
+      relations: T.overrideRelations(
         [
           
         ]
@@ -105,13 +104,13 @@ export class HotelDAO<MetadataType, OperationMetadataType> extends AbstractMongo
   }
   }
 
-export class InMemoryHotelDAO<MetadataType, OperationMetadataType> extends AbstractInMemoryDAO<HotelDAOGenerics<MetadataType, OperationMetadataType>> {  
+export class InMemoryHotelDAO<MetadataType, OperationMetadataType> extends T.AbstractInMemoryDAO<HotelDAOGenerics<MetadataType, OperationMetadataType>> {  
   
   public static projection<P extends HotelProjection>(p: P) {
     return p
   }
-  public static mergeProjection<P1 extends HotelProjection, P2 extends HotelProjection>(p1: P1, p2: P2): SelectProjection<HotelProjection, P1, P2> {
-    return mergeProjections(p1, p2) as SelectProjection<HotelProjection, P1, P2>
+  public static mergeProjection<P1 extends HotelProjection, P2 extends HotelProjection>(p1: P1, p2: P2): T.SelectProjection<HotelProjection, P1, P2> {
+    return T.mergeProjections(p1, p2) as T.SelectProjection<HotelProjection, P1, P2>
   }
   
   public constructor(params: InMemoryHotelDAOParams<MetadataType, OperationMetadataType>){
@@ -119,7 +118,7 @@ export class InMemoryHotelDAO<MetadataType, OperationMetadataType> extends Abstr
       ...params, 
       idField: 'id', 
       schema: hotelSchema(), 
-      relations: overrideRelations(
+      relations: T.overrideRelations(
         [
           
         ]
@@ -139,7 +138,7 @@ export class InMemoryHotelDAO<MetadataType, OperationMetadataType> extends Abstr
 export type ReservationExcludedFields = never
 export type ReservationRelationFields = 'room'
 
-export function reservationSchema(): Schema<types.Scalars> {
+export function reservationSchema(): T.Schema<types.Scalars> {
   return {
     'hotelId': {
       scalar: 'ID', 
@@ -165,14 +164,14 @@ export function reservationSchema(): Schema<types.Scalars> {
 }
 
 type ReservationFilterFields = {
-  'hotelId'?: types.Scalars['ID'] | null | EqualityOperators<types.Scalars['ID']> | ElementOperators,
-  'id'?: types.Scalars['ID'] | null | EqualityOperators<types.Scalars['ID']> | ElementOperators,
-  'roomId'?: types.Scalars['ID'] | null | EqualityOperators<types.Scalars['ID']> | ElementOperators,
-  'tenantId'?: types.Scalars['Int'] | null | EqualityOperators<types.Scalars['Int']> | ElementOperators | QuantityOperators<types.Scalars['Int']>,
-  'userId'?: types.Scalars['ID'] | null | EqualityOperators<types.Scalars['ID']> | ElementOperators
+  'hotelId'?: types.Scalars['ID'] | null | T.EqualityOperators<types.Scalars['ID']> | T.ElementOperators,
+  'id'?: types.Scalars['ID'] | null | T.EqualityOperators<types.Scalars['ID']> | T.ElementOperators,
+  'roomId'?: types.Scalars['ID'] | null | T.EqualityOperators<types.Scalars['ID']> | T.ElementOperators,
+  'tenantId'?: types.Scalars['Int'] | null | T.EqualityOperators<types.Scalars['Int']> | T.ElementOperators | T.QuantityOperators<types.Scalars['Int']>,
+  'userId'?: types.Scalars['ID'] | null | T.EqualityOperators<types.Scalars['ID']> | T.ElementOperators
 }
-export type ReservationFilter = ReservationFilterFields & LogicalOperators<ReservationFilterFields | ReservationRawFilter>
-export type ReservationRawFilter = () => Filter<Document>
+export type ReservationFilter = ReservationFilterFields & T.LogicalOperators<ReservationFilterFields | ReservationRawFilter>
+export type ReservationRawFilter = () => M.Filter<M.Document>
 
 export type ReservationRelations = Record<never, string>
 
@@ -184,11 +183,11 @@ export type ReservationProjection = {
   tenantId?: boolean,
   userId?: boolean,
 }
-export type ReservationParam<P extends ReservationProjection> = ParamProjection<types.Reservation, ReservationProjection, P>
+export type ReservationParam<P extends ReservationProjection> = T.ParamProjection<types.Reservation, ReservationProjection, P>
 
 export type ReservationSortKeys = 'hotelId' | 'id' | 'roomId' | 'tenantId' | 'userId'
-export type ReservationSort = OneKey<ReservationSortKeys, SortDirection>
-export type ReservationRawSort = () => Sort
+export type ReservationSort = T.OneKey<ReservationSortKeys, T.SortDirection>
+export type ReservationRawSort = () => M.Sort
 
 export type ReservationUpdate = {
   'hotelId'?: types.Scalars['ID'],
@@ -197,7 +196,7 @@ export type ReservationUpdate = {
   'tenantId'?: types.Scalars['Int'],
   'userId'?: types.Scalars['ID']
 }
-export type ReservationRawUpdate = () => UpdateFilter<Document>
+export type ReservationRawUpdate = () => M.UpdateFilter<M.Document>
 
 export type ReservationInsert = {
   hotelId: types.Scalars['ID'],
@@ -207,17 +206,17 @@ export type ReservationInsert = {
   userId: types.Scalars['ID'],
 }
 
-type ReservationDAOGenerics<MetadataType, OperationMetadataType> = MongoDBDAOGenerics<types.Reservation, 'id', 'ID', ReservationFilter, ReservationRawFilter, ReservationRelations, ReservationProjection, ReservationSort, ReservationRawSort, ReservationInsert, ReservationUpdate, ReservationRawUpdate, ReservationExcludedFields, ReservationRelationFields, MetadataType, OperationMetadataType, types.Scalars, 'reservation', DAOContext<MetadataType, OperationMetadataType>>
-export type ReservationDAOParams<MetadataType, OperationMetadataType> = Omit<MongoDBDAOParams<ReservationDAOGenerics<MetadataType, OperationMetadataType>>, 'idField' | 'schema' | 'idScalar' | 'idGeneration'>
-export type InMemoryReservationDAOParams<MetadataType, OperationMetadataType> = Omit<InMemoryDAOParams<ReservationDAOGenerics<MetadataType, OperationMetadataType>>, 'idField' | 'schema' | 'idScalar' | 'idGeneration'>
+type ReservationDAOGenerics<MetadataType, OperationMetadataType> = T.MongoDBDAOGenerics<types.Reservation, 'id', 'ID', ReservationFilter, ReservationRawFilter, ReservationRelations, ReservationProjection, ReservationSort, ReservationRawSort, ReservationInsert, ReservationUpdate, ReservationRawUpdate, ReservationExcludedFields, ReservationRelationFields, MetadataType, OperationMetadataType, types.Scalars, 'reservation', DAOContext<MetadataType, OperationMetadataType>>
+export type ReservationDAOParams<MetadataType, OperationMetadataType> = Omit<T.MongoDBDAOParams<ReservationDAOGenerics<MetadataType, OperationMetadataType>>, 'idField' | 'schema' | 'idScalar' | 'idGeneration'>
+export type InMemoryReservationDAOParams<MetadataType, OperationMetadataType> = Omit<T.InMemoryDAOParams<ReservationDAOGenerics<MetadataType, OperationMetadataType>>, 'idField' | 'schema' | 'idScalar' | 'idGeneration'>
 
-export class ReservationDAO<MetadataType, OperationMetadataType> extends AbstractMongoDBDAO<ReservationDAOGenerics<MetadataType, OperationMetadataType>> {  
+export class ReservationDAO<MetadataType, OperationMetadataType> extends T.AbstractMongoDBDAO<ReservationDAOGenerics<MetadataType, OperationMetadataType>> {  
   
   public static projection<P extends ReservationProjection>(p: P) {
     return p
   }
-  public static mergeProjection<P1 extends ReservationProjection, P2 extends ReservationProjection>(p1: P1, p2: P2): SelectProjection<ReservationProjection, P1, P2> {
-    return mergeProjections(p1, p2) as SelectProjection<ReservationProjection, P1, P2>
+  public static mergeProjection<P1 extends ReservationProjection, P2 extends ReservationProjection>(p1: P1, p2: P2): T.SelectProjection<ReservationProjection, P1, P2> {
+    return T.mergeProjections(p1, p2) as T.SelectProjection<ReservationProjection, P1, P2>
   }
   
   public constructor(params: ReservationDAOParams<MetadataType, OperationMetadataType>){
@@ -225,7 +224,7 @@ export class ReservationDAO<MetadataType, OperationMetadataType> extends Abstrac
       ...params, 
       idField: 'id', 
       schema: reservationSchema(), 
-      relations: overrideRelations(
+      relations: T.overrideRelations(
         [
           { type: '1-1', reference: 'inner', field: 'room', refFrom: 'roomId', refTo: 'id', dao: 'room', required: false }
         ]
@@ -236,13 +235,13 @@ export class ReservationDAO<MetadataType, OperationMetadataType> extends Abstrac
   }
   }
 
-export class InMemoryReservationDAO<MetadataType, OperationMetadataType> extends AbstractInMemoryDAO<ReservationDAOGenerics<MetadataType, OperationMetadataType>> {  
+export class InMemoryReservationDAO<MetadataType, OperationMetadataType> extends T.AbstractInMemoryDAO<ReservationDAOGenerics<MetadataType, OperationMetadataType>> {  
   
   public static projection<P extends ReservationProjection>(p: P) {
     return p
   }
-  public static mergeProjection<P1 extends ReservationProjection, P2 extends ReservationProjection>(p1: P1, p2: P2): SelectProjection<ReservationProjection, P1, P2> {
-    return mergeProjections(p1, p2) as SelectProjection<ReservationProjection, P1, P2>
+  public static mergeProjection<P1 extends ReservationProjection, P2 extends ReservationProjection>(p1: P1, p2: P2): T.SelectProjection<ReservationProjection, P1, P2> {
+    return T.mergeProjections(p1, p2) as T.SelectProjection<ReservationProjection, P1, P2>
   }
   
   public constructor(params: InMemoryReservationDAOParams<MetadataType, OperationMetadataType>){
@@ -250,7 +249,7 @@ export class InMemoryReservationDAO<MetadataType, OperationMetadataType> extends
       ...params, 
       idField: 'id', 
       schema: reservationSchema(), 
-      relations: overrideRelations(
+      relations: T.overrideRelations(
         [
           { type: '1-1', reference: 'inner', field: 'room', refFrom: 'roomId', refTo: 'id', dao: 'room', required: false }
         ]
@@ -270,7 +269,7 @@ export class InMemoryReservationDAO<MetadataType, OperationMetadataType> extends
 export type RoleExcludedFields = never
 export type RoleRelationFields = never
 
-export function roleSchema(): Schema<types.Scalars> {
+export function roleSchema(): T.Schema<types.Scalars> {
   return {
     'code': {
       scalar: 'String', 
@@ -285,11 +284,11 @@ export function roleSchema(): Schema<types.Scalars> {
 }
 
 type RoleFilterFields = {
-  'code'?: types.RoleCode | null | EqualityOperators<types.RoleCode> | ElementOperators | StringOperators,
-  'permissions'?: types.Permission[] | null | EqualityOperators<types.Permission[]> | ElementOperators | StringOperators
+  'code'?: types.RoleCode | null | T.EqualityOperators<types.RoleCode> | T.ElementOperators | T.StringOperators,
+  'permissions'?: types.Permission[] | null | T.EqualityOperators<types.Permission[]> | T.ElementOperators | T.StringOperators
 }
-export type RoleFilter = RoleFilterFields & LogicalOperators<RoleFilterFields | RoleRawFilter>
-export type RoleRawFilter = () => Filter<Document>
+export type RoleFilter = RoleFilterFields & T.LogicalOperators<RoleFilterFields | RoleRawFilter>
+export type RoleRawFilter = () => M.Filter<M.Document>
 
 export type RoleRelations = Record<never, string>
 
@@ -297,34 +296,34 @@ export type RoleProjection = {
   code?: boolean,
   permissions?: boolean,
 }
-export type RoleParam<P extends RoleProjection> = ParamProjection<types.Role, RoleProjection, P>
+export type RoleParam<P extends RoleProjection> = T.ParamProjection<types.Role, RoleProjection, P>
 
 export type RoleSortKeys = 'code' | 'permissions'
-export type RoleSort = OneKey<RoleSortKeys, SortDirection>
-export type RoleRawSort = () => Sort
+export type RoleSort = T.OneKey<RoleSortKeys, T.SortDirection>
+export type RoleRawSort = () => M.Sort
 
 export type RoleUpdate = {
   'code'?: types.RoleCode,
   'permissions'?: (null | types.Permission)[]
 }
-export type RoleRawUpdate = () => UpdateFilter<Document>
+export type RoleRawUpdate = () => M.UpdateFilter<M.Document>
 
 export type RoleInsert = {
   code: types.RoleCode,
   permissions: (null | types.Permission)[],
 }
 
-type RoleDAOGenerics<MetadataType, OperationMetadataType> = MongoDBDAOGenerics<types.Role, 'code', 'String', RoleFilter, RoleRawFilter, RoleRelations, RoleProjection, RoleSort, RoleRawSort, RoleInsert, RoleUpdate, RoleRawUpdate, RoleExcludedFields, RoleRelationFields, MetadataType, OperationMetadataType, types.Scalars, 'role', DAOContext<MetadataType, OperationMetadataType>>
-export type RoleDAOParams<MetadataType, OperationMetadataType> = Omit<MongoDBDAOParams<RoleDAOGenerics<MetadataType, OperationMetadataType>>, 'idGenerator' | 'idField' | 'schema' | 'idScalar' | 'idGeneration'>
-export type InMemoryRoleDAOParams<MetadataType, OperationMetadataType> = Omit<InMemoryDAOParams<RoleDAOGenerics<MetadataType, OperationMetadataType>>, 'idGenerator' | 'idField' | 'schema' | 'idScalar' | 'idGeneration'>
+type RoleDAOGenerics<MetadataType, OperationMetadataType> = T.MongoDBDAOGenerics<types.Role, 'code', 'String', RoleFilter, RoleRawFilter, RoleRelations, RoleProjection, RoleSort, RoleRawSort, RoleInsert, RoleUpdate, RoleRawUpdate, RoleExcludedFields, RoleRelationFields, MetadataType, OperationMetadataType, types.Scalars, 'role', DAOContext<MetadataType, OperationMetadataType>>
+export type RoleDAOParams<MetadataType, OperationMetadataType> = Omit<T.MongoDBDAOParams<RoleDAOGenerics<MetadataType, OperationMetadataType>>, 'idGenerator' | 'idField' | 'schema' | 'idScalar' | 'idGeneration'>
+export type InMemoryRoleDAOParams<MetadataType, OperationMetadataType> = Omit<T.InMemoryDAOParams<RoleDAOGenerics<MetadataType, OperationMetadataType>>, 'idGenerator' | 'idField' | 'schema' | 'idScalar' | 'idGeneration'>
 
-export class RoleDAO<MetadataType, OperationMetadataType> extends AbstractMongoDBDAO<RoleDAOGenerics<MetadataType, OperationMetadataType>> {  
+export class RoleDAO<MetadataType, OperationMetadataType> extends T.AbstractMongoDBDAO<RoleDAOGenerics<MetadataType, OperationMetadataType>> {  
   
   public static projection<P extends RoleProjection>(p: P) {
     return p
   }
-  public static mergeProjection<P1 extends RoleProjection, P2 extends RoleProjection>(p1: P1, p2: P2): SelectProjection<RoleProjection, P1, P2> {
-    return mergeProjections(p1, p2) as SelectProjection<RoleProjection, P1, P2>
+  public static mergeProjection<P1 extends RoleProjection, P2 extends RoleProjection>(p1: P1, p2: P2): T.SelectProjection<RoleProjection, P1, P2> {
+    return T.mergeProjections(p1, p2) as T.SelectProjection<RoleProjection, P1, P2>
   }
   
   public constructor(params: RoleDAOParams<MetadataType, OperationMetadataType>){
@@ -332,7 +331,7 @@ export class RoleDAO<MetadataType, OperationMetadataType> extends AbstractMongoD
       ...params, 
       idField: 'code', 
       schema: roleSchema(), 
-      relations: overrideRelations(
+      relations: T.overrideRelations(
         [
           
         ]
@@ -343,13 +342,13 @@ export class RoleDAO<MetadataType, OperationMetadataType> extends AbstractMongoD
   }
   }
 
-export class InMemoryRoleDAO<MetadataType, OperationMetadataType> extends AbstractInMemoryDAO<RoleDAOGenerics<MetadataType, OperationMetadataType>> {  
+export class InMemoryRoleDAO<MetadataType, OperationMetadataType> extends T.AbstractInMemoryDAO<RoleDAOGenerics<MetadataType, OperationMetadataType>> {  
   
   public static projection<P extends RoleProjection>(p: P) {
     return p
   }
-  public static mergeProjection<P1 extends RoleProjection, P2 extends RoleProjection>(p1: P1, p2: P2): SelectProjection<RoleProjection, P1, P2> {
-    return mergeProjections(p1, p2) as SelectProjection<RoleProjection, P1, P2>
+  public static mergeProjection<P1 extends RoleProjection, P2 extends RoleProjection>(p1: P1, p2: P2): T.SelectProjection<RoleProjection, P1, P2> {
+    return T.mergeProjections(p1, p2) as T.SelectProjection<RoleProjection, P1, P2>
   }
   
   public constructor(params: InMemoryRoleDAOParams<MetadataType, OperationMetadataType>){
@@ -357,7 +356,7 @@ export class InMemoryRoleDAO<MetadataType, OperationMetadataType> extends Abstra
       ...params, 
       idField: 'code', 
       schema: roleSchema(), 
-      relations: overrideRelations(
+      relations: T.overrideRelations(
         [
           
         ]
@@ -377,7 +376,7 @@ export class InMemoryRoleDAO<MetadataType, OperationMetadataType> extends Abstra
 export type RoomExcludedFields = never
 export type RoomRelationFields = 'hotel'
 
-export function roomSchema(): Schema<types.Scalars> {
+export function roomSchema(): T.Schema<types.Scalars> {
   return {
     'description': {
       scalar: 'String', 
@@ -407,15 +406,15 @@ export function roomSchema(): Schema<types.Scalars> {
 }
 
 type RoomFilterFields = {
-  'description'?: types.Scalars['String'] | null | EqualityOperators<types.Scalars['String']> | ElementOperators | StringOperators,
-  'from'?: types.Scalars['Date'] | null | EqualityOperators<types.Scalars['Date']> | ElementOperators,
-  'hotelId'?: types.Scalars['ID'] | null | EqualityOperators<types.Scalars['ID']> | ElementOperators,
-  'id'?: types.Scalars['ID'] | null | EqualityOperators<types.Scalars['ID']> | ElementOperators,
-  'tenantId'?: types.Scalars['Int'] | null | EqualityOperators<types.Scalars['Int']> | ElementOperators | QuantityOperators<types.Scalars['Int']>,
-  'to'?: types.Scalars['Date'] | null | EqualityOperators<types.Scalars['Date']> | ElementOperators
+  'description'?: types.Scalars['String'] | null | T.EqualityOperators<types.Scalars['String']> | T.ElementOperators | T.StringOperators,
+  'from'?: types.Scalars['Date'] | null | T.EqualityOperators<types.Scalars['Date']> | T.ElementOperators,
+  'hotelId'?: types.Scalars['ID'] | null | T.EqualityOperators<types.Scalars['ID']> | T.ElementOperators,
+  'id'?: types.Scalars['ID'] | null | T.EqualityOperators<types.Scalars['ID']> | T.ElementOperators,
+  'tenantId'?: types.Scalars['Int'] | null | T.EqualityOperators<types.Scalars['Int']> | T.ElementOperators | T.QuantityOperators<types.Scalars['Int']>,
+  'to'?: types.Scalars['Date'] | null | T.EqualityOperators<types.Scalars['Date']> | T.ElementOperators
 }
-export type RoomFilter = RoomFilterFields & LogicalOperators<RoomFilterFields | RoomRawFilter>
-export type RoomRawFilter = () => Filter<Document>
+export type RoomFilter = RoomFilterFields & T.LogicalOperators<RoomFilterFields | RoomRawFilter>
+export type RoomRawFilter = () => M.Filter<M.Document>
 
 export type RoomRelations = Record<never, string>
 
@@ -428,11 +427,11 @@ export type RoomProjection = {
   tenantId?: boolean,
   to?: boolean,
 }
-export type RoomParam<P extends RoomProjection> = ParamProjection<types.Room, RoomProjection, P>
+export type RoomParam<P extends RoomProjection> = T.ParamProjection<types.Room, RoomProjection, P>
 
 export type RoomSortKeys = 'description' | 'from' | 'hotelId' | 'id' | 'tenantId' | 'to'
-export type RoomSort = OneKey<RoomSortKeys, SortDirection>
-export type RoomRawSort = () => Sort
+export type RoomSort = T.OneKey<RoomSortKeys, T.SortDirection>
+export type RoomRawSort = () => M.Sort
 
 export type RoomUpdate = {
   'description'?: types.Scalars['String'],
@@ -442,7 +441,7 @@ export type RoomUpdate = {
   'tenantId'?: types.Scalars['Int'],
   'to'?: types.Scalars['Date']
 }
-export type RoomRawUpdate = () => UpdateFilter<Document>
+export type RoomRawUpdate = () => M.UpdateFilter<M.Document>
 
 export type RoomInsert = {
   description: types.Scalars['String'],
@@ -453,17 +452,17 @@ export type RoomInsert = {
   to: types.Scalars['Date'],
 }
 
-type RoomDAOGenerics<MetadataType, OperationMetadataType> = MongoDBDAOGenerics<types.Room, 'id', 'ID', RoomFilter, RoomRawFilter, RoomRelations, RoomProjection, RoomSort, RoomRawSort, RoomInsert, RoomUpdate, RoomRawUpdate, RoomExcludedFields, RoomRelationFields, MetadataType, OperationMetadataType, types.Scalars, 'room', DAOContext<MetadataType, OperationMetadataType>>
-export type RoomDAOParams<MetadataType, OperationMetadataType> = Omit<MongoDBDAOParams<RoomDAOGenerics<MetadataType, OperationMetadataType>>, 'idField' | 'schema' | 'idScalar' | 'idGeneration'>
-export type InMemoryRoomDAOParams<MetadataType, OperationMetadataType> = Omit<InMemoryDAOParams<RoomDAOGenerics<MetadataType, OperationMetadataType>>, 'idField' | 'schema' | 'idScalar' | 'idGeneration'>
+type RoomDAOGenerics<MetadataType, OperationMetadataType> = T.MongoDBDAOGenerics<types.Room, 'id', 'ID', RoomFilter, RoomRawFilter, RoomRelations, RoomProjection, RoomSort, RoomRawSort, RoomInsert, RoomUpdate, RoomRawUpdate, RoomExcludedFields, RoomRelationFields, MetadataType, OperationMetadataType, types.Scalars, 'room', DAOContext<MetadataType, OperationMetadataType>>
+export type RoomDAOParams<MetadataType, OperationMetadataType> = Omit<T.MongoDBDAOParams<RoomDAOGenerics<MetadataType, OperationMetadataType>>, 'idField' | 'schema' | 'idScalar' | 'idGeneration'>
+export type InMemoryRoomDAOParams<MetadataType, OperationMetadataType> = Omit<T.InMemoryDAOParams<RoomDAOGenerics<MetadataType, OperationMetadataType>>, 'idField' | 'schema' | 'idScalar' | 'idGeneration'>
 
-export class RoomDAO<MetadataType, OperationMetadataType> extends AbstractMongoDBDAO<RoomDAOGenerics<MetadataType, OperationMetadataType>> {  
+export class RoomDAO<MetadataType, OperationMetadataType> extends T.AbstractMongoDBDAO<RoomDAOGenerics<MetadataType, OperationMetadataType>> {  
   
   public static projection<P extends RoomProjection>(p: P) {
     return p
   }
-  public static mergeProjection<P1 extends RoomProjection, P2 extends RoomProjection>(p1: P1, p2: P2): SelectProjection<RoomProjection, P1, P2> {
-    return mergeProjections(p1, p2) as SelectProjection<RoomProjection, P1, P2>
+  public static mergeProjection<P1 extends RoomProjection, P2 extends RoomProjection>(p1: P1, p2: P2): T.SelectProjection<RoomProjection, P1, P2> {
+    return T.mergeProjections(p1, p2) as T.SelectProjection<RoomProjection, P1, P2>
   }
   
   public constructor(params: RoomDAOParams<MetadataType, OperationMetadataType>){
@@ -471,7 +470,7 @@ export class RoomDAO<MetadataType, OperationMetadataType> extends AbstractMongoD
       ...params, 
       idField: 'id', 
       schema: roomSchema(), 
-      relations: overrideRelations(
+      relations: T.overrideRelations(
         [
           { type: '1-1', reference: 'inner', field: 'hotel', refFrom: 'hotelId', refTo: 'id', dao: 'hotel', required: true }
         ]
@@ -482,13 +481,13 @@ export class RoomDAO<MetadataType, OperationMetadataType> extends AbstractMongoD
   }
   }
 
-export class InMemoryRoomDAO<MetadataType, OperationMetadataType> extends AbstractInMemoryDAO<RoomDAOGenerics<MetadataType, OperationMetadataType>> {  
+export class InMemoryRoomDAO<MetadataType, OperationMetadataType> extends T.AbstractInMemoryDAO<RoomDAOGenerics<MetadataType, OperationMetadataType>> {  
   
   public static projection<P extends RoomProjection>(p: P) {
     return p
   }
-  public static mergeProjection<P1 extends RoomProjection, P2 extends RoomProjection>(p1: P1, p2: P2): SelectProjection<RoomProjection, P1, P2> {
-    return mergeProjections(p1, p2) as SelectProjection<RoomProjection, P1, P2>
+  public static mergeProjection<P1 extends RoomProjection, P2 extends RoomProjection>(p1: P1, p2: P2): T.SelectProjection<RoomProjection, P1, P2> {
+    return T.mergeProjections(p1, p2) as T.SelectProjection<RoomProjection, P1, P2>
   }
   
   public constructor(params: InMemoryRoomDAOParams<MetadataType, OperationMetadataType>){
@@ -496,7 +495,7 @@ export class InMemoryRoomDAO<MetadataType, OperationMetadataType> extends Abstra
       ...params, 
       idField: 'id', 
       schema: roomSchema(), 
-      relations: overrideRelations(
+      relations: T.overrideRelations(
         [
           { type: '1-1', reference: 'inner', field: 'hotel', refFrom: 'hotelId', refTo: 'id', dao: 'hotel', required: true }
         ]
@@ -516,7 +515,7 @@ export class InMemoryRoomDAO<MetadataType, OperationMetadataType> extends Abstra
 export type UserExcludedFields = never
 export type UserRelationFields = 'reservations' | 'roles'
 
-export function userSchema(): Schema<types.Scalars> {
+export function userSchema(): T.Schema<types.Scalars> {
   return {
     'email': {
       scalar: 'Email', 
@@ -539,14 +538,14 @@ export function userSchema(): Schema<types.Scalars> {
 }
 
 type UserFilterFields = {
-  'email'?: types.Scalars['Email'] | null | EqualityOperators<types.Scalars['Email']> | ElementOperators,
-  'firstName'?: types.Scalars['String'] | null | EqualityOperators<types.Scalars['String']> | ElementOperators | StringOperators,
-  'id'?: types.Scalars['ID'] | null | EqualityOperators<types.Scalars['ID']> | ElementOperators,
-  'lastName'?: types.Scalars['String'] | null | EqualityOperators<types.Scalars['String']> | ElementOperators | StringOperators,
-  'totalPayments'?: types.Scalars['Int'] | null | EqualityOperators<types.Scalars['Int']> | ElementOperators | QuantityOperators<types.Scalars['Int']>
+  'email'?: types.Scalars['Email'] | null | T.EqualityOperators<types.Scalars['Email']> | T.ElementOperators,
+  'firstName'?: types.Scalars['String'] | null | T.EqualityOperators<types.Scalars['String']> | T.ElementOperators | T.StringOperators,
+  'id'?: types.Scalars['ID'] | null | T.EqualityOperators<types.Scalars['ID']> | T.ElementOperators,
+  'lastName'?: types.Scalars['String'] | null | T.EqualityOperators<types.Scalars['String']> | T.ElementOperators | T.StringOperators,
+  'totalPayments'?: types.Scalars['Int'] | null | T.EqualityOperators<types.Scalars['Int']> | T.ElementOperators | T.QuantityOperators<types.Scalars['Int']>
 }
-export type UserFilter = UserFilterFields & LogicalOperators<UserFilterFields | UserRawFilter>
-export type UserRawFilter = () => Filter<Document>
+export type UserFilter = UserFilterFields & T.LogicalOperators<UserFilterFields | UserRawFilter>
+export type UserRawFilter = () => M.Filter<M.Document>
 
 export type UserRelations = {
   reservations?: {
@@ -574,11 +573,11 @@ export type UserProjection = {
   roles?: UserRoleProjection | boolean,
   totalPayments?: boolean,
 }
-export type UserParam<P extends UserProjection> = ParamProjection<types.User, UserProjection, P>
+export type UserParam<P extends UserProjection> = T.ParamProjection<types.User, UserProjection, P>
 
 export type UserSortKeys = 'email' | 'firstName' | 'id' | 'lastName' | 'totalPayments'
-export type UserSort = OneKey<UserSortKeys, SortDirection>
-export type UserRawSort = () => Sort
+export type UserSort = T.OneKey<UserSortKeys, T.SortDirection>
+export type UserRawSort = () => M.Sort
 
 export type UserUpdate = {
   'email'?: types.Scalars['Email'],
@@ -587,7 +586,7 @@ export type UserUpdate = {
   'lastName'?: types.Scalars['String'] | null,
   'totalPayments'?: types.Scalars['Int'] | null
 }
-export type UserRawUpdate = () => UpdateFilter<Document>
+export type UserRawUpdate = () => M.UpdateFilter<M.Document>
 
 export type UserInsert = {
   email: types.Scalars['Email'],
@@ -597,17 +596,17 @@ export type UserInsert = {
   totalPayments?: null | types.Scalars['Int'],
 }
 
-type UserDAOGenerics<MetadataType, OperationMetadataType> = MongoDBDAOGenerics<types.User, 'id', 'ID', UserFilter, UserRawFilter, UserRelations, UserProjection, UserSort, UserRawSort, UserInsert, UserUpdate, UserRawUpdate, UserExcludedFields, UserRelationFields, MetadataType, OperationMetadataType, types.Scalars, 'user', DAOContext<MetadataType, OperationMetadataType>>
-export type UserDAOParams<MetadataType, OperationMetadataType> = Omit<MongoDBDAOParams<UserDAOGenerics<MetadataType, OperationMetadataType>>, 'idField' | 'schema' | 'idScalar' | 'idGeneration'>
-export type InMemoryUserDAOParams<MetadataType, OperationMetadataType> = Omit<InMemoryDAOParams<UserDAOGenerics<MetadataType, OperationMetadataType>>, 'idField' | 'schema' | 'idScalar' | 'idGeneration'>
+type UserDAOGenerics<MetadataType, OperationMetadataType> = T.MongoDBDAOGenerics<types.User, 'id', 'ID', UserFilter, UserRawFilter, UserRelations, UserProjection, UserSort, UserRawSort, UserInsert, UserUpdate, UserRawUpdate, UserExcludedFields, UserRelationFields, MetadataType, OperationMetadataType, types.Scalars, 'user', DAOContext<MetadataType, OperationMetadataType>>
+export type UserDAOParams<MetadataType, OperationMetadataType> = Omit<T.MongoDBDAOParams<UserDAOGenerics<MetadataType, OperationMetadataType>>, 'idField' | 'schema' | 'idScalar' | 'idGeneration'>
+export type InMemoryUserDAOParams<MetadataType, OperationMetadataType> = Omit<T.InMemoryDAOParams<UserDAOGenerics<MetadataType, OperationMetadataType>>, 'idField' | 'schema' | 'idScalar' | 'idGeneration'>
 
-export class UserDAO<MetadataType, OperationMetadataType> extends AbstractMongoDBDAO<UserDAOGenerics<MetadataType, OperationMetadataType>> {  
+export class UserDAO<MetadataType, OperationMetadataType> extends T.AbstractMongoDBDAO<UserDAOGenerics<MetadataType, OperationMetadataType>> {  
   
   public static projection<P extends UserProjection>(p: P) {
     return p
   }
-  public static mergeProjection<P1 extends UserProjection, P2 extends UserProjection>(p1: P1, p2: P2): SelectProjection<UserProjection, P1, P2> {
-    return mergeProjections(p1, p2) as SelectProjection<UserProjection, P1, P2>
+  public static mergeProjection<P1 extends UserProjection, P2 extends UserProjection>(p1: P1, p2: P2): T.SelectProjection<UserProjection, P1, P2> {
+    return T.mergeProjections(p1, p2) as T.SelectProjection<UserProjection, P1, P2>
   }
   
   public constructor(params: UserDAOParams<MetadataType, OperationMetadataType>){
@@ -615,7 +614,7 @@ export class UserDAO<MetadataType, OperationMetadataType> extends AbstractMongoD
       ...params, 
       idField: 'id', 
       schema: userSchema(), 
-      relations: overrideRelations(
+      relations: T.overrideRelations(
         [
           { type: '1-n', reference: 'foreign', field: 'reservations', refFrom: 'userId', refTo: 'id', dao: 'reservation', required: true },
           { type: '1-n', reference: 'foreign', field: 'roles', refFrom: 'refUserId', refTo: 'id', dao: 'userRole', required: true }
@@ -627,13 +626,13 @@ export class UserDAO<MetadataType, OperationMetadataType> extends AbstractMongoD
   }
   }
 
-export class InMemoryUserDAO<MetadataType, OperationMetadataType> extends AbstractInMemoryDAO<UserDAOGenerics<MetadataType, OperationMetadataType>> {  
+export class InMemoryUserDAO<MetadataType, OperationMetadataType> extends T.AbstractInMemoryDAO<UserDAOGenerics<MetadataType, OperationMetadataType>> {  
   
   public static projection<P extends UserProjection>(p: P) {
     return p
   }
-  public static mergeProjection<P1 extends UserProjection, P2 extends UserProjection>(p1: P1, p2: P2): SelectProjection<UserProjection, P1, P2> {
-    return mergeProjections(p1, p2) as SelectProjection<UserProjection, P1, P2>
+  public static mergeProjection<P1 extends UserProjection, P2 extends UserProjection>(p1: P1, p2: P2): T.SelectProjection<UserProjection, P1, P2> {
+    return T.mergeProjections(p1, p2) as T.SelectProjection<UserProjection, P1, P2>
   }
   
   public constructor(params: InMemoryUserDAOParams<MetadataType, OperationMetadataType>){
@@ -641,7 +640,7 @@ export class InMemoryUserDAO<MetadataType, OperationMetadataType> extends Abstra
       ...params, 
       idField: 'id', 
       schema: userSchema(), 
-      relations: overrideRelations(
+      relations: T.overrideRelations(
         [
           { type: '1-n', reference: 'foreign', field: 'reservations', refFrom: 'userId', refTo: 'id', dao: 'reservation', required: true },
           { type: '1-n', reference: 'foreign', field: 'roles', refFrom: 'refUserId', refTo: 'id', dao: 'userRole', required: true }
@@ -662,7 +661,7 @@ export class InMemoryUserDAO<MetadataType, OperationMetadataType> extends Abstra
 export type UserRoleExcludedFields = never
 export type UserRoleRelationFields = 'role'
 
-export function userRoleSchema(): Schema<types.Scalars> {
+export function userRoleSchema(): T.Schema<types.Scalars> {
   return {
     'hotelId': {
       scalar: 'ID'
@@ -690,15 +689,15 @@ export function userRoleSchema(): Schema<types.Scalars> {
 }
 
 type UserRoleFilterFields = {
-  'hotelId'?: types.Scalars['ID'] | null | EqualityOperators<types.Scalars['ID']> | ElementOperators,
-  'id'?: types.Scalars['ID'] | null | EqualityOperators<types.Scalars['ID']> | ElementOperators,
-  'refUserId'?: types.Scalars['ID'] | null | EqualityOperators<types.Scalars['ID']> | ElementOperators,
-  'roleCode'?: types.RoleCode | null | EqualityOperators<types.RoleCode> | ElementOperators | StringOperators,
-  'tenantId'?: types.Scalars['Int'] | null | EqualityOperators<types.Scalars['Int']> | ElementOperators | QuantityOperators<types.Scalars['Int']>,
-  'userId'?: types.Scalars['ID'] | null | EqualityOperators<types.Scalars['ID']> | ElementOperators
+  'hotelId'?: types.Scalars['ID'] | null | T.EqualityOperators<types.Scalars['ID']> | T.ElementOperators,
+  'id'?: types.Scalars['ID'] | null | T.EqualityOperators<types.Scalars['ID']> | T.ElementOperators,
+  'refUserId'?: types.Scalars['ID'] | null | T.EqualityOperators<types.Scalars['ID']> | T.ElementOperators,
+  'roleCode'?: types.RoleCode | null | T.EqualityOperators<types.RoleCode> | T.ElementOperators | T.StringOperators,
+  'tenantId'?: types.Scalars['Int'] | null | T.EqualityOperators<types.Scalars['Int']> | T.ElementOperators | T.QuantityOperators<types.Scalars['Int']>,
+  'userId'?: types.Scalars['ID'] | null | T.EqualityOperators<types.Scalars['ID']> | T.ElementOperators
 }
-export type UserRoleFilter = UserRoleFilterFields & LogicalOperators<UserRoleFilterFields | UserRoleRawFilter>
-export type UserRoleRawFilter = () => Filter<Document>
+export type UserRoleFilter = UserRoleFilterFields & T.LogicalOperators<UserRoleFilterFields | UserRoleRawFilter>
+export type UserRoleRawFilter = () => M.Filter<M.Document>
 
 export type UserRoleRelations = Record<never, string>
 
@@ -711,11 +710,11 @@ export type UserRoleProjection = {
   tenantId?: boolean,
   userId?: boolean,
 }
-export type UserRoleParam<P extends UserRoleProjection> = ParamProjection<types.UserRole, UserRoleProjection, P>
+export type UserRoleParam<P extends UserRoleProjection> = T.ParamProjection<types.UserRole, UserRoleProjection, P>
 
 export type UserRoleSortKeys = 'hotelId' | 'id' | 'refUserId' | 'roleCode' | 'tenantId' | 'userId'
-export type UserRoleSort = OneKey<UserRoleSortKeys, SortDirection>
-export type UserRoleRawSort = () => Sort
+export type UserRoleSort = T.OneKey<UserRoleSortKeys, T.SortDirection>
+export type UserRoleRawSort = () => M.Sort
 
 export type UserRoleUpdate = {
   'hotelId'?: types.Scalars['ID'] | null,
@@ -725,7 +724,7 @@ export type UserRoleUpdate = {
   'tenantId'?: types.Scalars['Int'] | null,
   'userId'?: types.Scalars['ID'] | null
 }
-export type UserRoleRawUpdate = () => UpdateFilter<Document>
+export type UserRoleRawUpdate = () => M.UpdateFilter<M.Document>
 
 export type UserRoleInsert = {
   hotelId?: null | types.Scalars['ID'],
@@ -735,17 +734,17 @@ export type UserRoleInsert = {
   userId?: null | types.Scalars['ID'],
 }
 
-type UserRoleDAOGenerics<MetadataType, OperationMetadataType> = MongoDBDAOGenerics<types.UserRole, 'id', 'ID', UserRoleFilter, UserRoleRawFilter, UserRoleRelations, UserRoleProjection, UserRoleSort, UserRoleRawSort, UserRoleInsert, UserRoleUpdate, UserRoleRawUpdate, UserRoleExcludedFields, UserRoleRelationFields, MetadataType, OperationMetadataType, types.Scalars, 'userRole', DAOContext<MetadataType, OperationMetadataType>>
-export type UserRoleDAOParams<MetadataType, OperationMetadataType> = Omit<MongoDBDAOParams<UserRoleDAOGenerics<MetadataType, OperationMetadataType>>, 'idGenerator' | 'idField' | 'schema' | 'idScalar' | 'idGeneration'>
-export type InMemoryUserRoleDAOParams<MetadataType, OperationMetadataType> = Omit<InMemoryDAOParams<UserRoleDAOGenerics<MetadataType, OperationMetadataType>>, 'idGenerator' | 'idField' | 'schema' | 'idScalar' | 'idGeneration'>
+type UserRoleDAOGenerics<MetadataType, OperationMetadataType> = T.MongoDBDAOGenerics<types.UserRole, 'id', 'ID', UserRoleFilter, UserRoleRawFilter, UserRoleRelations, UserRoleProjection, UserRoleSort, UserRoleRawSort, UserRoleInsert, UserRoleUpdate, UserRoleRawUpdate, UserRoleExcludedFields, UserRoleRelationFields, MetadataType, OperationMetadataType, types.Scalars, 'userRole', DAOContext<MetadataType, OperationMetadataType>>
+export type UserRoleDAOParams<MetadataType, OperationMetadataType> = Omit<T.MongoDBDAOParams<UserRoleDAOGenerics<MetadataType, OperationMetadataType>>, 'idGenerator' | 'idField' | 'schema' | 'idScalar' | 'idGeneration'>
+export type InMemoryUserRoleDAOParams<MetadataType, OperationMetadataType> = Omit<T.InMemoryDAOParams<UserRoleDAOGenerics<MetadataType, OperationMetadataType>>, 'idGenerator' | 'idField' | 'schema' | 'idScalar' | 'idGeneration'>
 
-export class UserRoleDAO<MetadataType, OperationMetadataType> extends AbstractMongoDBDAO<UserRoleDAOGenerics<MetadataType, OperationMetadataType>> {  
+export class UserRoleDAO<MetadataType, OperationMetadataType> extends T.AbstractMongoDBDAO<UserRoleDAOGenerics<MetadataType, OperationMetadataType>> {  
   
   public static projection<P extends UserRoleProjection>(p: P) {
     return p
   }
-  public static mergeProjection<P1 extends UserRoleProjection, P2 extends UserRoleProjection>(p1: P1, p2: P2): SelectProjection<UserRoleProjection, P1, P2> {
-    return mergeProjections(p1, p2) as SelectProjection<UserRoleProjection, P1, P2>
+  public static mergeProjection<P1 extends UserRoleProjection, P2 extends UserRoleProjection>(p1: P1, p2: P2): T.SelectProjection<UserRoleProjection, P1, P2> {
+    return T.mergeProjections(p1, p2) as T.SelectProjection<UserRoleProjection, P1, P2>
   }
   
   public constructor(params: UserRoleDAOParams<MetadataType, OperationMetadataType>){
@@ -753,7 +752,7 @@ export class UserRoleDAO<MetadataType, OperationMetadataType> extends AbstractMo
       ...params, 
       idField: 'id', 
       schema: userRoleSchema(), 
-      relations: overrideRelations(
+      relations: T.overrideRelations(
         [
           { type: '1-1', reference: 'inner', field: 'role', refFrom: 'roleCode', refTo: 'code', dao: 'role', required: true }
         ]
@@ -764,13 +763,13 @@ export class UserRoleDAO<MetadataType, OperationMetadataType> extends AbstractMo
   }
   }
 
-export class InMemoryUserRoleDAO<MetadataType, OperationMetadataType> extends AbstractInMemoryDAO<UserRoleDAOGenerics<MetadataType, OperationMetadataType>> {  
+export class InMemoryUserRoleDAO<MetadataType, OperationMetadataType> extends T.AbstractInMemoryDAO<UserRoleDAOGenerics<MetadataType, OperationMetadataType>> {  
   
   public static projection<P extends UserRoleProjection>(p: P) {
     return p
   }
-  public static mergeProjection<P1 extends UserRoleProjection, P2 extends UserRoleProjection>(p1: P1, p2: P2): SelectProjection<UserRoleProjection, P1, P2> {
-    return mergeProjections(p1, p2) as SelectProjection<UserRoleProjection, P1, P2>
+  public static mergeProjection<P1 extends UserRoleProjection, P2 extends UserRoleProjection>(p1: P1, p2: P2): T.SelectProjection<UserRoleProjection, P1, P2> {
+    return T.mergeProjections(p1, p2) as T.SelectProjection<UserRoleProjection, P1, P2>
   }
   
   public constructor(params: InMemoryUserRoleDAOParams<MetadataType, OperationMetadataType>){
@@ -778,7 +777,7 @@ export class InMemoryUserRoleDAO<MetadataType, OperationMetadataType> extends Ab
       ...params, 
       idField: 'id', 
       schema: userRoleSchema(), 
-      relations: overrideRelations(
+      relations: T.overrideRelations(
         [
           { type: '1-1', reference: 'inner', field: 'role', refFrom: 'roleCode', refTo: 'code', dao: 'role', required: true }
         ]
@@ -801,15 +800,15 @@ export type DAOContextParams<MetadataType, OperationMetadataType, Permissions ex
     user?: Pick<Partial<UserDAOParams<MetadataType, OperationMetadataType>>, 'idGenerator' | 'middlewares' | 'metadata'>,
     userRole?: Pick<Partial<UserRoleDAOParams<MetadataType, OperationMetadataType>>, 'middlewares' | 'metadata'>
   },
-  mongodb: Record<'default', Db | 'mock'>,
-  scalars?: UserInputDriverDataTypeAdapterMap<types.Scalars, 'mongo'>,
-  log?: LogInput<'hotel' | 'reservation' | 'role' | 'room' | 'user' | 'userRole'>,
-  security?: DAOContextSecurtyPolicy<DAOGenericsMap<MetadataType, OperationMetadataType>, OperationMetadataType, Permissions, SecurityDomain>
+  mongodb: Record<'default', M.Db | 'mock'>,
+  scalars?: T.UserInputDriverDataTypeAdapterMap<types.Scalars, 'mongo'>,
+  log?: T.LogInput<'hotel' | 'reservation' | 'role' | 'room' | 'user' | 'userRole'>,
+  security?: T.DAOContextSecurtyPolicy<DAOGenericsMap<MetadataType, OperationMetadataType>, OperationMetadataType, Permissions, SecurityDomain>
 }
 
-type DAOContextMiddleware<MetadataType = never, OperationMetadataType = never> = DAOMiddleware<DAOGenericsUnion<MetadataType, OperationMetadataType>>
+type DAOContextMiddleware<MetadataType = never, OperationMetadataType = never> = T.DAOMiddleware<DAOGenericsUnion<MetadataType, OperationMetadataType>>
 
-export class DAOContext<MetadataType = never, OperationMetadataType = never, Permissions extends string = never, SecurityDomain extends object = never> extends AbstractDAOContext<'default', never, types.Scalars, MetadataType>  {
+export class DAOContext<MetadataType = never, OperationMetadataType = never, Permissions extends string = never, SecurityDomain extends object = never> extends T.AbstractDAOContext<'default', never, types.Scalars, MetadataType>  {
 
   private _hotel: HotelDAO<MetadataType, OperationMetadataType> | undefined
   private _reservation: ReservationDAO<MetadataType, OperationMetadataType> | undefined
@@ -821,51 +820,51 @@ export class DAOContext<MetadataType = never, OperationMetadataType = never, Per
   private params: DAOContextParams<MetadataType, OperationMetadataType, Permissions, SecurityDomain>
   
   private overrides: DAOContextParams<MetadataType, OperationMetadataType, Permissions, SecurityDomain>['overrides']
-  private mongodb: Record<'default', Db | 'mock'>
+  private mongodb: Record<'default', M.Db | 'mock'>
   
   private middlewares: (DAOContextMiddleware<MetadataType, OperationMetadataType> | GroupMiddleware<any, MetadataType, OperationMetadataType>)[]
   
-  private logger?: LogFunction<'hotel' | 'reservation' | 'role' | 'room' | 'user' | 'userRole'>
+  private logger?: T.LogFunction<'hotel' | 'reservation' | 'role' | 'room' | 'user' | 'userRole'>
   
   get hotel(): HotelDAO<MetadataType, OperationMetadataType> {
     if(!this._hotel) {
       const db = this.mongodb.default
-      this._hotel = db === 'mock' ? (new InMemoryHotelDAO({ daoContext: this, datasource: null, metadata: this.metadata, ...this.overrides?.hotel, middlewares: [...(this.overrides?.hotel?.middlewares || []), ...selectMiddleware('hotel', this.middlewares) as DAOMiddleware<HotelDAOGenerics<MetadataType, OperationMetadataType>>[]], name: 'hotel', logger: this.logger }) as unknown as HotelDAO<MetadataType, OperationMetadataType>) : new HotelDAO({ daoContext: this, datasource: 'default', metadata: this.metadata, ...this.overrides?.hotel, collection: db.collection('hotels'), middlewares: [...(this.overrides?.hotel?.middlewares || []), ...selectMiddleware('hotel', this.middlewares) as DAOMiddleware<HotelDAOGenerics<MetadataType, OperationMetadataType>>[]], name: 'hotel', logger: this.logger })
+      this._hotel = db === 'mock' ? (new InMemoryHotelDAO({ daoContext: this, datasource: null, metadata: this.metadata, ...this.overrides?.hotel, middlewares: [...(this.overrides?.hotel?.middlewares || []), ...selectMiddleware('hotel', this.middlewares) as T.DAOMiddleware<HotelDAOGenerics<MetadataType, OperationMetadataType>>[]], name: 'hotel', logger: this.logger }) as unknown as HotelDAO<MetadataType, OperationMetadataType>) : new HotelDAO({ daoContext: this, datasource: 'default', metadata: this.metadata, ...this.overrides?.hotel, collection: db.collection('hotels'), middlewares: [...(this.overrides?.hotel?.middlewares || []), ...selectMiddleware('hotel', this.middlewares) as T.DAOMiddleware<HotelDAOGenerics<MetadataType, OperationMetadataType>>[]], name: 'hotel', logger: this.logger })
     }
     return this._hotel
   }
   get reservation(): ReservationDAO<MetadataType, OperationMetadataType> {
     if(!this._reservation) {
       const db = this.mongodb.default
-      this._reservation = db === 'mock' ? (new InMemoryReservationDAO({ daoContext: this, datasource: null, metadata: this.metadata, ...this.overrides?.reservation, middlewares: [...(this.overrides?.reservation?.middlewares || []), ...selectMiddleware('reservation', this.middlewares) as DAOMiddleware<ReservationDAOGenerics<MetadataType, OperationMetadataType>>[]], name: 'reservation', logger: this.logger }) as unknown as ReservationDAO<MetadataType, OperationMetadataType>) : new ReservationDAO({ daoContext: this, datasource: 'default', metadata: this.metadata, ...this.overrides?.reservation, collection: db.collection('reservations'), middlewares: [...(this.overrides?.reservation?.middlewares || []), ...selectMiddleware('reservation', this.middlewares) as DAOMiddleware<ReservationDAOGenerics<MetadataType, OperationMetadataType>>[]], name: 'reservation', logger: this.logger })
+      this._reservation = db === 'mock' ? (new InMemoryReservationDAO({ daoContext: this, datasource: null, metadata: this.metadata, ...this.overrides?.reservation, middlewares: [...(this.overrides?.reservation?.middlewares || []), ...selectMiddleware('reservation', this.middlewares) as T.DAOMiddleware<ReservationDAOGenerics<MetadataType, OperationMetadataType>>[]], name: 'reservation', logger: this.logger }) as unknown as ReservationDAO<MetadataType, OperationMetadataType>) : new ReservationDAO({ daoContext: this, datasource: 'default', metadata: this.metadata, ...this.overrides?.reservation, collection: db.collection('reservations'), middlewares: [...(this.overrides?.reservation?.middlewares || []), ...selectMiddleware('reservation', this.middlewares) as T.DAOMiddleware<ReservationDAOGenerics<MetadataType, OperationMetadataType>>[]], name: 'reservation', logger: this.logger })
     }
     return this._reservation
   }
   get role(): RoleDAO<MetadataType, OperationMetadataType> {
     if(!this._role) {
       const db = this.mongodb.default
-      this._role = db === 'mock' ? (new InMemoryRoleDAO({ daoContext: this, datasource: null, metadata: this.metadata, ...this.overrides?.role, middlewares: [...(this.overrides?.role?.middlewares || []), ...selectMiddleware('role', this.middlewares) as DAOMiddleware<RoleDAOGenerics<MetadataType, OperationMetadataType>>[]], name: 'role', logger: this.logger }) as unknown as RoleDAO<MetadataType, OperationMetadataType>) : new RoleDAO({ daoContext: this, datasource: 'default', metadata: this.metadata, ...this.overrides?.role, collection: db.collection('roles'), middlewares: [...(this.overrides?.role?.middlewares || []), ...selectMiddleware('role', this.middlewares) as DAOMiddleware<RoleDAOGenerics<MetadataType, OperationMetadataType>>[]], name: 'role', logger: this.logger })
+      this._role = db === 'mock' ? (new InMemoryRoleDAO({ daoContext: this, datasource: null, metadata: this.metadata, ...this.overrides?.role, middlewares: [...(this.overrides?.role?.middlewares || []), ...selectMiddleware('role', this.middlewares) as T.DAOMiddleware<RoleDAOGenerics<MetadataType, OperationMetadataType>>[]], name: 'role', logger: this.logger }) as unknown as RoleDAO<MetadataType, OperationMetadataType>) : new RoleDAO({ daoContext: this, datasource: 'default', metadata: this.metadata, ...this.overrides?.role, collection: db.collection('roles'), middlewares: [...(this.overrides?.role?.middlewares || []), ...selectMiddleware('role', this.middlewares) as T.DAOMiddleware<RoleDAOGenerics<MetadataType, OperationMetadataType>>[]], name: 'role', logger: this.logger })
     }
     return this._role
   }
   get room(): RoomDAO<MetadataType, OperationMetadataType> {
     if(!this._room) {
       const db = this.mongodb.default
-      this._room = db === 'mock' ? (new InMemoryRoomDAO({ daoContext: this, datasource: null, metadata: this.metadata, ...this.overrides?.room, middlewares: [...(this.overrides?.room?.middlewares || []), ...selectMiddleware('room', this.middlewares) as DAOMiddleware<RoomDAOGenerics<MetadataType, OperationMetadataType>>[]], name: 'room', logger: this.logger }) as unknown as RoomDAO<MetadataType, OperationMetadataType>) : new RoomDAO({ daoContext: this, datasource: 'default', metadata: this.metadata, ...this.overrides?.room, collection: db.collection('rooms'), middlewares: [...(this.overrides?.room?.middlewares || []), ...selectMiddleware('room', this.middlewares) as DAOMiddleware<RoomDAOGenerics<MetadataType, OperationMetadataType>>[]], name: 'room', logger: this.logger })
+      this._room = db === 'mock' ? (new InMemoryRoomDAO({ daoContext: this, datasource: null, metadata: this.metadata, ...this.overrides?.room, middlewares: [...(this.overrides?.room?.middlewares || []), ...selectMiddleware('room', this.middlewares) as T.DAOMiddleware<RoomDAOGenerics<MetadataType, OperationMetadataType>>[]], name: 'room', logger: this.logger }) as unknown as RoomDAO<MetadataType, OperationMetadataType>) : new RoomDAO({ daoContext: this, datasource: 'default', metadata: this.metadata, ...this.overrides?.room, collection: db.collection('rooms'), middlewares: [...(this.overrides?.room?.middlewares || []), ...selectMiddleware('room', this.middlewares) as T.DAOMiddleware<RoomDAOGenerics<MetadataType, OperationMetadataType>>[]], name: 'room', logger: this.logger })
     }
     return this._room
   }
   get user(): UserDAO<MetadataType, OperationMetadataType> {
     if(!this._user) {
       const db = this.mongodb.default
-      this._user = db === 'mock' ? (new InMemoryUserDAO({ daoContext: this, datasource: null, metadata: this.metadata, ...this.overrides?.user, middlewares: [...(this.overrides?.user?.middlewares || []), ...selectMiddleware('user', this.middlewares) as DAOMiddleware<UserDAOGenerics<MetadataType, OperationMetadataType>>[]], name: 'user', logger: this.logger }) as unknown as UserDAO<MetadataType, OperationMetadataType>) : new UserDAO({ daoContext: this, datasource: 'default', metadata: this.metadata, ...this.overrides?.user, collection: db.collection('users'), middlewares: [...(this.overrides?.user?.middlewares || []), ...selectMiddleware('user', this.middlewares) as DAOMiddleware<UserDAOGenerics<MetadataType, OperationMetadataType>>[]], name: 'user', logger: this.logger })
+      this._user = db === 'mock' ? (new InMemoryUserDAO({ daoContext: this, datasource: null, metadata: this.metadata, ...this.overrides?.user, middlewares: [...(this.overrides?.user?.middlewares || []), ...selectMiddleware('user', this.middlewares) as T.DAOMiddleware<UserDAOGenerics<MetadataType, OperationMetadataType>>[]], name: 'user', logger: this.logger }) as unknown as UserDAO<MetadataType, OperationMetadataType>) : new UserDAO({ daoContext: this, datasource: 'default', metadata: this.metadata, ...this.overrides?.user, collection: db.collection('users'), middlewares: [...(this.overrides?.user?.middlewares || []), ...selectMiddleware('user', this.middlewares) as T.DAOMiddleware<UserDAOGenerics<MetadataType, OperationMetadataType>>[]], name: 'user', logger: this.logger })
     }
     return this._user
   }
   get userRole(): UserRoleDAO<MetadataType, OperationMetadataType> {
     if(!this._userRole) {
       const db = this.mongodb.default
-      this._userRole = db === 'mock' ? (new InMemoryUserRoleDAO({ daoContext: this, datasource: null, metadata: this.metadata, ...this.overrides?.userRole, middlewares: [...(this.overrides?.userRole?.middlewares || []), ...selectMiddleware('userRole', this.middlewares) as DAOMiddleware<UserRoleDAOGenerics<MetadataType, OperationMetadataType>>[]], name: 'userRole', logger: this.logger }) as unknown as UserRoleDAO<MetadataType, OperationMetadataType>) : new UserRoleDAO({ daoContext: this, datasource: 'default', metadata: this.metadata, ...this.overrides?.userRole, collection: db.collection('userRoles'), middlewares: [...(this.overrides?.userRole?.middlewares || []), ...selectMiddleware('userRole', this.middlewares) as DAOMiddleware<UserRoleDAOGenerics<MetadataType, OperationMetadataType>>[]], name: 'userRole', logger: this.logger })
+      this._userRole = db === 'mock' ? (new InMemoryUserRoleDAO({ daoContext: this, datasource: null, metadata: this.metadata, ...this.overrides?.userRole, middlewares: [...(this.overrides?.userRole?.middlewares || []), ...selectMiddleware('userRole', this.middlewares) as T.DAOMiddleware<UserRoleDAOGenerics<MetadataType, OperationMetadataType>>[]], name: 'userRole', logger: this.logger }) as unknown as UserRoleDAO<MetadataType, OperationMetadataType>) : new UserRoleDAO({ daoContext: this, datasource: 'default', metadata: this.metadata, ...this.overrides?.userRole, collection: db.collection('userRoles'), middlewares: [...(this.overrides?.userRole?.middlewares || []), ...selectMiddleware('userRole', this.middlewares) as T.DAOMiddleware<UserRoleDAOGenerics<MetadataType, OperationMetadataType>>[]], name: 'userRole', logger: this.logger })
     }
     return this._userRole
   }
@@ -873,21 +872,21 @@ export class DAOContext<MetadataType = never, OperationMetadataType = never, Per
   constructor(params: DAOContextParams<MetadataType, OperationMetadataType, Permissions, SecurityDomain>) {
     super({
       ...params,
-      scalars: params.scalars ? userInputDataTypeAdapterToDataTypeAdapter(params.scalars, ['Date', 'Email', 'Password', 'Username', 'ID', 'String', 'Boolean', 'Int', 'Float']) : undefined
+      scalars: params.scalars ? T.userInputDataTypeAdapterToDataTypeAdapter(params.scalars, ['Date', 'Email', 'Password', 'Username', 'ID', 'String', 'Boolean', 'Int', 'Float']) : undefined
     })
     this.overrides = params.overrides
     this.mongodb = params.mongodb
     this.middlewares = params.middlewares || []
-    this.logger = logInputToLogger(params.log)
+    this.logger = T.logInputToLogger(params.log)
     if(params.security && params.security.applySecurity !== false) {
-      const securityMiddlewares = createSecurityPolicyMiddlewares(params.security)
+      const securityMiddlewares = T.createSecurityPolicyMiddlewares(params.security)
       const defaultMiddleware = securityMiddlewares.others ? [groupMiddleware.excludes(Object.fromEntries(Object.keys(securityMiddlewares.middlewares).map(k => [k, true])) as any, securityMiddlewares.others as any)] : []
       this.middlewares = [...(params.middlewares ?? []), ...defaultMiddleware, ...Object.entries(securityMiddlewares.middlewares).map(([name, middleware]) => groupMiddleware.includes({[name]: true} as any, middleware as any))]
     }
     this.params = params
   }
   
-  public async execQuery<T>(run: (dbs: { mongodb: Record<'default', Db | 'mock'> }, entities: { hotel: Collection<Document> | null, reservation: Collection<Document> | null, role: Collection<Document> | null, room: Collection<Document> | null, user: Collection<Document> | null, userRole: Collection<Document> | null }) => Promise<T>): Promise<T> {
+  public async execQuery<T>(run: (dbs: { mongodb: Record<'default', M.Db | 'mock'> }, entities: { hotel: M.Collection<M.Document> | null, reservation: M.Collection<M.Document> | null, role: M.Collection<M.Document> | null, room: M.Collection<M.Document> | null, user: M.Collection<M.Document> | null, userRole: M.Collection<M.Document> | null }) => Promise<T>): Promise<T> {
     return run({ mongodb: this.mongodb }, { hotel: this.mongodb.default === 'mock' ? null : this.mongodb.default.collection('hotels'), reservation: this.mongodb.default === 'mock' ? null : this.mongodb.default.collection('reservations'), role: this.mongodb.default === 'mock' ? null : this.mongodb.default.collection('roles'), room: this.mongodb.default === 'mock' ? null : this.mongodb.default.collection('rooms'), user: this.mongodb.default === 'mock' ? null : this.mongodb.default.collection('users'), userRole: this.mongodb.default === 'mock' ? null : this.mongodb.default.collection('userRoles') })
   }
   
@@ -919,16 +918,16 @@ type GroupMiddleware<N extends DAOName, MetadataType, OperationMetadataType> =
   | ExcludeGroupMiddleware<N, MetadataType, OperationMetadataType>
 type IncludeGroupMiddleware<N extends DAOName, MetadataType, OperationMetadataType> = {
   include: { [K in N]: true }
-  middleware: DAOMiddleware<DAOGenericsMap<MetadataType, OperationMetadataType>[N]>
+  middleware: T.DAOMiddleware<DAOGenericsMap<MetadataType, OperationMetadataType>[N]>
 }
 type ExcludeGroupMiddleware<N extends DAOName, MetadataType, OperationMetadataType> = {
   exclude: { [K in N]: true }
-  middleware: DAOMiddleware<DAOGenericsMap<MetadataType, OperationMetadataType>[Exclude<DAOName, N>]>
+  middleware: T.DAOMiddleware<DAOGenericsMap<MetadataType, OperationMetadataType>[Exclude<DAOName, N>]>
 }
 export const groupMiddleware = {
   includes<N extends DAOName, MetadataType, OperationMetadataType>(
     include: { [K in N]: true },
-    middleware: DAOMiddleware<DAOGenericsMap<MetadataType, OperationMetadataType>[N]>,
+    middleware: T.DAOMiddleware<DAOGenericsMap<MetadataType, OperationMetadataType>[N]>,
   ): IncludeGroupMiddleware<N, MetadataType, OperationMetadataType> {
     return { include, middleware }
   },

--- a/tests/sql/dao.mock.ts
+++ b/tests/sql/dao.mock.ts
@@ -1,6 +1,5 @@
-import { DAOMiddleware, Coordinates, UserInputDriverDataTypeAdapterMap, Schema, AbstractDAOContext, LogicalOperators, QuantityOperators, EqualityOperators, StringOperators, ElementOperators, OneKey, SortDirection, overrideRelations, userInputDataTypeAdapterToDataTypeAdapter, LogFunction, LogInput, logInputToLogger, ParamProjection, DAOGenerics, CRUDPermission, DAOContextSecurtyPolicy, createSecurityPolicyMiddlewares, SelectProjection, mergeProjections, AbstractInMemoryDAO, InMemoryDAOGenerics, InMemoryDAOParams } from '../../src'
+import * as T from '../../src'
 import * as types from './models.mock'
-import { KnexJsDAOGenerics, KnexJsDAOParams, AbstractKnexJsDAO } from '../../src'
 import { Knex } from 'knex'
 
 //--------------------------------------------------------------------------------
@@ -10,7 +9,7 @@ import { Knex } from 'knex'
 export type AddressExcludedFields = never
 export type AddressRelationFields = 'cities'
 
-export function addressSchema(): Schema<types.Scalars> {
+export function addressSchema(): T.Schema<types.Scalars> {
   return {
     'id': {
       scalar: 'ID', 
@@ -20,9 +19,9 @@ export function addressSchema(): Schema<types.Scalars> {
 }
 
 type AddressFilterFields = {
-  'id'?: types.Scalars['ID'] | null | EqualityOperators<types.Scalars['ID']> | ElementOperators
+  'id'?: types.Scalars['ID'] | null | T.EqualityOperators<types.Scalars['ID']> | T.ElementOperators
 }
-export type AddressFilter = AddressFilterFields & LogicalOperators<AddressFilterFields | AddressRawFilter>
+export type AddressFilter = AddressFilterFields & T.LogicalOperators<AddressFilterFields | AddressRawFilter>
 export type AddressRawFilter = (builder: Knex.QueryBuilder<any, any>) => Knex.QueryBuilder<any, any>
 
 export type AddressRelations = {
@@ -39,10 +38,10 @@ export type AddressProjection = {
   cities?: CityProjection | boolean,
   id?: boolean,
 }
-export type AddressParam<P extends AddressProjection> = ParamProjection<types.Address, AddressProjection, P>
+export type AddressParam<P extends AddressProjection> = T.ParamProjection<types.Address, AddressProjection, P>
 
 export type AddressSortKeys = 'id'
-export type AddressSort = OneKey<AddressSortKeys, SortDirection>
+export type AddressSort = T.OneKey<AddressSortKeys, T.SortDirection>
 export type AddressRawSort = (builder: Knex.QueryBuilder<any, any>) => Knex.QueryBuilder<any, any>
 
 export type AddressUpdate = {
@@ -54,17 +53,17 @@ export type AddressInsert = {
   id?: null | types.Scalars['ID'],
 }
 
-type AddressDAOGenerics<MetadataType, OperationMetadataType> = KnexJsDAOGenerics<types.Address, 'id', 'ID', AddressFilter, AddressRawFilter, AddressRelations, AddressProjection, AddressSort, AddressRawSort, AddressInsert, AddressUpdate, AddressRawUpdate, AddressExcludedFields, AddressRelationFields, MetadataType, OperationMetadataType, types.Scalars, 'address', DAOContext<MetadataType, OperationMetadataType>>
-export type AddressDAOParams<MetadataType, OperationMetadataType> = Omit<KnexJsDAOParams<AddressDAOGenerics<MetadataType, OperationMetadataType>>, 'idField' | 'schema' | 'idScalar' | 'idGeneration'>
-export type InMemoryAddressDAOParams<MetadataType, OperationMetadataType> = Omit<InMemoryDAOParams<AddressDAOGenerics<MetadataType, OperationMetadataType>>, 'idField' | 'schema' | 'idScalar' | 'idGeneration'>
+type AddressDAOGenerics<MetadataType, OperationMetadataType> = T.KnexJsDAOGenerics<types.Address, 'id', 'ID', AddressFilter, AddressRawFilter, AddressRelations, AddressProjection, AddressSort, AddressRawSort, AddressInsert, AddressUpdate, AddressRawUpdate, AddressExcludedFields, AddressRelationFields, MetadataType, OperationMetadataType, types.Scalars, 'address', DAOContext<MetadataType, OperationMetadataType>>
+export type AddressDAOParams<MetadataType, OperationMetadataType> = Omit<T.KnexJsDAOParams<AddressDAOGenerics<MetadataType, OperationMetadataType>>, 'idField' | 'schema' | 'idScalar' | 'idGeneration'>
+export type InMemoryAddressDAOParams<MetadataType, OperationMetadataType> = Omit<T.InMemoryDAOParams<AddressDAOGenerics<MetadataType, OperationMetadataType>>, 'idField' | 'schema' | 'idScalar' | 'idGeneration'>
 
-export class AddressDAO<MetadataType, OperationMetadataType> extends AbstractKnexJsDAO<AddressDAOGenerics<MetadataType, OperationMetadataType>> {  
+export class AddressDAO<MetadataType, OperationMetadataType> extends T.AbstractKnexJsDAO<AddressDAOGenerics<MetadataType, OperationMetadataType>> {  
   
   public static projection<P extends AddressProjection>(p: P) {
     return p
   }
-  public static mergeProjection<P1 extends AddressProjection, P2 extends AddressProjection>(p1: P1, p2: P2): SelectProjection<AddressProjection, P1, P2> {
-    return mergeProjections(p1, p2) as SelectProjection<AddressProjection, P1, P2>
+  public static mergeProjection<P1 extends AddressProjection, P2 extends AddressProjection>(p1: P1, p2: P2): T.SelectProjection<AddressProjection, P1, P2> {
+    return T.mergeProjections(p1, p2) as T.SelectProjection<AddressProjection, P1, P2>
   }
   
   public constructor(params: AddressDAOParams<MetadataType, OperationMetadataType>){
@@ -72,7 +71,7 @@ export class AddressDAO<MetadataType, OperationMetadataType> extends AbstractKne
       ...params, 
       idField: 'id', 
       schema: addressSchema(), 
-      relations: overrideRelations(
+      relations: T.overrideRelations(
         [
           { type: '1-n', reference: 'foreign', field: 'cities', refFrom: 'addressId', refTo: 'id', dao: 'city', required: false }
         ]
@@ -83,13 +82,13 @@ export class AddressDAO<MetadataType, OperationMetadataType> extends AbstractKne
   }
   }
 
-export class InMemoryAddressDAO<MetadataType, OperationMetadataType> extends AbstractInMemoryDAO<AddressDAOGenerics<MetadataType, OperationMetadataType>> {  
+export class InMemoryAddressDAO<MetadataType, OperationMetadataType> extends T.AbstractInMemoryDAO<AddressDAOGenerics<MetadataType, OperationMetadataType>> {  
   
   public static projection<P extends AddressProjection>(p: P) {
     return p
   }
-  public static mergeProjection<P1 extends AddressProjection, P2 extends AddressProjection>(p1: P1, p2: P2): SelectProjection<AddressProjection, P1, P2> {
-    return mergeProjections(p1, p2) as SelectProjection<AddressProjection, P1, P2>
+  public static mergeProjection<P1 extends AddressProjection, P2 extends AddressProjection>(p1: P1, p2: P2): T.SelectProjection<AddressProjection, P1, P2> {
+    return T.mergeProjections(p1, p2) as T.SelectProjection<AddressProjection, P1, P2>
   }
   
   public constructor(params: InMemoryAddressDAOParams<MetadataType, OperationMetadataType>){
@@ -97,7 +96,7 @@ export class InMemoryAddressDAO<MetadataType, OperationMetadataType> extends Abs
       ...params, 
       idField: 'id', 
       schema: addressSchema(), 
-      relations: overrideRelations(
+      relations: T.overrideRelations(
         [
           { type: '1-n', reference: 'foreign', field: 'cities', refFrom: 'addressId', refTo: 'id', dao: 'city', required: false }
         ]
@@ -114,7 +113,7 @@ export class InMemoryAddressDAO<MetadataType, OperationMetadataType> extends Abs
 //----------------------------------- ANOTHER ------------------------------------
 //--------------------------------------------------------------------------------
 
-export function anotherSchema(): Schema<types.Scalars> {
+export function anotherSchema(): T.Schema<types.Scalars> {
   return {
     'test': {
       scalar: 'String', 
@@ -126,7 +125,7 @@ export function anotherSchema(): Schema<types.Scalars> {
 export type AnotherProjection = {
   test?: boolean,
 }
-export type AnotherParam<P extends AnotherProjection> = ParamProjection<types.Another, AnotherProjection, P>
+export type AnotherParam<P extends AnotherProjection> = T.ParamProjection<types.Another, AnotherProjection, P>
 
 export type AnotherInsert = {
   test?: null | types.Scalars['String'],
@@ -141,7 +140,7 @@ export type AnotherInsert = {
 export type AuthorExcludedFields = never
 export type AuthorRelationFields = 'books'
 
-export function authorSchema(): Schema<types.Scalars> {
+export function authorSchema(): T.Schema<types.Scalars> {
   return {
     'id': {
       scalar: 'ID', 
@@ -151,9 +150,9 @@ export function authorSchema(): Schema<types.Scalars> {
 }
 
 type AuthorFilterFields = {
-  'id'?: types.Scalars['ID'] | null | EqualityOperators<types.Scalars['ID']> | ElementOperators
+  'id'?: types.Scalars['ID'] | null | T.EqualityOperators<types.Scalars['ID']> | T.ElementOperators
 }
-export type AuthorFilter = AuthorFilterFields & LogicalOperators<AuthorFilterFields | AuthorRawFilter>
+export type AuthorFilter = AuthorFilterFields & T.LogicalOperators<AuthorFilterFields | AuthorRawFilter>
 export type AuthorRawFilter = (builder: Knex.QueryBuilder<any, any>) => Knex.QueryBuilder<any, any>
 
 export type AuthorRelations = {
@@ -170,10 +169,10 @@ export type AuthorProjection = {
   books?: BookProjection | boolean,
   id?: boolean,
 }
-export type AuthorParam<P extends AuthorProjection> = ParamProjection<types.Author, AuthorProjection, P>
+export type AuthorParam<P extends AuthorProjection> = T.ParamProjection<types.Author, AuthorProjection, P>
 
 export type AuthorSortKeys = 'id'
-export type AuthorSort = OneKey<AuthorSortKeys, SortDirection>
+export type AuthorSort = T.OneKey<AuthorSortKeys, T.SortDirection>
 export type AuthorRawSort = (builder: Knex.QueryBuilder<any, any>) => Knex.QueryBuilder<any, any>
 
 export type AuthorUpdate = {
@@ -185,17 +184,17 @@ export type AuthorInsert = {
   id?: null | types.Scalars['ID'],
 }
 
-type AuthorDAOGenerics<MetadataType, OperationMetadataType> = KnexJsDAOGenerics<types.Author, 'id', 'ID', AuthorFilter, AuthorRawFilter, AuthorRelations, AuthorProjection, AuthorSort, AuthorRawSort, AuthorInsert, AuthorUpdate, AuthorRawUpdate, AuthorExcludedFields, AuthorRelationFields, MetadataType, OperationMetadataType, types.Scalars, 'author', DAOContext<MetadataType, OperationMetadataType>>
-export type AuthorDAOParams<MetadataType, OperationMetadataType> = Omit<KnexJsDAOParams<AuthorDAOGenerics<MetadataType, OperationMetadataType>>, 'idField' | 'schema' | 'idScalar' | 'idGeneration'>
-export type InMemoryAuthorDAOParams<MetadataType, OperationMetadataType> = Omit<InMemoryDAOParams<AuthorDAOGenerics<MetadataType, OperationMetadataType>>, 'idField' | 'schema' | 'idScalar' | 'idGeneration'>
+type AuthorDAOGenerics<MetadataType, OperationMetadataType> = T.KnexJsDAOGenerics<types.Author, 'id', 'ID', AuthorFilter, AuthorRawFilter, AuthorRelations, AuthorProjection, AuthorSort, AuthorRawSort, AuthorInsert, AuthorUpdate, AuthorRawUpdate, AuthorExcludedFields, AuthorRelationFields, MetadataType, OperationMetadataType, types.Scalars, 'author', DAOContext<MetadataType, OperationMetadataType>>
+export type AuthorDAOParams<MetadataType, OperationMetadataType> = Omit<T.KnexJsDAOParams<AuthorDAOGenerics<MetadataType, OperationMetadataType>>, 'idField' | 'schema' | 'idScalar' | 'idGeneration'>
+export type InMemoryAuthorDAOParams<MetadataType, OperationMetadataType> = Omit<T.InMemoryDAOParams<AuthorDAOGenerics<MetadataType, OperationMetadataType>>, 'idField' | 'schema' | 'idScalar' | 'idGeneration'>
 
-export class AuthorDAO<MetadataType, OperationMetadataType> extends AbstractKnexJsDAO<AuthorDAOGenerics<MetadataType, OperationMetadataType>> {  
+export class AuthorDAO<MetadataType, OperationMetadataType> extends T.AbstractKnexJsDAO<AuthorDAOGenerics<MetadataType, OperationMetadataType>> {  
   
   public static projection<P extends AuthorProjection>(p: P) {
     return p
   }
-  public static mergeProjection<P1 extends AuthorProjection, P2 extends AuthorProjection>(p1: P1, p2: P2): SelectProjection<AuthorProjection, P1, P2> {
-    return mergeProjections(p1, p2) as SelectProjection<AuthorProjection, P1, P2>
+  public static mergeProjection<P1 extends AuthorProjection, P2 extends AuthorProjection>(p1: P1, p2: P2): T.SelectProjection<AuthorProjection, P1, P2> {
+    return T.mergeProjections(p1, p2) as T.SelectProjection<AuthorProjection, P1, P2>
   }
   
   public constructor(params: AuthorDAOParams<MetadataType, OperationMetadataType>){
@@ -203,7 +202,7 @@ export class AuthorDAO<MetadataType, OperationMetadataType> extends AbstractKnex
       ...params, 
       idField: 'id', 
       schema: authorSchema(), 
-      relations: overrideRelations(
+      relations: T.overrideRelations(
         [
           { type: '1-n', reference: 'relation', field: 'books', relationDao: 'authorBook', entityDao: 'book', refThis: { refFrom: 'authorId', refTo: 'id' }, refOther: { refFrom: 'bookId', refTo: 'id' }, required: false }
         ]
@@ -214,13 +213,13 @@ export class AuthorDAO<MetadataType, OperationMetadataType> extends AbstractKnex
   }
   }
 
-export class InMemoryAuthorDAO<MetadataType, OperationMetadataType> extends AbstractInMemoryDAO<AuthorDAOGenerics<MetadataType, OperationMetadataType>> {  
+export class InMemoryAuthorDAO<MetadataType, OperationMetadataType> extends T.AbstractInMemoryDAO<AuthorDAOGenerics<MetadataType, OperationMetadataType>> {  
   
   public static projection<P extends AuthorProjection>(p: P) {
     return p
   }
-  public static mergeProjection<P1 extends AuthorProjection, P2 extends AuthorProjection>(p1: P1, p2: P2): SelectProjection<AuthorProjection, P1, P2> {
-    return mergeProjections(p1, p2) as SelectProjection<AuthorProjection, P1, P2>
+  public static mergeProjection<P1 extends AuthorProjection, P2 extends AuthorProjection>(p1: P1, p2: P2): T.SelectProjection<AuthorProjection, P1, P2> {
+    return T.mergeProjections(p1, p2) as T.SelectProjection<AuthorProjection, P1, P2>
   }
   
   public constructor(params: InMemoryAuthorDAOParams<MetadataType, OperationMetadataType>){
@@ -228,7 +227,7 @@ export class InMemoryAuthorDAO<MetadataType, OperationMetadataType> extends Abst
       ...params, 
       idField: 'id', 
       schema: authorSchema(), 
-      relations: overrideRelations(
+      relations: T.overrideRelations(
         [
           { type: '1-n', reference: 'relation', field: 'books', relationDao: 'authorBook', entityDao: 'book', refThis: { refFrom: 'authorId', refTo: 'id' }, refOther: { refFrom: 'bookId', refTo: 'id' }, required: false }
         ]
@@ -248,7 +247,7 @@ export class InMemoryAuthorDAO<MetadataType, OperationMetadataType> extends Abst
 export type AuthorBookExcludedFields = never
 export type AuthorBookRelationFields = never
 
-export function authorBookSchema(): Schema<types.Scalars> {
+export function authorBookSchema(): T.Schema<types.Scalars> {
   return {
     'authorId': {
       scalar: 'ID', 
@@ -266,11 +265,11 @@ export function authorBookSchema(): Schema<types.Scalars> {
 }
 
 type AuthorBookFilterFields = {
-  'authorId'?: types.Scalars['ID'] | null | EqualityOperators<types.Scalars['ID']> | ElementOperators,
-  'bookId'?: types.Scalars['ID'] | null | EqualityOperators<types.Scalars['ID']> | ElementOperators,
-  'id'?: types.Scalars['ID'] | null | EqualityOperators<types.Scalars['ID']> | ElementOperators
+  'authorId'?: types.Scalars['ID'] | null | T.EqualityOperators<types.Scalars['ID']> | T.ElementOperators,
+  'bookId'?: types.Scalars['ID'] | null | T.EqualityOperators<types.Scalars['ID']> | T.ElementOperators,
+  'id'?: types.Scalars['ID'] | null | T.EqualityOperators<types.Scalars['ID']> | T.ElementOperators
 }
-export type AuthorBookFilter = AuthorBookFilterFields & LogicalOperators<AuthorBookFilterFields | AuthorBookRawFilter>
+export type AuthorBookFilter = AuthorBookFilterFields & T.LogicalOperators<AuthorBookFilterFields | AuthorBookRawFilter>
 export type AuthorBookRawFilter = (builder: Knex.QueryBuilder<any, any>) => Knex.QueryBuilder<any, any>
 
 export type AuthorBookRelations = Record<never, string>
@@ -280,10 +279,10 @@ export type AuthorBookProjection = {
   bookId?: boolean,
   id?: boolean,
 }
-export type AuthorBookParam<P extends AuthorBookProjection> = ParamProjection<types.AuthorBook, AuthorBookProjection, P>
+export type AuthorBookParam<P extends AuthorBookProjection> = T.ParamProjection<types.AuthorBook, AuthorBookProjection, P>
 
 export type AuthorBookSortKeys = 'authorId' | 'bookId' | 'id'
-export type AuthorBookSort = OneKey<AuthorBookSortKeys, SortDirection>
+export type AuthorBookSort = T.OneKey<AuthorBookSortKeys, T.SortDirection>
 export type AuthorBookRawSort = (builder: Knex.QueryBuilder<any, any>) => Knex.QueryBuilder<any, any>
 
 export type AuthorBookUpdate = {
@@ -299,17 +298,17 @@ export type AuthorBookInsert = {
   id?: null | types.Scalars['ID'],
 }
 
-type AuthorBookDAOGenerics<MetadataType, OperationMetadataType> = KnexJsDAOGenerics<types.AuthorBook, 'id', 'ID', AuthorBookFilter, AuthorBookRawFilter, AuthorBookRelations, AuthorBookProjection, AuthorBookSort, AuthorBookRawSort, AuthorBookInsert, AuthorBookUpdate, AuthorBookRawUpdate, AuthorBookExcludedFields, AuthorBookRelationFields, MetadataType, OperationMetadataType, types.Scalars, 'authorBook', DAOContext<MetadataType, OperationMetadataType>>
-export type AuthorBookDAOParams<MetadataType, OperationMetadataType> = Omit<KnexJsDAOParams<AuthorBookDAOGenerics<MetadataType, OperationMetadataType>>, 'idField' | 'schema' | 'idScalar' | 'idGeneration'>
-export type InMemoryAuthorBookDAOParams<MetadataType, OperationMetadataType> = Omit<InMemoryDAOParams<AuthorBookDAOGenerics<MetadataType, OperationMetadataType>>, 'idField' | 'schema' | 'idScalar' | 'idGeneration'>
+type AuthorBookDAOGenerics<MetadataType, OperationMetadataType> = T.KnexJsDAOGenerics<types.AuthorBook, 'id', 'ID', AuthorBookFilter, AuthorBookRawFilter, AuthorBookRelations, AuthorBookProjection, AuthorBookSort, AuthorBookRawSort, AuthorBookInsert, AuthorBookUpdate, AuthorBookRawUpdate, AuthorBookExcludedFields, AuthorBookRelationFields, MetadataType, OperationMetadataType, types.Scalars, 'authorBook', DAOContext<MetadataType, OperationMetadataType>>
+export type AuthorBookDAOParams<MetadataType, OperationMetadataType> = Omit<T.KnexJsDAOParams<AuthorBookDAOGenerics<MetadataType, OperationMetadataType>>, 'idField' | 'schema' | 'idScalar' | 'idGeneration'>
+export type InMemoryAuthorBookDAOParams<MetadataType, OperationMetadataType> = Omit<T.InMemoryDAOParams<AuthorBookDAOGenerics<MetadataType, OperationMetadataType>>, 'idField' | 'schema' | 'idScalar' | 'idGeneration'>
 
-export class AuthorBookDAO<MetadataType, OperationMetadataType> extends AbstractKnexJsDAO<AuthorBookDAOGenerics<MetadataType, OperationMetadataType>> {  
+export class AuthorBookDAO<MetadataType, OperationMetadataType> extends T.AbstractKnexJsDAO<AuthorBookDAOGenerics<MetadataType, OperationMetadataType>> {  
   
   public static projection<P extends AuthorBookProjection>(p: P) {
     return p
   }
-  public static mergeProjection<P1 extends AuthorBookProjection, P2 extends AuthorBookProjection>(p1: P1, p2: P2): SelectProjection<AuthorBookProjection, P1, P2> {
-    return mergeProjections(p1, p2) as SelectProjection<AuthorBookProjection, P1, P2>
+  public static mergeProjection<P1 extends AuthorBookProjection, P2 extends AuthorBookProjection>(p1: P1, p2: P2): T.SelectProjection<AuthorBookProjection, P1, P2> {
+    return T.mergeProjections(p1, p2) as T.SelectProjection<AuthorBookProjection, P1, P2>
   }
   
   public constructor(params: AuthorBookDAOParams<MetadataType, OperationMetadataType>){
@@ -317,7 +316,7 @@ export class AuthorBookDAO<MetadataType, OperationMetadataType> extends Abstract
       ...params, 
       idField: 'id', 
       schema: authorBookSchema(), 
-      relations: overrideRelations(
+      relations: T.overrideRelations(
         [
           
         ]
@@ -328,13 +327,13 @@ export class AuthorBookDAO<MetadataType, OperationMetadataType> extends Abstract
   }
   }
 
-export class InMemoryAuthorBookDAO<MetadataType, OperationMetadataType> extends AbstractInMemoryDAO<AuthorBookDAOGenerics<MetadataType, OperationMetadataType>> {  
+export class InMemoryAuthorBookDAO<MetadataType, OperationMetadataType> extends T.AbstractInMemoryDAO<AuthorBookDAOGenerics<MetadataType, OperationMetadataType>> {  
   
   public static projection<P extends AuthorBookProjection>(p: P) {
     return p
   }
-  public static mergeProjection<P1 extends AuthorBookProjection, P2 extends AuthorBookProjection>(p1: P1, p2: P2): SelectProjection<AuthorBookProjection, P1, P2> {
-    return mergeProjections(p1, p2) as SelectProjection<AuthorBookProjection, P1, P2>
+  public static mergeProjection<P1 extends AuthorBookProjection, P2 extends AuthorBookProjection>(p1: P1, p2: P2): T.SelectProjection<AuthorBookProjection, P1, P2> {
+    return T.mergeProjections(p1, p2) as T.SelectProjection<AuthorBookProjection, P1, P2>
   }
   
   public constructor(params: InMemoryAuthorBookDAOParams<MetadataType, OperationMetadataType>){
@@ -342,7 +341,7 @@ export class InMemoryAuthorBookDAO<MetadataType, OperationMetadataType> extends 
       ...params, 
       idField: 'id', 
       schema: authorBookSchema(), 
-      relations: overrideRelations(
+      relations: T.overrideRelations(
         [
           
         ]
@@ -362,7 +361,7 @@ export class InMemoryAuthorBookDAO<MetadataType, OperationMetadataType> extends 
 export type BookExcludedFields = never
 export type BookRelationFields = 'authors'
 
-export function bookSchema(): Schema<types.Scalars> {
+export function bookSchema(): T.Schema<types.Scalars> {
   return {
     'id': {
       scalar: 'ID', 
@@ -372,9 +371,9 @@ export function bookSchema(): Schema<types.Scalars> {
 }
 
 type BookFilterFields = {
-  'id'?: types.Scalars['ID'] | null | EqualityOperators<types.Scalars['ID']> | ElementOperators
+  'id'?: types.Scalars['ID'] | null | T.EqualityOperators<types.Scalars['ID']> | T.ElementOperators
 }
-export type BookFilter = BookFilterFields & LogicalOperators<BookFilterFields | BookRawFilter>
+export type BookFilter = BookFilterFields & T.LogicalOperators<BookFilterFields | BookRawFilter>
 export type BookRawFilter = (builder: Knex.QueryBuilder<any, any>) => Knex.QueryBuilder<any, any>
 
 export type BookRelations = {
@@ -391,10 +390,10 @@ export type BookProjection = {
   authors?: AuthorProjection | boolean,
   id?: boolean,
 }
-export type BookParam<P extends BookProjection> = ParamProjection<types.Book, BookProjection, P>
+export type BookParam<P extends BookProjection> = T.ParamProjection<types.Book, BookProjection, P>
 
 export type BookSortKeys = 'id'
-export type BookSort = OneKey<BookSortKeys, SortDirection>
+export type BookSort = T.OneKey<BookSortKeys, T.SortDirection>
 export type BookRawSort = (builder: Knex.QueryBuilder<any, any>) => Knex.QueryBuilder<any, any>
 
 export type BookUpdate = {
@@ -406,17 +405,17 @@ export type BookInsert = {
   id?: null | types.Scalars['ID'],
 }
 
-type BookDAOGenerics<MetadataType, OperationMetadataType> = KnexJsDAOGenerics<types.Book, 'id', 'ID', BookFilter, BookRawFilter, BookRelations, BookProjection, BookSort, BookRawSort, BookInsert, BookUpdate, BookRawUpdate, BookExcludedFields, BookRelationFields, MetadataType, OperationMetadataType, types.Scalars, 'book', DAOContext<MetadataType, OperationMetadataType>>
-export type BookDAOParams<MetadataType, OperationMetadataType> = Omit<KnexJsDAOParams<BookDAOGenerics<MetadataType, OperationMetadataType>>, 'idField' | 'schema' | 'idScalar' | 'idGeneration'>
-export type InMemoryBookDAOParams<MetadataType, OperationMetadataType> = Omit<InMemoryDAOParams<BookDAOGenerics<MetadataType, OperationMetadataType>>, 'idField' | 'schema' | 'idScalar' | 'idGeneration'>
+type BookDAOGenerics<MetadataType, OperationMetadataType> = T.KnexJsDAOGenerics<types.Book, 'id', 'ID', BookFilter, BookRawFilter, BookRelations, BookProjection, BookSort, BookRawSort, BookInsert, BookUpdate, BookRawUpdate, BookExcludedFields, BookRelationFields, MetadataType, OperationMetadataType, types.Scalars, 'book', DAOContext<MetadataType, OperationMetadataType>>
+export type BookDAOParams<MetadataType, OperationMetadataType> = Omit<T.KnexJsDAOParams<BookDAOGenerics<MetadataType, OperationMetadataType>>, 'idField' | 'schema' | 'idScalar' | 'idGeneration'>
+export type InMemoryBookDAOParams<MetadataType, OperationMetadataType> = Omit<T.InMemoryDAOParams<BookDAOGenerics<MetadataType, OperationMetadataType>>, 'idField' | 'schema' | 'idScalar' | 'idGeneration'>
 
-export class BookDAO<MetadataType, OperationMetadataType> extends AbstractKnexJsDAO<BookDAOGenerics<MetadataType, OperationMetadataType>> {  
+export class BookDAO<MetadataType, OperationMetadataType> extends T.AbstractKnexJsDAO<BookDAOGenerics<MetadataType, OperationMetadataType>> {  
   
   public static projection<P extends BookProjection>(p: P) {
     return p
   }
-  public static mergeProjection<P1 extends BookProjection, P2 extends BookProjection>(p1: P1, p2: P2): SelectProjection<BookProjection, P1, P2> {
-    return mergeProjections(p1, p2) as SelectProjection<BookProjection, P1, P2>
+  public static mergeProjection<P1 extends BookProjection, P2 extends BookProjection>(p1: P1, p2: P2): T.SelectProjection<BookProjection, P1, P2> {
+    return T.mergeProjections(p1, p2) as T.SelectProjection<BookProjection, P1, P2>
   }
   
   public constructor(params: BookDAOParams<MetadataType, OperationMetadataType>){
@@ -424,7 +423,7 @@ export class BookDAO<MetadataType, OperationMetadataType> extends AbstractKnexJs
       ...params, 
       idField: 'id', 
       schema: bookSchema(), 
-      relations: overrideRelations(
+      relations: T.overrideRelations(
         [
           { type: '1-n', reference: 'relation', field: 'authors', relationDao: 'authorBook', entityDao: 'author', refThis: { refFrom: 'bookId', refTo: 'id' }, refOther: { refFrom: 'authorId', refTo: 'id' }, required: false }
         ]
@@ -435,13 +434,13 @@ export class BookDAO<MetadataType, OperationMetadataType> extends AbstractKnexJs
   }
   }
 
-export class InMemoryBookDAO<MetadataType, OperationMetadataType> extends AbstractInMemoryDAO<BookDAOGenerics<MetadataType, OperationMetadataType>> {  
+export class InMemoryBookDAO<MetadataType, OperationMetadataType> extends T.AbstractInMemoryDAO<BookDAOGenerics<MetadataType, OperationMetadataType>> {  
   
   public static projection<P extends BookProjection>(p: P) {
     return p
   }
-  public static mergeProjection<P1 extends BookProjection, P2 extends BookProjection>(p1: P1, p2: P2): SelectProjection<BookProjection, P1, P2> {
-    return mergeProjections(p1, p2) as SelectProjection<BookProjection, P1, P2>
+  public static mergeProjection<P1 extends BookProjection, P2 extends BookProjection>(p1: P1, p2: P2): T.SelectProjection<BookProjection, P1, P2> {
+    return T.mergeProjections(p1, p2) as T.SelectProjection<BookProjection, P1, P2>
   }
   
   public constructor(params: InMemoryBookDAOParams<MetadataType, OperationMetadataType>){
@@ -449,7 +448,7 @@ export class InMemoryBookDAO<MetadataType, OperationMetadataType> extends Abstra
       ...params, 
       idField: 'id', 
       schema: bookSchema(), 
-      relations: overrideRelations(
+      relations: T.overrideRelations(
         [
           { type: '1-n', reference: 'relation', field: 'authors', relationDao: 'authorBook', entityDao: 'author', refThis: { refFrom: 'bookId', refTo: 'id' }, refOther: { refFrom: 'authorId', refTo: 'id' }, required: false }
         ]
@@ -469,7 +468,7 @@ export class InMemoryBookDAO<MetadataType, OperationMetadataType> extends Abstra
 export type CityExcludedFields = 'computedAddressName' | 'computedName'
 export type CityRelationFields = never
 
-export function citySchema(): Schema<types.Scalars> {
+export function citySchema(): T.Schema<types.Scalars> {
   return {
     'addressId': {
       scalar: 'ID', 
@@ -487,11 +486,11 @@ export function citySchema(): Schema<types.Scalars> {
 }
 
 type CityFilterFields = {
-  'addressId'?: types.Scalars['ID'] | null | EqualityOperators<types.Scalars['ID']> | ElementOperators,
-  'id'?: types.Scalars['ID'] | null | EqualityOperators<types.Scalars['ID']> | ElementOperators,
-  'name'?: types.Scalars['String'] | null | EqualityOperators<types.Scalars['String']> | ElementOperators | StringOperators
+  'addressId'?: types.Scalars['ID'] | null | T.EqualityOperators<types.Scalars['ID']> | T.ElementOperators,
+  'id'?: types.Scalars['ID'] | null | T.EqualityOperators<types.Scalars['ID']> | T.ElementOperators,
+  'name'?: types.Scalars['String'] | null | T.EqualityOperators<types.Scalars['String']> | T.ElementOperators | T.StringOperators
 }
-export type CityFilter = CityFilterFields & LogicalOperators<CityFilterFields | CityRawFilter>
+export type CityFilter = CityFilterFields & T.LogicalOperators<CityFilterFields | CityRawFilter>
 export type CityRawFilter = (builder: Knex.QueryBuilder<any, any>) => Knex.QueryBuilder<any, any>
 
 export type CityRelations = Record<never, string>
@@ -503,10 +502,10 @@ export type CityProjection = {
   id?: boolean,
   name?: boolean,
 }
-export type CityParam<P extends CityProjection> = ParamProjection<types.City, CityProjection, P>
+export type CityParam<P extends CityProjection> = T.ParamProjection<types.City, CityProjection, P>
 
 export type CitySortKeys = 'addressId' | 'id' | 'name'
-export type CitySort = OneKey<CitySortKeys, SortDirection>
+export type CitySort = T.OneKey<CitySortKeys, T.SortDirection>
 export type CityRawSort = (builder: Knex.QueryBuilder<any, any>) => Knex.QueryBuilder<any, any>
 
 export type CityUpdate = {
@@ -522,17 +521,17 @@ export type CityInsert = {
   name: types.Scalars['String'],
 }
 
-type CityDAOGenerics<MetadataType, OperationMetadataType> = KnexJsDAOGenerics<types.City, 'id', 'ID', CityFilter, CityRawFilter, CityRelations, CityProjection, CitySort, CityRawSort, CityInsert, CityUpdate, CityRawUpdate, CityExcludedFields, CityRelationFields, MetadataType, OperationMetadataType, types.Scalars, 'city', DAOContext<MetadataType, OperationMetadataType>>
-export type CityDAOParams<MetadataType, OperationMetadataType> = Omit<KnexJsDAOParams<CityDAOGenerics<MetadataType, OperationMetadataType>>, 'idField' | 'schema' | 'idScalar' | 'idGeneration'>
-export type InMemoryCityDAOParams<MetadataType, OperationMetadataType> = Omit<InMemoryDAOParams<CityDAOGenerics<MetadataType, OperationMetadataType>>, 'idField' | 'schema' | 'idScalar' | 'idGeneration'>
+type CityDAOGenerics<MetadataType, OperationMetadataType> = T.KnexJsDAOGenerics<types.City, 'id', 'ID', CityFilter, CityRawFilter, CityRelations, CityProjection, CitySort, CityRawSort, CityInsert, CityUpdate, CityRawUpdate, CityExcludedFields, CityRelationFields, MetadataType, OperationMetadataType, types.Scalars, 'city', DAOContext<MetadataType, OperationMetadataType>>
+export type CityDAOParams<MetadataType, OperationMetadataType> = Omit<T.KnexJsDAOParams<CityDAOGenerics<MetadataType, OperationMetadataType>>, 'idField' | 'schema' | 'idScalar' | 'idGeneration'>
+export type InMemoryCityDAOParams<MetadataType, OperationMetadataType> = Omit<T.InMemoryDAOParams<CityDAOGenerics<MetadataType, OperationMetadataType>>, 'idField' | 'schema' | 'idScalar' | 'idGeneration'>
 
-export class CityDAO<MetadataType, OperationMetadataType> extends AbstractKnexJsDAO<CityDAOGenerics<MetadataType, OperationMetadataType>> {  
+export class CityDAO<MetadataType, OperationMetadataType> extends T.AbstractKnexJsDAO<CityDAOGenerics<MetadataType, OperationMetadataType>> {  
   
   public static projection<P extends CityProjection>(p: P) {
     return p
   }
-  public static mergeProjection<P1 extends CityProjection, P2 extends CityProjection>(p1: P1, p2: P2): SelectProjection<CityProjection, P1, P2> {
-    return mergeProjections(p1, p2) as SelectProjection<CityProjection, P1, P2>
+  public static mergeProjection<P1 extends CityProjection, P2 extends CityProjection>(p1: P1, p2: P2): T.SelectProjection<CityProjection, P1, P2> {
+    return T.mergeProjections(p1, p2) as T.SelectProjection<CityProjection, P1, P2>
   }
   
   public constructor(params: CityDAOParams<MetadataType, OperationMetadataType>){
@@ -540,7 +539,7 @@ export class CityDAO<MetadataType, OperationMetadataType> extends AbstractKnexJs
       ...params, 
       idField: 'id', 
       schema: citySchema(), 
-      relations: overrideRelations(
+      relations: T.overrideRelations(
         [
           
         ]
@@ -551,13 +550,13 @@ export class CityDAO<MetadataType, OperationMetadataType> extends AbstractKnexJs
   }
   }
 
-export class InMemoryCityDAO<MetadataType, OperationMetadataType> extends AbstractInMemoryDAO<CityDAOGenerics<MetadataType, OperationMetadataType>> {  
+export class InMemoryCityDAO<MetadataType, OperationMetadataType> extends T.AbstractInMemoryDAO<CityDAOGenerics<MetadataType, OperationMetadataType>> {  
   
   public static projection<P extends CityProjection>(p: P) {
     return p
   }
-  public static mergeProjection<P1 extends CityProjection, P2 extends CityProjection>(p1: P1, p2: P2): SelectProjection<CityProjection, P1, P2> {
-    return mergeProjections(p1, p2) as SelectProjection<CityProjection, P1, P2>
+  public static mergeProjection<P1 extends CityProjection, P2 extends CityProjection>(p1: P1, p2: P2): T.SelectProjection<CityProjection, P1, P2> {
+    return T.mergeProjections(p1, p2) as T.SelectProjection<CityProjection, P1, P2>
   }
   
   public constructor(params: InMemoryCityDAOParams<MetadataType, OperationMetadataType>){
@@ -565,7 +564,7 @@ export class InMemoryCityDAO<MetadataType, OperationMetadataType> extends Abstra
       ...params, 
       idField: 'id', 
       schema: citySchema(), 
-      relations: overrideRelations(
+      relations: T.overrideRelations(
         [
           
         ]
@@ -585,7 +584,7 @@ export class InMemoryCityDAO<MetadataType, OperationMetadataType> extends Abstra
 export type DefaultFieldsEntityExcludedFields = never
 export type DefaultFieldsEntityRelationFields = never
 
-export function defaultFieldsEntitySchema(): Schema<types.Scalars> {
+export function defaultFieldsEntitySchema(): T.Schema<types.Scalars> {
   return {
     'creationDate': {
       scalar: 'Int', 
@@ -617,14 +616,14 @@ export function defaultFieldsEntitySchema(): Schema<types.Scalars> {
 }
 
 type DefaultFieldsEntityFilterFields = {
-  'creationDate'?: types.Scalars['Int'] | null | EqualityOperators<types.Scalars['Int']> | ElementOperators | QuantityOperators<types.Scalars['Int']>,
-  'id'?: types.Scalars['ID'] | null | EqualityOperators<types.Scalars['ID']> | ElementOperators,
-  'live'?: types.Scalars['Live'] | null | EqualityOperators<types.Scalars['Live']> | ElementOperators,
-  'name'?: types.Scalars['String'] | null | EqualityOperators<types.Scalars['String']> | ElementOperators | StringOperators,
-  'opt1'?: types.Scalars['Live'] | null | EqualityOperators<types.Scalars['Live']> | ElementOperators,
-  'opt2'?: types.Scalars['Live'] | null | EqualityOperators<types.Scalars['Live']> | ElementOperators
+  'creationDate'?: types.Scalars['Int'] | null | T.EqualityOperators<types.Scalars['Int']> | T.ElementOperators | T.QuantityOperators<types.Scalars['Int']>,
+  'id'?: types.Scalars['ID'] | null | T.EqualityOperators<types.Scalars['ID']> | T.ElementOperators,
+  'live'?: types.Scalars['Live'] | null | T.EqualityOperators<types.Scalars['Live']> | T.ElementOperators,
+  'name'?: types.Scalars['String'] | null | T.EqualityOperators<types.Scalars['String']> | T.ElementOperators | T.StringOperators,
+  'opt1'?: types.Scalars['Live'] | null | T.EqualityOperators<types.Scalars['Live']> | T.ElementOperators,
+  'opt2'?: types.Scalars['Live'] | null | T.EqualityOperators<types.Scalars['Live']> | T.ElementOperators
 }
-export type DefaultFieldsEntityFilter = DefaultFieldsEntityFilterFields & LogicalOperators<DefaultFieldsEntityFilterFields | DefaultFieldsEntityRawFilter>
+export type DefaultFieldsEntityFilter = DefaultFieldsEntityFilterFields & T.LogicalOperators<DefaultFieldsEntityFilterFields | DefaultFieldsEntityRawFilter>
 export type DefaultFieldsEntityRawFilter = (builder: Knex.QueryBuilder<any, any>) => Knex.QueryBuilder<any, any>
 
 export type DefaultFieldsEntityRelations = Record<never, string>
@@ -637,10 +636,10 @@ export type DefaultFieldsEntityProjection = {
   opt1?: boolean,
   opt2?: boolean,
 }
-export type DefaultFieldsEntityParam<P extends DefaultFieldsEntityProjection> = ParamProjection<types.DefaultFieldsEntity, DefaultFieldsEntityProjection, P>
+export type DefaultFieldsEntityParam<P extends DefaultFieldsEntityProjection> = T.ParamProjection<types.DefaultFieldsEntity, DefaultFieldsEntityProjection, P>
 
 export type DefaultFieldsEntitySortKeys = 'creationDate' | 'id' | 'live' | 'name' | 'opt1' | 'opt2'
-export type DefaultFieldsEntitySort = OneKey<DefaultFieldsEntitySortKeys, SortDirection>
+export type DefaultFieldsEntitySort = T.OneKey<DefaultFieldsEntitySortKeys, T.SortDirection>
 export type DefaultFieldsEntityRawSort = (builder: Knex.QueryBuilder<any, any>) => Knex.QueryBuilder<any, any>
 
 export type DefaultFieldsEntityUpdate = {
@@ -662,17 +661,17 @@ export type DefaultFieldsEntityInsert = {
   opt2?: null | types.Scalars['Live'],
 }
 
-type DefaultFieldsEntityDAOGenerics<MetadataType, OperationMetadataType> = KnexJsDAOGenerics<types.DefaultFieldsEntity, 'id', 'ID', DefaultFieldsEntityFilter, DefaultFieldsEntityRawFilter, DefaultFieldsEntityRelations, DefaultFieldsEntityProjection, DefaultFieldsEntitySort, DefaultFieldsEntityRawSort, DefaultFieldsEntityInsert, DefaultFieldsEntityUpdate, DefaultFieldsEntityRawUpdate, DefaultFieldsEntityExcludedFields, DefaultFieldsEntityRelationFields, MetadataType, OperationMetadataType, types.Scalars, 'defaultFieldsEntity', DAOContext<MetadataType, OperationMetadataType>>
-export type DefaultFieldsEntityDAOParams<MetadataType, OperationMetadataType> = Omit<KnexJsDAOParams<DefaultFieldsEntityDAOGenerics<MetadataType, OperationMetadataType>>, 'idGenerator' | 'idField' | 'schema' | 'idScalar' | 'idGeneration'>
-export type InMemoryDefaultFieldsEntityDAOParams<MetadataType, OperationMetadataType> = Omit<InMemoryDAOParams<DefaultFieldsEntityDAOGenerics<MetadataType, OperationMetadataType>>, 'idGenerator' | 'idField' | 'schema' | 'idScalar' | 'idGeneration'>
+type DefaultFieldsEntityDAOGenerics<MetadataType, OperationMetadataType> = T.KnexJsDAOGenerics<types.DefaultFieldsEntity, 'id', 'ID', DefaultFieldsEntityFilter, DefaultFieldsEntityRawFilter, DefaultFieldsEntityRelations, DefaultFieldsEntityProjection, DefaultFieldsEntitySort, DefaultFieldsEntityRawSort, DefaultFieldsEntityInsert, DefaultFieldsEntityUpdate, DefaultFieldsEntityRawUpdate, DefaultFieldsEntityExcludedFields, DefaultFieldsEntityRelationFields, MetadataType, OperationMetadataType, types.Scalars, 'defaultFieldsEntity', DAOContext<MetadataType, OperationMetadataType>>
+export type DefaultFieldsEntityDAOParams<MetadataType, OperationMetadataType> = Omit<T.KnexJsDAOParams<DefaultFieldsEntityDAOGenerics<MetadataType, OperationMetadataType>>, 'idGenerator' | 'idField' | 'schema' | 'idScalar' | 'idGeneration'>
+export type InMemoryDefaultFieldsEntityDAOParams<MetadataType, OperationMetadataType> = Omit<T.InMemoryDAOParams<DefaultFieldsEntityDAOGenerics<MetadataType, OperationMetadataType>>, 'idGenerator' | 'idField' | 'schema' | 'idScalar' | 'idGeneration'>
 
-export class DefaultFieldsEntityDAO<MetadataType, OperationMetadataType> extends AbstractKnexJsDAO<DefaultFieldsEntityDAOGenerics<MetadataType, OperationMetadataType>> {  
+export class DefaultFieldsEntityDAO<MetadataType, OperationMetadataType> extends T.AbstractKnexJsDAO<DefaultFieldsEntityDAOGenerics<MetadataType, OperationMetadataType>> {  
   
   public static projection<P extends DefaultFieldsEntityProjection>(p: P) {
     return p
   }
-  public static mergeProjection<P1 extends DefaultFieldsEntityProjection, P2 extends DefaultFieldsEntityProjection>(p1: P1, p2: P2): SelectProjection<DefaultFieldsEntityProjection, P1, P2> {
-    return mergeProjections(p1, p2) as SelectProjection<DefaultFieldsEntityProjection, P1, P2>
+  public static mergeProjection<P1 extends DefaultFieldsEntityProjection, P2 extends DefaultFieldsEntityProjection>(p1: P1, p2: P2): T.SelectProjection<DefaultFieldsEntityProjection, P1, P2> {
+    return T.mergeProjections(p1, p2) as T.SelectProjection<DefaultFieldsEntityProjection, P1, P2>
   }
   
   public constructor(params: DefaultFieldsEntityDAOParams<MetadataType, OperationMetadataType>){
@@ -680,7 +679,7 @@ export class DefaultFieldsEntityDAO<MetadataType, OperationMetadataType> extends
       ...params, 
       idField: 'id', 
       schema: defaultFieldsEntitySchema(), 
-      relations: overrideRelations(
+      relations: T.overrideRelations(
         [
           
         ]
@@ -691,13 +690,13 @@ export class DefaultFieldsEntityDAO<MetadataType, OperationMetadataType> extends
   }
   }
 
-export class InMemoryDefaultFieldsEntityDAO<MetadataType, OperationMetadataType> extends AbstractInMemoryDAO<DefaultFieldsEntityDAOGenerics<MetadataType, OperationMetadataType>> {  
+export class InMemoryDefaultFieldsEntityDAO<MetadataType, OperationMetadataType> extends T.AbstractInMemoryDAO<DefaultFieldsEntityDAOGenerics<MetadataType, OperationMetadataType>> {  
   
   public static projection<P extends DefaultFieldsEntityProjection>(p: P) {
     return p
   }
-  public static mergeProjection<P1 extends DefaultFieldsEntityProjection, P2 extends DefaultFieldsEntityProjection>(p1: P1, p2: P2): SelectProjection<DefaultFieldsEntityProjection, P1, P2> {
-    return mergeProjections(p1, p2) as SelectProjection<DefaultFieldsEntityProjection, P1, P2>
+  public static mergeProjection<P1 extends DefaultFieldsEntityProjection, P2 extends DefaultFieldsEntityProjection>(p1: P1, p2: P2): T.SelectProjection<DefaultFieldsEntityProjection, P1, P2> {
+    return T.mergeProjections(p1, p2) as T.SelectProjection<DefaultFieldsEntityProjection, P1, P2>
   }
   
   public constructor(params: InMemoryDefaultFieldsEntityDAOParams<MetadataType, OperationMetadataType>){
@@ -705,7 +704,7 @@ export class InMemoryDefaultFieldsEntityDAO<MetadataType, OperationMetadataType>
       ...params, 
       idField: 'id', 
       schema: defaultFieldsEntitySchema(), 
-      relations: overrideRelations(
+      relations: T.overrideRelations(
         [
           
         ]
@@ -725,7 +724,7 @@ export class InMemoryDefaultFieldsEntityDAO<MetadataType, OperationMetadataType>
 export type DeviceExcludedFields = never
 export type DeviceRelationFields = 'user'
 
-export function deviceSchema(): Schema<types.Scalars> {
+export function deviceSchema(): T.Schema<types.Scalars> {
   return {
     'id': {
       scalar: 'ID', 
@@ -742,11 +741,11 @@ export function deviceSchema(): Schema<types.Scalars> {
 }
 
 type DeviceFilterFields = {
-  'id'?: types.Scalars['ID'] | null | EqualityOperators<types.Scalars['ID']> | ElementOperators,
-  'name'?: types.Scalars['String'] | null | EqualityOperators<types.Scalars['String']> | ElementOperators | StringOperators,
-  'userId'?: types.Scalars['ID'] | null | EqualityOperators<types.Scalars['ID']> | ElementOperators
+  'id'?: types.Scalars['ID'] | null | T.EqualityOperators<types.Scalars['ID']> | T.ElementOperators,
+  'name'?: types.Scalars['String'] | null | T.EqualityOperators<types.Scalars['String']> | T.ElementOperators | T.StringOperators,
+  'userId'?: types.Scalars['ID'] | null | T.EqualityOperators<types.Scalars['ID']> | T.ElementOperators
 }
-export type DeviceFilter = DeviceFilterFields & LogicalOperators<DeviceFilterFields | DeviceRawFilter>
+export type DeviceFilter = DeviceFilterFields & T.LogicalOperators<DeviceFilterFields | DeviceRawFilter>
 export type DeviceRawFilter = (builder: Knex.QueryBuilder<any, any>) => Knex.QueryBuilder<any, any>
 
 export type DeviceRelations = Record<never, string>
@@ -757,10 +756,10 @@ export type DeviceProjection = {
   user?: UserProjection | boolean,
   userId?: boolean,
 }
-export type DeviceParam<P extends DeviceProjection> = ParamProjection<types.Device, DeviceProjection, P>
+export type DeviceParam<P extends DeviceProjection> = T.ParamProjection<types.Device, DeviceProjection, P>
 
 export type DeviceSortKeys = 'id' | 'name' | 'userId'
-export type DeviceSort = OneKey<DeviceSortKeys, SortDirection>
+export type DeviceSort = T.OneKey<DeviceSortKeys, T.SortDirection>
 export type DeviceRawSort = (builder: Knex.QueryBuilder<any, any>) => Knex.QueryBuilder<any, any>
 
 export type DeviceUpdate = {
@@ -776,17 +775,17 @@ export type DeviceInsert = {
   userId?: null | types.Scalars['ID'],
 }
 
-type DeviceDAOGenerics<MetadataType, OperationMetadataType> = KnexJsDAOGenerics<types.Device, 'id', 'ID', DeviceFilter, DeviceRawFilter, DeviceRelations, DeviceProjection, DeviceSort, DeviceRawSort, DeviceInsert, DeviceUpdate, DeviceRawUpdate, DeviceExcludedFields, DeviceRelationFields, MetadataType, OperationMetadataType, types.Scalars, 'device', DAOContext<MetadataType, OperationMetadataType>>
-export type DeviceDAOParams<MetadataType, OperationMetadataType> = Omit<KnexJsDAOParams<DeviceDAOGenerics<MetadataType, OperationMetadataType>>, 'idField' | 'schema' | 'idScalar' | 'idGeneration'>
-export type InMemoryDeviceDAOParams<MetadataType, OperationMetadataType> = Omit<InMemoryDAOParams<DeviceDAOGenerics<MetadataType, OperationMetadataType>>, 'idField' | 'schema' | 'idScalar' | 'idGeneration'>
+type DeviceDAOGenerics<MetadataType, OperationMetadataType> = T.KnexJsDAOGenerics<types.Device, 'id', 'ID', DeviceFilter, DeviceRawFilter, DeviceRelations, DeviceProjection, DeviceSort, DeviceRawSort, DeviceInsert, DeviceUpdate, DeviceRawUpdate, DeviceExcludedFields, DeviceRelationFields, MetadataType, OperationMetadataType, types.Scalars, 'device', DAOContext<MetadataType, OperationMetadataType>>
+export type DeviceDAOParams<MetadataType, OperationMetadataType> = Omit<T.KnexJsDAOParams<DeviceDAOGenerics<MetadataType, OperationMetadataType>>, 'idField' | 'schema' | 'idScalar' | 'idGeneration'>
+export type InMemoryDeviceDAOParams<MetadataType, OperationMetadataType> = Omit<T.InMemoryDAOParams<DeviceDAOGenerics<MetadataType, OperationMetadataType>>, 'idField' | 'schema' | 'idScalar' | 'idGeneration'>
 
-export class DeviceDAO<MetadataType, OperationMetadataType> extends AbstractKnexJsDAO<DeviceDAOGenerics<MetadataType, OperationMetadataType>> {  
+export class DeviceDAO<MetadataType, OperationMetadataType> extends T.AbstractKnexJsDAO<DeviceDAOGenerics<MetadataType, OperationMetadataType>> {  
   
   public static projection<P extends DeviceProjection>(p: P) {
     return p
   }
-  public static mergeProjection<P1 extends DeviceProjection, P2 extends DeviceProjection>(p1: P1, p2: P2): SelectProjection<DeviceProjection, P1, P2> {
-    return mergeProjections(p1, p2) as SelectProjection<DeviceProjection, P1, P2>
+  public static mergeProjection<P1 extends DeviceProjection, P2 extends DeviceProjection>(p1: P1, p2: P2): T.SelectProjection<DeviceProjection, P1, P2> {
+    return T.mergeProjections(p1, p2) as T.SelectProjection<DeviceProjection, P1, P2>
   }
   
   public constructor(params: DeviceDAOParams<MetadataType, OperationMetadataType>){
@@ -794,7 +793,7 @@ export class DeviceDAO<MetadataType, OperationMetadataType> extends AbstractKnex
       ...params, 
       idField: 'id', 
       schema: deviceSchema(), 
-      relations: overrideRelations(
+      relations: T.overrideRelations(
         [
           { type: '1-1', reference: 'inner', field: 'user', refFrom: 'userId', refTo: 'id', dao: 'user', required: false }
         ]
@@ -805,13 +804,13 @@ export class DeviceDAO<MetadataType, OperationMetadataType> extends AbstractKnex
   }
   }
 
-export class InMemoryDeviceDAO<MetadataType, OperationMetadataType> extends AbstractInMemoryDAO<DeviceDAOGenerics<MetadataType, OperationMetadataType>> {  
+export class InMemoryDeviceDAO<MetadataType, OperationMetadataType> extends T.AbstractInMemoryDAO<DeviceDAOGenerics<MetadataType, OperationMetadataType>> {  
   
   public static projection<P extends DeviceProjection>(p: P) {
     return p
   }
-  public static mergeProjection<P1 extends DeviceProjection, P2 extends DeviceProjection>(p1: P1, p2: P2): SelectProjection<DeviceProjection, P1, P2> {
-    return mergeProjections(p1, p2) as SelectProjection<DeviceProjection, P1, P2>
+  public static mergeProjection<P1 extends DeviceProjection, P2 extends DeviceProjection>(p1: P1, p2: P2): T.SelectProjection<DeviceProjection, P1, P2> {
+    return T.mergeProjections(p1, p2) as T.SelectProjection<DeviceProjection, P1, P2>
   }
   
   public constructor(params: InMemoryDeviceDAOParams<MetadataType, OperationMetadataType>){
@@ -819,7 +818,7 @@ export class InMemoryDeviceDAO<MetadataType, OperationMetadataType> extends Abst
       ...params, 
       idField: 'id', 
       schema: deviceSchema(), 
-      relations: overrideRelations(
+      relations: T.overrideRelations(
         [
           { type: '1-1', reference: 'inner', field: 'user', refFrom: 'userId', refTo: 'id', dao: 'user', required: false }
         ]
@@ -839,7 +838,7 @@ export class InMemoryDeviceDAO<MetadataType, OperationMetadataType> extends Abst
 export type DogExcludedFields = never
 export type DogRelationFields = 'owner'
 
-export function dogSchema(): Schema<types.Scalars> {
+export function dogSchema(): T.Schema<types.Scalars> {
   return {
     'id': {
       scalar: 'ID', 
@@ -857,11 +856,11 @@ export function dogSchema(): Schema<types.Scalars> {
 }
 
 type DogFilterFields = {
-  'id'?: types.Scalars['ID'] | null | EqualityOperators<types.Scalars['ID']> | ElementOperators,
-  'name'?: types.Scalars['String'] | null | EqualityOperators<types.Scalars['String']> | ElementOperators | StringOperators,
-  'ownerId'?: types.Scalars['ID'] | null | EqualityOperators<types.Scalars['ID']> | ElementOperators
+  'id'?: types.Scalars['ID'] | null | T.EqualityOperators<types.Scalars['ID']> | T.ElementOperators,
+  'name'?: types.Scalars['String'] | null | T.EqualityOperators<types.Scalars['String']> | T.ElementOperators | T.StringOperators,
+  'ownerId'?: types.Scalars['ID'] | null | T.EqualityOperators<types.Scalars['ID']> | T.ElementOperators
 }
-export type DogFilter = DogFilterFields & LogicalOperators<DogFilterFields | DogRawFilter>
+export type DogFilter = DogFilterFields & T.LogicalOperators<DogFilterFields | DogRawFilter>
 export type DogRawFilter = (builder: Knex.QueryBuilder<any, any>) => Knex.QueryBuilder<any, any>
 
 export type DogRelations = Record<never, string>
@@ -872,10 +871,10 @@ export type DogProjection = {
   owner?: UserProjection | boolean,
   ownerId?: boolean,
 }
-export type DogParam<P extends DogProjection> = ParamProjection<types.Dog, DogProjection, P>
+export type DogParam<P extends DogProjection> = T.ParamProjection<types.Dog, DogProjection, P>
 
 export type DogSortKeys = 'id' | 'name' | 'ownerId'
-export type DogSort = OneKey<DogSortKeys, SortDirection>
+export type DogSort = T.OneKey<DogSortKeys, T.SortDirection>
 export type DogRawSort = (builder: Knex.QueryBuilder<any, any>) => Knex.QueryBuilder<any, any>
 
 export type DogUpdate = {
@@ -891,17 +890,17 @@ export type DogInsert = {
   ownerId: types.Scalars['ID'],
 }
 
-type DogDAOGenerics<MetadataType, OperationMetadataType> = KnexJsDAOGenerics<types.Dog, 'id', 'ID', DogFilter, DogRawFilter, DogRelations, DogProjection, DogSort, DogRawSort, DogInsert, DogUpdate, DogRawUpdate, DogExcludedFields, DogRelationFields, MetadataType, OperationMetadataType, types.Scalars, 'dog', DAOContext<MetadataType, OperationMetadataType>>
-export type DogDAOParams<MetadataType, OperationMetadataType> = Omit<KnexJsDAOParams<DogDAOGenerics<MetadataType, OperationMetadataType>>, 'idField' | 'schema' | 'idScalar' | 'idGeneration'>
-export type InMemoryDogDAOParams<MetadataType, OperationMetadataType> = Omit<InMemoryDAOParams<DogDAOGenerics<MetadataType, OperationMetadataType>>, 'idField' | 'schema' | 'idScalar' | 'idGeneration'>
+type DogDAOGenerics<MetadataType, OperationMetadataType> = T.KnexJsDAOGenerics<types.Dog, 'id', 'ID', DogFilter, DogRawFilter, DogRelations, DogProjection, DogSort, DogRawSort, DogInsert, DogUpdate, DogRawUpdate, DogExcludedFields, DogRelationFields, MetadataType, OperationMetadataType, types.Scalars, 'dog', DAOContext<MetadataType, OperationMetadataType>>
+export type DogDAOParams<MetadataType, OperationMetadataType> = Omit<T.KnexJsDAOParams<DogDAOGenerics<MetadataType, OperationMetadataType>>, 'idField' | 'schema' | 'idScalar' | 'idGeneration'>
+export type InMemoryDogDAOParams<MetadataType, OperationMetadataType> = Omit<T.InMemoryDAOParams<DogDAOGenerics<MetadataType, OperationMetadataType>>, 'idField' | 'schema' | 'idScalar' | 'idGeneration'>
 
-export class DogDAO<MetadataType, OperationMetadataType> extends AbstractKnexJsDAO<DogDAOGenerics<MetadataType, OperationMetadataType>> {  
+export class DogDAO<MetadataType, OperationMetadataType> extends T.AbstractKnexJsDAO<DogDAOGenerics<MetadataType, OperationMetadataType>> {  
   
   public static projection<P extends DogProjection>(p: P) {
     return p
   }
-  public static mergeProjection<P1 extends DogProjection, P2 extends DogProjection>(p1: P1, p2: P2): SelectProjection<DogProjection, P1, P2> {
-    return mergeProjections(p1, p2) as SelectProjection<DogProjection, P1, P2>
+  public static mergeProjection<P1 extends DogProjection, P2 extends DogProjection>(p1: P1, p2: P2): T.SelectProjection<DogProjection, P1, P2> {
+    return T.mergeProjections(p1, p2) as T.SelectProjection<DogProjection, P1, P2>
   }
   
   public constructor(params: DogDAOParams<MetadataType, OperationMetadataType>){
@@ -909,7 +908,7 @@ export class DogDAO<MetadataType, OperationMetadataType> extends AbstractKnexJsD
       ...params, 
       idField: 'id', 
       schema: dogSchema(), 
-      relations: overrideRelations(
+      relations: T.overrideRelations(
         [
           { type: '1-1', reference: 'inner', field: 'owner', refFrom: 'ownerId', refTo: 'id', dao: 'user', required: false }
         ]
@@ -920,13 +919,13 @@ export class DogDAO<MetadataType, OperationMetadataType> extends AbstractKnexJsD
   }
   }
 
-export class InMemoryDogDAO<MetadataType, OperationMetadataType> extends AbstractInMemoryDAO<DogDAOGenerics<MetadataType, OperationMetadataType>> {  
+export class InMemoryDogDAO<MetadataType, OperationMetadataType> extends T.AbstractInMemoryDAO<DogDAOGenerics<MetadataType, OperationMetadataType>> {  
   
   public static projection<P extends DogProjection>(p: P) {
     return p
   }
-  public static mergeProjection<P1 extends DogProjection, P2 extends DogProjection>(p1: P1, p2: P2): SelectProjection<DogProjection, P1, P2> {
-    return mergeProjections(p1, p2) as SelectProjection<DogProjection, P1, P2>
+  public static mergeProjection<P1 extends DogProjection, P2 extends DogProjection>(p1: P1, p2: P2): T.SelectProjection<DogProjection, P1, P2> {
+    return T.mergeProjections(p1, p2) as T.SelectProjection<DogProjection, P1, P2>
   }
   
   public constructor(params: InMemoryDogDAOParams<MetadataType, OperationMetadataType>){
@@ -934,7 +933,7 @@ export class InMemoryDogDAO<MetadataType, OperationMetadataType> extends Abstrac
       ...params, 
       idField: 'id', 
       schema: dogSchema(), 
-      relations: overrideRelations(
+      relations: T.overrideRelations(
         [
           { type: '1-1', reference: 'inner', field: 'owner', refFrom: 'ownerId', refTo: 'id', dao: 'user', required: false }
         ]
@@ -954,7 +953,7 @@ export class InMemoryDogDAO<MetadataType, OperationMetadataType> extends Abstrac
 export type FriendsExcludedFields = never
 export type FriendsRelationFields = never
 
-export function friendsSchema(): Schema<types.Scalars> {
+export function friendsSchema(): T.Schema<types.Scalars> {
   return {
     'from': {
       scalar: 'ID', 
@@ -972,11 +971,11 @@ export function friendsSchema(): Schema<types.Scalars> {
 }
 
 type FriendsFilterFields = {
-  'from'?: types.Scalars['ID'] | null | EqualityOperators<types.Scalars['ID']> | ElementOperators,
-  'id'?: types.Scalars['ID'] | null | EqualityOperators<types.Scalars['ID']> | ElementOperators,
-  'to'?: types.Scalars['ID'] | null | EqualityOperators<types.Scalars['ID']> | ElementOperators
+  'from'?: types.Scalars['ID'] | null | T.EqualityOperators<types.Scalars['ID']> | T.ElementOperators,
+  'id'?: types.Scalars['ID'] | null | T.EqualityOperators<types.Scalars['ID']> | T.ElementOperators,
+  'to'?: types.Scalars['ID'] | null | T.EqualityOperators<types.Scalars['ID']> | T.ElementOperators
 }
-export type FriendsFilter = FriendsFilterFields & LogicalOperators<FriendsFilterFields | FriendsRawFilter>
+export type FriendsFilter = FriendsFilterFields & T.LogicalOperators<FriendsFilterFields | FriendsRawFilter>
 export type FriendsRawFilter = (builder: Knex.QueryBuilder<any, any>) => Knex.QueryBuilder<any, any>
 
 export type FriendsRelations = Record<never, string>
@@ -986,10 +985,10 @@ export type FriendsProjection = {
   id?: boolean,
   to?: boolean,
 }
-export type FriendsParam<P extends FriendsProjection> = ParamProjection<types.Friends, FriendsProjection, P>
+export type FriendsParam<P extends FriendsProjection> = T.ParamProjection<types.Friends, FriendsProjection, P>
 
 export type FriendsSortKeys = 'from' | 'id' | 'to'
-export type FriendsSort = OneKey<FriendsSortKeys, SortDirection>
+export type FriendsSort = T.OneKey<FriendsSortKeys, T.SortDirection>
 export type FriendsRawSort = (builder: Knex.QueryBuilder<any, any>) => Knex.QueryBuilder<any, any>
 
 export type FriendsUpdate = {
@@ -1005,17 +1004,17 @@ export type FriendsInsert = {
   to: types.Scalars['ID'],
 }
 
-type FriendsDAOGenerics<MetadataType, OperationMetadataType> = KnexJsDAOGenerics<types.Friends, 'id', 'ID', FriendsFilter, FriendsRawFilter, FriendsRelations, FriendsProjection, FriendsSort, FriendsRawSort, FriendsInsert, FriendsUpdate, FriendsRawUpdate, FriendsExcludedFields, FriendsRelationFields, MetadataType, OperationMetadataType, types.Scalars, 'friends', DAOContext<MetadataType, OperationMetadataType>>
-export type FriendsDAOParams<MetadataType, OperationMetadataType> = Omit<KnexJsDAOParams<FriendsDAOGenerics<MetadataType, OperationMetadataType>>, 'idField' | 'schema' | 'idScalar' | 'idGeneration'>
-export type InMemoryFriendsDAOParams<MetadataType, OperationMetadataType> = Omit<InMemoryDAOParams<FriendsDAOGenerics<MetadataType, OperationMetadataType>>, 'idField' | 'schema' | 'idScalar' | 'idGeneration'>
+type FriendsDAOGenerics<MetadataType, OperationMetadataType> = T.KnexJsDAOGenerics<types.Friends, 'id', 'ID', FriendsFilter, FriendsRawFilter, FriendsRelations, FriendsProjection, FriendsSort, FriendsRawSort, FriendsInsert, FriendsUpdate, FriendsRawUpdate, FriendsExcludedFields, FriendsRelationFields, MetadataType, OperationMetadataType, types.Scalars, 'friends', DAOContext<MetadataType, OperationMetadataType>>
+export type FriendsDAOParams<MetadataType, OperationMetadataType> = Omit<T.KnexJsDAOParams<FriendsDAOGenerics<MetadataType, OperationMetadataType>>, 'idField' | 'schema' | 'idScalar' | 'idGeneration'>
+export type InMemoryFriendsDAOParams<MetadataType, OperationMetadataType> = Omit<T.InMemoryDAOParams<FriendsDAOGenerics<MetadataType, OperationMetadataType>>, 'idField' | 'schema' | 'idScalar' | 'idGeneration'>
 
-export class FriendsDAO<MetadataType, OperationMetadataType> extends AbstractKnexJsDAO<FriendsDAOGenerics<MetadataType, OperationMetadataType>> {  
+export class FriendsDAO<MetadataType, OperationMetadataType> extends T.AbstractKnexJsDAO<FriendsDAOGenerics<MetadataType, OperationMetadataType>> {  
   
   public static projection<P extends FriendsProjection>(p: P) {
     return p
   }
-  public static mergeProjection<P1 extends FriendsProjection, P2 extends FriendsProjection>(p1: P1, p2: P2): SelectProjection<FriendsProjection, P1, P2> {
-    return mergeProjections(p1, p2) as SelectProjection<FriendsProjection, P1, P2>
+  public static mergeProjection<P1 extends FriendsProjection, P2 extends FriendsProjection>(p1: P1, p2: P2): T.SelectProjection<FriendsProjection, P1, P2> {
+    return T.mergeProjections(p1, p2) as T.SelectProjection<FriendsProjection, P1, P2>
   }
   
   public constructor(params: FriendsDAOParams<MetadataType, OperationMetadataType>){
@@ -1023,7 +1022,7 @@ export class FriendsDAO<MetadataType, OperationMetadataType> extends AbstractKne
       ...params, 
       idField: 'id', 
       schema: friendsSchema(), 
-      relations: overrideRelations(
+      relations: T.overrideRelations(
         [
           
         ]
@@ -1034,13 +1033,13 @@ export class FriendsDAO<MetadataType, OperationMetadataType> extends AbstractKne
   }
   }
 
-export class InMemoryFriendsDAO<MetadataType, OperationMetadataType> extends AbstractInMemoryDAO<FriendsDAOGenerics<MetadataType, OperationMetadataType>> {  
+export class InMemoryFriendsDAO<MetadataType, OperationMetadataType> extends T.AbstractInMemoryDAO<FriendsDAOGenerics<MetadataType, OperationMetadataType>> {  
   
   public static projection<P extends FriendsProjection>(p: P) {
     return p
   }
-  public static mergeProjection<P1 extends FriendsProjection, P2 extends FriendsProjection>(p1: P1, p2: P2): SelectProjection<FriendsProjection, P1, P2> {
-    return mergeProjections(p1, p2) as SelectProjection<FriendsProjection, P1, P2>
+  public static mergeProjection<P1 extends FriendsProjection, P2 extends FriendsProjection>(p1: P1, p2: P2): T.SelectProjection<FriendsProjection, P1, P2> {
+    return T.mergeProjections(p1, p2) as T.SelectProjection<FriendsProjection, P1, P2>
   }
   
   public constructor(params: InMemoryFriendsDAOParams<MetadataType, OperationMetadataType>){
@@ -1048,7 +1047,7 @@ export class InMemoryFriendsDAO<MetadataType, OperationMetadataType> extends Abs
       ...params, 
       idField: 'id', 
       schema: friendsSchema(), 
-      relations: overrideRelations(
+      relations: T.overrideRelations(
         [
           
         ]
@@ -1068,7 +1067,7 @@ export class InMemoryFriendsDAO<MetadataType, OperationMetadataType> extends Abs
 export type OrganizationExcludedFields = 'computedName'
 export type OrganizationRelationFields = never
 
-export function organizationSchema(): Schema<types.Scalars> {
+export function organizationSchema(): T.Schema<types.Scalars> {
   return {
     'address': { embedded: addressSchema() },
     'id': {
@@ -1086,12 +1085,12 @@ export function organizationSchema(): Schema<types.Scalars> {
 }
 
 type OrganizationFilterFields = {
-  'address.id'?: types.Scalars['ID'] | null | EqualityOperators<types.Scalars['ID']> | ElementOperators,
-  'id'?: types.Scalars['ID'] | null | EqualityOperators<types.Scalars['ID']> | ElementOperators,
-  'name'?: types.Scalars['String'] | null | EqualityOperators<types.Scalars['String']> | ElementOperators | StringOperators,
-  'vatNumber'?: types.Scalars['String'] | null | EqualityOperators<types.Scalars['String']> | ElementOperators | StringOperators
+  'address.id'?: types.Scalars['ID'] | null | T.EqualityOperators<types.Scalars['ID']> | T.ElementOperators,
+  'id'?: types.Scalars['ID'] | null | T.EqualityOperators<types.Scalars['ID']> | T.ElementOperators,
+  'name'?: types.Scalars['String'] | null | T.EqualityOperators<types.Scalars['String']> | T.ElementOperators | T.StringOperators,
+  'vatNumber'?: types.Scalars['String'] | null | T.EqualityOperators<types.Scalars['String']> | T.ElementOperators | T.StringOperators
 }
-export type OrganizationFilter = OrganizationFilterFields & LogicalOperators<OrganizationFilterFields | OrganizationRawFilter>
+export type OrganizationFilter = OrganizationFilterFields & T.LogicalOperators<OrganizationFilterFields | OrganizationRawFilter>
 export type OrganizationRawFilter = (builder: Knex.QueryBuilder<any, any>) => Knex.QueryBuilder<any, any>
 
 export type OrganizationRelations = Record<never, string>
@@ -1106,10 +1105,10 @@ export type OrganizationProjection = {
   name?: boolean,
   vatNumber?: boolean,
 }
-export type OrganizationParam<P extends OrganizationProjection> = ParamProjection<types.Organization, OrganizationProjection, P>
+export type OrganizationParam<P extends OrganizationProjection> = T.ParamProjection<types.Organization, OrganizationProjection, P>
 
 export type OrganizationSortKeys = 'address.id' | 'id' | 'name' | 'vatNumber'
-export type OrganizationSort = OneKey<OrganizationSortKeys, SortDirection>
+export type OrganizationSort = T.OneKey<OrganizationSortKeys, T.SortDirection>
 export type OrganizationRawSort = (builder: Knex.QueryBuilder<any, any>) => Knex.QueryBuilder<any, any>
 
 export type OrganizationUpdate = {
@@ -1128,17 +1127,17 @@ export type OrganizationInsert = {
   vatNumber?: null | types.Scalars['String'],
 }
 
-type OrganizationDAOGenerics<MetadataType, OperationMetadataType> = KnexJsDAOGenerics<types.Organization, 'id', 'ID', OrganizationFilter, OrganizationRawFilter, OrganizationRelations, OrganizationProjection, OrganizationSort, OrganizationRawSort, OrganizationInsert, OrganizationUpdate, OrganizationRawUpdate, OrganizationExcludedFields, OrganizationRelationFields, MetadataType, OperationMetadataType, types.Scalars, 'organization', DAOContext<MetadataType, OperationMetadataType>>
-export type OrganizationDAOParams<MetadataType, OperationMetadataType> = Omit<KnexJsDAOParams<OrganizationDAOGenerics<MetadataType, OperationMetadataType>>, 'idField' | 'schema' | 'idScalar' | 'idGeneration'>
-export type InMemoryOrganizationDAOParams<MetadataType, OperationMetadataType> = Omit<InMemoryDAOParams<OrganizationDAOGenerics<MetadataType, OperationMetadataType>>, 'idField' | 'schema' | 'idScalar' | 'idGeneration'>
+type OrganizationDAOGenerics<MetadataType, OperationMetadataType> = T.KnexJsDAOGenerics<types.Organization, 'id', 'ID', OrganizationFilter, OrganizationRawFilter, OrganizationRelations, OrganizationProjection, OrganizationSort, OrganizationRawSort, OrganizationInsert, OrganizationUpdate, OrganizationRawUpdate, OrganizationExcludedFields, OrganizationRelationFields, MetadataType, OperationMetadataType, types.Scalars, 'organization', DAOContext<MetadataType, OperationMetadataType>>
+export type OrganizationDAOParams<MetadataType, OperationMetadataType> = Omit<T.KnexJsDAOParams<OrganizationDAOGenerics<MetadataType, OperationMetadataType>>, 'idField' | 'schema' | 'idScalar' | 'idGeneration'>
+export type InMemoryOrganizationDAOParams<MetadataType, OperationMetadataType> = Omit<T.InMemoryDAOParams<OrganizationDAOGenerics<MetadataType, OperationMetadataType>>, 'idField' | 'schema' | 'idScalar' | 'idGeneration'>
 
-export class OrganizationDAO<MetadataType, OperationMetadataType> extends AbstractKnexJsDAO<OrganizationDAOGenerics<MetadataType, OperationMetadataType>> {  
+export class OrganizationDAO<MetadataType, OperationMetadataType> extends T.AbstractKnexJsDAO<OrganizationDAOGenerics<MetadataType, OperationMetadataType>> {  
   
   public static projection<P extends OrganizationProjection>(p: P) {
     return p
   }
-  public static mergeProjection<P1 extends OrganizationProjection, P2 extends OrganizationProjection>(p1: P1, p2: P2): SelectProjection<OrganizationProjection, P1, P2> {
-    return mergeProjections(p1, p2) as SelectProjection<OrganizationProjection, P1, P2>
+  public static mergeProjection<P1 extends OrganizationProjection, P2 extends OrganizationProjection>(p1: P1, p2: P2): T.SelectProjection<OrganizationProjection, P1, P2> {
+    return T.mergeProjections(p1, p2) as T.SelectProjection<OrganizationProjection, P1, P2>
   }
   
   public constructor(params: OrganizationDAOParams<MetadataType, OperationMetadataType>){
@@ -1146,7 +1145,7 @@ export class OrganizationDAO<MetadataType, OperationMetadataType> extends Abstra
       ...params, 
       idField: 'id', 
       schema: organizationSchema(), 
-      relations: overrideRelations(
+      relations: T.overrideRelations(
         [
           { type: '1-n', reference: 'foreign', field: 'address.cities', refFrom: 'addressId', refTo: 'address.id', dao: 'city', required: false }
         ]
@@ -1157,13 +1156,13 @@ export class OrganizationDAO<MetadataType, OperationMetadataType> extends Abstra
   }
   }
 
-export class InMemoryOrganizationDAO<MetadataType, OperationMetadataType> extends AbstractInMemoryDAO<OrganizationDAOGenerics<MetadataType, OperationMetadataType>> {  
+export class InMemoryOrganizationDAO<MetadataType, OperationMetadataType> extends T.AbstractInMemoryDAO<OrganizationDAOGenerics<MetadataType, OperationMetadataType>> {  
   
   public static projection<P extends OrganizationProjection>(p: P) {
     return p
   }
-  public static mergeProjection<P1 extends OrganizationProjection, P2 extends OrganizationProjection>(p1: P1, p2: P2): SelectProjection<OrganizationProjection, P1, P2> {
-    return mergeProjections(p1, p2) as SelectProjection<OrganizationProjection, P1, P2>
+  public static mergeProjection<P1 extends OrganizationProjection, P2 extends OrganizationProjection>(p1: P1, p2: P2): T.SelectProjection<OrganizationProjection, P1, P2> {
+    return T.mergeProjections(p1, p2) as T.SelectProjection<OrganizationProjection, P1, P2>
   }
   
   public constructor(params: InMemoryOrganizationDAOParams<MetadataType, OperationMetadataType>){
@@ -1171,7 +1170,7 @@ export class InMemoryOrganizationDAO<MetadataType, OperationMetadataType> extend
       ...params, 
       idField: 'id', 
       schema: organizationSchema(), 
-      relations: overrideRelations(
+      relations: T.overrideRelations(
         [
           { type: '1-n', reference: 'foreign', field: 'address.cities', refFrom: 'addressId', refTo: 'address.id', dao: 'city', required: false }
         ]
@@ -1191,7 +1190,7 @@ export class InMemoryOrganizationDAO<MetadataType, OperationMetadataType> extend
 export type UserExcludedFields = never
 export type UserRelationFields = 'bestFriend' | 'dogs' | 'friends'
 
-export function userSchema(): Schema<types.Scalars> {
+export function userSchema(): T.Schema<types.Scalars> {
   return {
     'amount': {
       scalar: 'Decimal', 
@@ -1236,20 +1235,20 @@ export function userSchema(): Schema<types.Scalars> {
 }
 
 type UserFilterFields = {
-  'amount'?: types.Scalars['Decimal'] | null | EqualityOperators<types.Scalars['Decimal']> | ElementOperators,
-  'amounts'?: types.Scalars['Decimal'][] | null | EqualityOperators<types.Scalars['Decimal'][]> | ElementOperators,
-  'bestFriendId'?: types.Scalars['ID'] | null | EqualityOperators<types.Scalars['ID']> | ElementOperators,
-  'credentials.another.test'?: types.Scalars['String'] | null | EqualityOperators<types.Scalars['String']> | ElementOperators | StringOperators,
-  'credentials.password'?: types.Scalars['Password'] | null | EqualityOperators<types.Scalars['Password']> | ElementOperators,
-  'credentials.username'?: types.Scalars['String'] | null | EqualityOperators<types.Scalars['String']> | ElementOperators | StringOperators,
-  'firstName'?: types.Scalars['String'] | null | EqualityOperators<types.Scalars['String']> | ElementOperators | StringOperators,
-  'id'?: types.Scalars['ID'] | null | EqualityOperators<types.Scalars['ID']> | ElementOperators,
-  'lastName'?: types.Scalars['String'] | null | EqualityOperators<types.Scalars['String']> | ElementOperators | StringOperators,
-  'live'?: types.Scalars['Boolean'] | null | EqualityOperators<types.Scalars['Boolean']> | ElementOperators,
-  'localization'?: types.Scalars['Coordinates'] | null | EqualityOperators<types.Scalars['Coordinates']> | ElementOperators,
-  'title'?: types.Scalars['LocalizedString'] | null | EqualityOperators<types.Scalars['LocalizedString']> | ElementOperators
+  'amount'?: types.Scalars['Decimal'] | null | T.EqualityOperators<types.Scalars['Decimal']> | T.ElementOperators,
+  'amounts'?: types.Scalars['Decimal'][] | null | T.EqualityOperators<types.Scalars['Decimal'][]> | T.ElementOperators,
+  'bestFriendId'?: types.Scalars['ID'] | null | T.EqualityOperators<types.Scalars['ID']> | T.ElementOperators,
+  'credentials.another.test'?: types.Scalars['String'] | null | T.EqualityOperators<types.Scalars['String']> | T.ElementOperators | T.StringOperators,
+  'credentials.password'?: types.Scalars['Password'] | null | T.EqualityOperators<types.Scalars['Password']> | T.ElementOperators,
+  'credentials.username'?: types.Scalars['String'] | null | T.EqualityOperators<types.Scalars['String']> | T.ElementOperators | T.StringOperators,
+  'firstName'?: types.Scalars['String'] | null | T.EqualityOperators<types.Scalars['String']> | T.ElementOperators | T.StringOperators,
+  'id'?: types.Scalars['ID'] | null | T.EqualityOperators<types.Scalars['ID']> | T.ElementOperators,
+  'lastName'?: types.Scalars['String'] | null | T.EqualityOperators<types.Scalars['String']> | T.ElementOperators | T.StringOperators,
+  'live'?: types.Scalars['Boolean'] | null | T.EqualityOperators<types.Scalars['Boolean']> | T.ElementOperators,
+  'localization'?: types.Scalars['Coordinates'] | null | T.EqualityOperators<types.Scalars['Coordinates']> | T.ElementOperators,
+  'title'?: types.Scalars['LocalizedString'] | null | T.EqualityOperators<types.Scalars['LocalizedString']> | T.ElementOperators
 }
-export type UserFilter = UserFilterFields & LogicalOperators<UserFilterFields | UserRawFilter>
+export type UserFilter = UserFilterFields & T.LogicalOperators<UserFilterFields | UserRawFilter>
 export type UserRawFilter = (builder: Knex.QueryBuilder<any, any>) => Knex.QueryBuilder<any, any>
 
 export type UserRelations = {
@@ -1290,10 +1289,10 @@ export type UserProjection = {
   localization?: boolean,
   title?: boolean,
 }
-export type UserParam<P extends UserProjection> = ParamProjection<types.User, UserProjection, P>
+export type UserParam<P extends UserProjection> = T.ParamProjection<types.User, UserProjection, P>
 
 export type UserSortKeys = 'amount' | 'amounts' | 'bestFriendId' | 'credentials.another.test' | 'credentials.password' | 'credentials.username' | 'firstName' | 'id' | 'lastName' | 'live' | 'localization' | 'title'
-export type UserSort = OneKey<UserSortKeys, SortDirection>
+export type UserSort = T.OneKey<UserSortKeys, T.SortDirection>
 export type UserRawSort = (builder: Knex.QueryBuilder<any, any>) => Knex.QueryBuilder<any, any>
 
 export type UserUpdate = {
@@ -1327,17 +1326,17 @@ export type UserInsert = {
   title?: null | types.Scalars['LocalizedString'],
 }
 
-type UserDAOGenerics<MetadataType, OperationMetadataType> = KnexJsDAOGenerics<types.User, 'id', 'ID', UserFilter, UserRawFilter, UserRelations, UserProjection, UserSort, UserRawSort, UserInsert, UserUpdate, UserRawUpdate, UserExcludedFields, UserRelationFields, MetadataType, OperationMetadataType, types.Scalars, 'user', DAOContext<MetadataType, OperationMetadataType>>
-export type UserDAOParams<MetadataType, OperationMetadataType> = Omit<KnexJsDAOParams<UserDAOGenerics<MetadataType, OperationMetadataType>>, 'idField' | 'schema' | 'idScalar' | 'idGeneration'>
-export type InMemoryUserDAOParams<MetadataType, OperationMetadataType> = Omit<InMemoryDAOParams<UserDAOGenerics<MetadataType, OperationMetadataType>>, 'idField' | 'schema' | 'idScalar' | 'idGeneration'>
+type UserDAOGenerics<MetadataType, OperationMetadataType> = T.KnexJsDAOGenerics<types.User, 'id', 'ID', UserFilter, UserRawFilter, UserRelations, UserProjection, UserSort, UserRawSort, UserInsert, UserUpdate, UserRawUpdate, UserExcludedFields, UserRelationFields, MetadataType, OperationMetadataType, types.Scalars, 'user', DAOContext<MetadataType, OperationMetadataType>>
+export type UserDAOParams<MetadataType, OperationMetadataType> = Omit<T.KnexJsDAOParams<UserDAOGenerics<MetadataType, OperationMetadataType>>, 'idField' | 'schema' | 'idScalar' | 'idGeneration'>
+export type InMemoryUserDAOParams<MetadataType, OperationMetadataType> = Omit<T.InMemoryDAOParams<UserDAOGenerics<MetadataType, OperationMetadataType>>, 'idField' | 'schema' | 'idScalar' | 'idGeneration'>
 
-export class UserDAO<MetadataType, OperationMetadataType> extends AbstractKnexJsDAO<UserDAOGenerics<MetadataType, OperationMetadataType>> {  
+export class UserDAO<MetadataType, OperationMetadataType> extends T.AbstractKnexJsDAO<UserDAOGenerics<MetadataType, OperationMetadataType>> {  
   
   public static projection<P extends UserProjection>(p: P) {
     return p
   }
-  public static mergeProjection<P1 extends UserProjection, P2 extends UserProjection>(p1: P1, p2: P2): SelectProjection<UserProjection, P1, P2> {
-    return mergeProjections(p1, p2) as SelectProjection<UserProjection, P1, P2>
+  public static mergeProjection<P1 extends UserProjection, P2 extends UserProjection>(p1: P1, p2: P2): T.SelectProjection<UserProjection, P1, P2> {
+    return T.mergeProjections(p1, p2) as T.SelectProjection<UserProjection, P1, P2>
   }
   
   public constructor(params: UserDAOParams<MetadataType, OperationMetadataType>){
@@ -1345,7 +1344,7 @@ export class UserDAO<MetadataType, OperationMetadataType> extends AbstractKnexJs
       ...params, 
       idField: 'id', 
       schema: userSchema(), 
-      relations: overrideRelations(
+      relations: T.overrideRelations(
         [
           { type: '1-1', reference: 'inner', field: 'bestFriend', refFrom: 'bestFriendId', refTo: 'id', dao: 'user', required: false },
           { type: '1-n', reference: 'foreign', field: 'dogs', refFrom: 'ownerId', refTo: 'id', dao: 'dog', required: false },
@@ -1358,13 +1357,13 @@ export class UserDAO<MetadataType, OperationMetadataType> extends AbstractKnexJs
   }
   }
 
-export class InMemoryUserDAO<MetadataType, OperationMetadataType> extends AbstractInMemoryDAO<UserDAOGenerics<MetadataType, OperationMetadataType>> {  
+export class InMemoryUserDAO<MetadataType, OperationMetadataType> extends T.AbstractInMemoryDAO<UserDAOGenerics<MetadataType, OperationMetadataType>> {  
   
   public static projection<P extends UserProjection>(p: P) {
     return p
   }
-  public static mergeProjection<P1 extends UserProjection, P2 extends UserProjection>(p1: P1, p2: P2): SelectProjection<UserProjection, P1, P2> {
-    return mergeProjections(p1, p2) as SelectProjection<UserProjection, P1, P2>
+  public static mergeProjection<P1 extends UserProjection, P2 extends UserProjection>(p1: P1, p2: P2): T.SelectProjection<UserProjection, P1, P2> {
+    return T.mergeProjections(p1, p2) as T.SelectProjection<UserProjection, P1, P2>
   }
   
   public constructor(params: InMemoryUserDAOParams<MetadataType, OperationMetadataType>){
@@ -1372,7 +1371,7 @@ export class InMemoryUserDAO<MetadataType, OperationMetadataType> extends Abstra
       ...params, 
       idField: 'id', 
       schema: userSchema(), 
-      relations: overrideRelations(
+      relations: T.overrideRelations(
         [
           { type: '1-1', reference: 'inner', field: 'bestFriend', refFrom: 'bestFriendId', refTo: 'id', dao: 'user', required: false },
           { type: '1-n', reference: 'foreign', field: 'dogs', refFrom: 'ownerId', refTo: 'id', dao: 'dog', required: false },
@@ -1391,7 +1390,7 @@ export class InMemoryUserDAO<MetadataType, OperationMetadataType> extends Abstra
 //------------------------- USERNAMEPASSWORDCREDENTIALS --------------------------
 //--------------------------------------------------------------------------------
 
-export function usernamePasswordCredentialsSchema(): Schema<types.Scalars> {
+export function usernamePasswordCredentialsSchema(): T.Schema<types.Scalars> {
   return {
     'another': { embedded: anotherSchema(), alias: 'a' },
     'password': {
@@ -1414,7 +1413,7 @@ export type UsernamePasswordCredentialsProjection = {
   password?: boolean,
   username?: boolean,
 }
-export type UsernamePasswordCredentialsParam<P extends UsernamePasswordCredentialsProjection> = ParamProjection<types.UsernamePasswordCredentials, UsernamePasswordCredentialsProjection, P>
+export type UsernamePasswordCredentialsParam<P extends UsernamePasswordCredentialsProjection> = T.ParamProjection<types.UsernamePasswordCredentials, UsernamePasswordCredentialsProjection, P>
 
 export type UsernamePasswordCredentialsInsert = {
   another?: null | AnotherInsert,
@@ -1440,14 +1439,14 @@ export type DAOContextParams<MetadataType, OperationMetadataType, Permissions ex
     user?: Pick<Partial<UserDAOParams<MetadataType, OperationMetadataType>>, 'idGenerator' | 'middlewares' | 'metadata'>
   },
   knex: Record<'default', Knex | 'mock'>,
-  scalars?: UserInputDriverDataTypeAdapterMap<types.Scalars, 'knex'>,
-  log?: LogInput<'address' | 'author' | 'authorBook' | 'book' | 'city' | 'defaultFieldsEntity' | 'device' | 'dog' | 'friends' | 'organization' | 'user'>,
-  security?: DAOContextSecurtyPolicy<DAOGenericsMap<MetadataType, OperationMetadataType>, OperationMetadataType, Permissions, SecurityDomain>
+  scalars?: T.UserInputDriverDataTypeAdapterMap<types.Scalars, 'knex'>,
+  log?: T.LogInput<'address' | 'author' | 'authorBook' | 'book' | 'city' | 'defaultFieldsEntity' | 'device' | 'dog' | 'friends' | 'organization' | 'user'>,
+  security?: T.DAOContextSecurtyPolicy<DAOGenericsMap<MetadataType, OperationMetadataType>, OperationMetadataType, Permissions, SecurityDomain>
 }
 
-type DAOContextMiddleware<MetadataType = never, OperationMetadataType = never> = DAOMiddleware<DAOGenericsUnion<MetadataType, OperationMetadataType>>
+type DAOContextMiddleware<MetadataType = never, OperationMetadataType = never> = T.DAOMiddleware<DAOGenericsUnion<MetadataType, OperationMetadataType>>
 
-export class DAOContext<MetadataType = never, OperationMetadataType = never, Permissions extends string = never, SecurityDomain extends object = never> extends AbstractDAOContext<never, 'default', types.Scalars, MetadataType>  {
+export class DAOContext<MetadataType = never, OperationMetadataType = never, Permissions extends string = never, SecurityDomain extends object = never> extends T.AbstractDAOContext<never, 'default', types.Scalars, MetadataType>  {
 
   private _address: AddressDAO<MetadataType, OperationMetadataType> | undefined
   private _author: AuthorDAO<MetadataType, OperationMetadataType> | undefined
@@ -1468,82 +1467,82 @@ export class DAOContext<MetadataType = never, OperationMetadataType = never, Per
   
   private middlewares: (DAOContextMiddleware<MetadataType, OperationMetadataType> | GroupMiddleware<any, MetadataType, OperationMetadataType>)[]
   
-  private logger?: LogFunction<'address' | 'author' | 'authorBook' | 'book' | 'city' | 'defaultFieldsEntity' | 'device' | 'dog' | 'friends' | 'organization' | 'user'>
+  private logger?: T.LogFunction<'address' | 'author' | 'authorBook' | 'book' | 'city' | 'defaultFieldsEntity' | 'device' | 'dog' | 'friends' | 'organization' | 'user'>
   
   get address(): AddressDAO<MetadataType, OperationMetadataType> {
     if(!this._address) {
       const db = this.knex.default
-      this._address = db === 'mock' ? (new InMemoryAddressDAO({ daoContext: this, datasource: null, metadata: this.metadata, ...this.overrides?.address, middlewares: [...(this.overrides?.address?.middlewares || []), ...selectMiddleware('address', this.middlewares) as DAOMiddleware<AddressDAOGenerics<MetadataType, OperationMetadataType>>[]], name: 'address', logger: this.logger }) as unknown as AddressDAO<MetadataType, OperationMetadataType>) : new AddressDAO({ daoContext: this, datasource: 'default', metadata: this.metadata, ...this.overrides?.address, knex: db, tableName: 'addresses', middlewares: [...(this.overrides?.address?.middlewares || []), ...selectMiddleware('address', this.middlewares) as DAOMiddleware<AddressDAOGenerics<MetadataType, OperationMetadataType>>[]], name: 'address', logger: this.logger })
+      this._address = db === 'mock' ? (new InMemoryAddressDAO({ daoContext: this, datasource: null, metadata: this.metadata, ...this.overrides?.address, middlewares: [...(this.overrides?.address?.middlewares || []), ...selectMiddleware('address', this.middlewares) as T.DAOMiddleware<AddressDAOGenerics<MetadataType, OperationMetadataType>>[]], name: 'address', logger: this.logger }) as unknown as AddressDAO<MetadataType, OperationMetadataType>) : new AddressDAO({ daoContext: this, datasource: 'default', metadata: this.metadata, ...this.overrides?.address, knex: db, tableName: 'addresses', middlewares: [...(this.overrides?.address?.middlewares || []), ...selectMiddleware('address', this.middlewares) as T.DAOMiddleware<AddressDAOGenerics<MetadataType, OperationMetadataType>>[]], name: 'address', logger: this.logger })
     }
     return this._address
   }
   get author(): AuthorDAO<MetadataType, OperationMetadataType> {
     if(!this._author) {
       const db = this.knex.default
-      this._author = db === 'mock' ? (new InMemoryAuthorDAO({ daoContext: this, datasource: null, metadata: this.metadata, ...this.overrides?.author, middlewares: [...(this.overrides?.author?.middlewares || []), ...selectMiddleware('author', this.middlewares) as DAOMiddleware<AuthorDAOGenerics<MetadataType, OperationMetadataType>>[]], name: 'author', logger: this.logger }) as unknown as AuthorDAO<MetadataType, OperationMetadataType>) : new AuthorDAO({ daoContext: this, datasource: 'default', metadata: this.metadata, ...this.overrides?.author, knex: db, tableName: 'authors', middlewares: [...(this.overrides?.author?.middlewares || []), ...selectMiddleware('author', this.middlewares) as DAOMiddleware<AuthorDAOGenerics<MetadataType, OperationMetadataType>>[]], name: 'author', logger: this.logger })
+      this._author = db === 'mock' ? (new InMemoryAuthorDAO({ daoContext: this, datasource: null, metadata: this.metadata, ...this.overrides?.author, middlewares: [...(this.overrides?.author?.middlewares || []), ...selectMiddleware('author', this.middlewares) as T.DAOMiddleware<AuthorDAOGenerics<MetadataType, OperationMetadataType>>[]], name: 'author', logger: this.logger }) as unknown as AuthorDAO<MetadataType, OperationMetadataType>) : new AuthorDAO({ daoContext: this, datasource: 'default', metadata: this.metadata, ...this.overrides?.author, knex: db, tableName: 'authors', middlewares: [...(this.overrides?.author?.middlewares || []), ...selectMiddleware('author', this.middlewares) as T.DAOMiddleware<AuthorDAOGenerics<MetadataType, OperationMetadataType>>[]], name: 'author', logger: this.logger })
     }
     return this._author
   }
   get authorBook(): AuthorBookDAO<MetadataType, OperationMetadataType> {
     if(!this._authorBook) {
       const db = this.knex.default
-      this._authorBook = db === 'mock' ? (new InMemoryAuthorBookDAO({ daoContext: this, datasource: null, metadata: this.metadata, ...this.overrides?.authorBook, middlewares: [...(this.overrides?.authorBook?.middlewares || []), ...selectMiddleware('authorBook', this.middlewares) as DAOMiddleware<AuthorBookDAOGenerics<MetadataType, OperationMetadataType>>[]], name: 'authorBook', logger: this.logger }) as unknown as AuthorBookDAO<MetadataType, OperationMetadataType>) : new AuthorBookDAO({ daoContext: this, datasource: 'default', metadata: this.metadata, ...this.overrides?.authorBook, knex: db, tableName: 'authorBooks', middlewares: [...(this.overrides?.authorBook?.middlewares || []), ...selectMiddleware('authorBook', this.middlewares) as DAOMiddleware<AuthorBookDAOGenerics<MetadataType, OperationMetadataType>>[]], name: 'authorBook', logger: this.logger })
+      this._authorBook = db === 'mock' ? (new InMemoryAuthorBookDAO({ daoContext: this, datasource: null, metadata: this.metadata, ...this.overrides?.authorBook, middlewares: [...(this.overrides?.authorBook?.middlewares || []), ...selectMiddleware('authorBook', this.middlewares) as T.DAOMiddleware<AuthorBookDAOGenerics<MetadataType, OperationMetadataType>>[]], name: 'authorBook', logger: this.logger }) as unknown as AuthorBookDAO<MetadataType, OperationMetadataType>) : new AuthorBookDAO({ daoContext: this, datasource: 'default', metadata: this.metadata, ...this.overrides?.authorBook, knex: db, tableName: 'authorBooks', middlewares: [...(this.overrides?.authorBook?.middlewares || []), ...selectMiddleware('authorBook', this.middlewares) as T.DAOMiddleware<AuthorBookDAOGenerics<MetadataType, OperationMetadataType>>[]], name: 'authorBook', logger: this.logger })
     }
     return this._authorBook
   }
   get book(): BookDAO<MetadataType, OperationMetadataType> {
     if(!this._book) {
       const db = this.knex.default
-      this._book = db === 'mock' ? (new InMemoryBookDAO({ daoContext: this, datasource: null, metadata: this.metadata, ...this.overrides?.book, middlewares: [...(this.overrides?.book?.middlewares || []), ...selectMiddleware('book', this.middlewares) as DAOMiddleware<BookDAOGenerics<MetadataType, OperationMetadataType>>[]], name: 'book', logger: this.logger }) as unknown as BookDAO<MetadataType, OperationMetadataType>) : new BookDAO({ daoContext: this, datasource: 'default', metadata: this.metadata, ...this.overrides?.book, knex: db, tableName: 'books', middlewares: [...(this.overrides?.book?.middlewares || []), ...selectMiddleware('book', this.middlewares) as DAOMiddleware<BookDAOGenerics<MetadataType, OperationMetadataType>>[]], name: 'book', logger: this.logger })
+      this._book = db === 'mock' ? (new InMemoryBookDAO({ daoContext: this, datasource: null, metadata: this.metadata, ...this.overrides?.book, middlewares: [...(this.overrides?.book?.middlewares || []), ...selectMiddleware('book', this.middlewares) as T.DAOMiddleware<BookDAOGenerics<MetadataType, OperationMetadataType>>[]], name: 'book', logger: this.logger }) as unknown as BookDAO<MetadataType, OperationMetadataType>) : new BookDAO({ daoContext: this, datasource: 'default', metadata: this.metadata, ...this.overrides?.book, knex: db, tableName: 'books', middlewares: [...(this.overrides?.book?.middlewares || []), ...selectMiddleware('book', this.middlewares) as T.DAOMiddleware<BookDAOGenerics<MetadataType, OperationMetadataType>>[]], name: 'book', logger: this.logger })
     }
     return this._book
   }
   get city(): CityDAO<MetadataType, OperationMetadataType> {
     if(!this._city) {
       const db = this.knex.default
-      this._city = db === 'mock' ? (new InMemoryCityDAO({ daoContext: this, datasource: null, metadata: this.metadata, ...this.overrides?.city, middlewares: [...(this.overrides?.city?.middlewares || []), ...selectMiddleware('city', this.middlewares) as DAOMiddleware<CityDAOGenerics<MetadataType, OperationMetadataType>>[]], name: 'city', logger: this.logger }) as unknown as CityDAO<MetadataType, OperationMetadataType>) : new CityDAO({ daoContext: this, datasource: 'default', metadata: this.metadata, ...this.overrides?.city, knex: db, tableName: 'citys', middlewares: [...(this.overrides?.city?.middlewares || []), ...selectMiddleware('city', this.middlewares) as DAOMiddleware<CityDAOGenerics<MetadataType, OperationMetadataType>>[]], name: 'city', logger: this.logger })
+      this._city = db === 'mock' ? (new InMemoryCityDAO({ daoContext: this, datasource: null, metadata: this.metadata, ...this.overrides?.city, middlewares: [...(this.overrides?.city?.middlewares || []), ...selectMiddleware('city', this.middlewares) as T.DAOMiddleware<CityDAOGenerics<MetadataType, OperationMetadataType>>[]], name: 'city', logger: this.logger }) as unknown as CityDAO<MetadataType, OperationMetadataType>) : new CityDAO({ daoContext: this, datasource: 'default', metadata: this.metadata, ...this.overrides?.city, knex: db, tableName: 'citys', middlewares: [...(this.overrides?.city?.middlewares || []), ...selectMiddleware('city', this.middlewares) as T.DAOMiddleware<CityDAOGenerics<MetadataType, OperationMetadataType>>[]], name: 'city', logger: this.logger })
     }
     return this._city
   }
   get defaultFieldsEntity(): DefaultFieldsEntityDAO<MetadataType, OperationMetadataType> {
     if(!this._defaultFieldsEntity) {
       const db = this.knex.default
-      this._defaultFieldsEntity = db === 'mock' ? (new InMemoryDefaultFieldsEntityDAO({ daoContext: this, datasource: null, metadata: this.metadata, ...this.overrides?.defaultFieldsEntity, middlewares: [...(this.overrides?.defaultFieldsEntity?.middlewares || []), ...selectMiddleware('defaultFieldsEntity', this.middlewares) as DAOMiddleware<DefaultFieldsEntityDAOGenerics<MetadataType, OperationMetadataType>>[]], name: 'defaultFieldsEntity', logger: this.logger }) as unknown as DefaultFieldsEntityDAO<MetadataType, OperationMetadataType>) : new DefaultFieldsEntityDAO({ daoContext: this, datasource: 'default', metadata: this.metadata, ...this.overrides?.defaultFieldsEntity, knex: db, tableName: 'defaultFieldsEntitys', middlewares: [...(this.overrides?.defaultFieldsEntity?.middlewares || []), ...selectMiddleware('defaultFieldsEntity', this.middlewares) as DAOMiddleware<DefaultFieldsEntityDAOGenerics<MetadataType, OperationMetadataType>>[]], name: 'defaultFieldsEntity', logger: this.logger })
+      this._defaultFieldsEntity = db === 'mock' ? (new InMemoryDefaultFieldsEntityDAO({ daoContext: this, datasource: null, metadata: this.metadata, ...this.overrides?.defaultFieldsEntity, middlewares: [...(this.overrides?.defaultFieldsEntity?.middlewares || []), ...selectMiddleware('defaultFieldsEntity', this.middlewares) as T.DAOMiddleware<DefaultFieldsEntityDAOGenerics<MetadataType, OperationMetadataType>>[]], name: 'defaultFieldsEntity', logger: this.logger }) as unknown as DefaultFieldsEntityDAO<MetadataType, OperationMetadataType>) : new DefaultFieldsEntityDAO({ daoContext: this, datasource: 'default', metadata: this.metadata, ...this.overrides?.defaultFieldsEntity, knex: db, tableName: 'defaultFieldsEntitys', middlewares: [...(this.overrides?.defaultFieldsEntity?.middlewares || []), ...selectMiddleware('defaultFieldsEntity', this.middlewares) as T.DAOMiddleware<DefaultFieldsEntityDAOGenerics<MetadataType, OperationMetadataType>>[]], name: 'defaultFieldsEntity', logger: this.logger })
     }
     return this._defaultFieldsEntity
   }
   get device(): DeviceDAO<MetadataType, OperationMetadataType> {
     if(!this._device) {
       const db = this.knex.default
-      this._device = db === 'mock' ? (new InMemoryDeviceDAO({ daoContext: this, datasource: null, metadata: this.metadata, ...this.overrides?.device, middlewares: [...(this.overrides?.device?.middlewares || []), ...selectMiddleware('device', this.middlewares) as DAOMiddleware<DeviceDAOGenerics<MetadataType, OperationMetadataType>>[]], name: 'device', logger: this.logger }) as unknown as DeviceDAO<MetadataType, OperationMetadataType>) : new DeviceDAO({ daoContext: this, datasource: 'default', metadata: this.metadata, ...this.overrides?.device, knex: db, tableName: 'devices', middlewares: [...(this.overrides?.device?.middlewares || []), ...selectMiddleware('device', this.middlewares) as DAOMiddleware<DeviceDAOGenerics<MetadataType, OperationMetadataType>>[]], name: 'device', logger: this.logger })
+      this._device = db === 'mock' ? (new InMemoryDeviceDAO({ daoContext: this, datasource: null, metadata: this.metadata, ...this.overrides?.device, middlewares: [...(this.overrides?.device?.middlewares || []), ...selectMiddleware('device', this.middlewares) as T.DAOMiddleware<DeviceDAOGenerics<MetadataType, OperationMetadataType>>[]], name: 'device', logger: this.logger }) as unknown as DeviceDAO<MetadataType, OperationMetadataType>) : new DeviceDAO({ daoContext: this, datasource: 'default', metadata: this.metadata, ...this.overrides?.device, knex: db, tableName: 'devices', middlewares: [...(this.overrides?.device?.middlewares || []), ...selectMiddleware('device', this.middlewares) as T.DAOMiddleware<DeviceDAOGenerics<MetadataType, OperationMetadataType>>[]], name: 'device', logger: this.logger })
     }
     return this._device
   }
   get dog(): DogDAO<MetadataType, OperationMetadataType> {
     if(!this._dog) {
       const db = this.knex.default
-      this._dog = db === 'mock' ? (new InMemoryDogDAO({ daoContext: this, datasource: null, metadata: this.metadata, ...this.overrides?.dog, middlewares: [...(this.overrides?.dog?.middlewares || []), ...selectMiddleware('dog', this.middlewares) as DAOMiddleware<DogDAOGenerics<MetadataType, OperationMetadataType>>[]], name: 'dog', logger: this.logger }) as unknown as DogDAO<MetadataType, OperationMetadataType>) : new DogDAO({ daoContext: this, datasource: 'default', metadata: this.metadata, ...this.overrides?.dog, knex: db, tableName: 'dogs', middlewares: [...(this.overrides?.dog?.middlewares || []), ...selectMiddleware('dog', this.middlewares) as DAOMiddleware<DogDAOGenerics<MetadataType, OperationMetadataType>>[]], name: 'dog', logger: this.logger })
+      this._dog = db === 'mock' ? (new InMemoryDogDAO({ daoContext: this, datasource: null, metadata: this.metadata, ...this.overrides?.dog, middlewares: [...(this.overrides?.dog?.middlewares || []), ...selectMiddleware('dog', this.middlewares) as T.DAOMiddleware<DogDAOGenerics<MetadataType, OperationMetadataType>>[]], name: 'dog', logger: this.logger }) as unknown as DogDAO<MetadataType, OperationMetadataType>) : new DogDAO({ daoContext: this, datasource: 'default', metadata: this.metadata, ...this.overrides?.dog, knex: db, tableName: 'dogs', middlewares: [...(this.overrides?.dog?.middlewares || []), ...selectMiddleware('dog', this.middlewares) as T.DAOMiddleware<DogDAOGenerics<MetadataType, OperationMetadataType>>[]], name: 'dog', logger: this.logger })
     }
     return this._dog
   }
   get friends(): FriendsDAO<MetadataType, OperationMetadataType> {
     if(!this._friends) {
       const db = this.knex.default
-      this._friends = db === 'mock' ? (new InMemoryFriendsDAO({ daoContext: this, datasource: null, metadata: this.metadata, ...this.overrides?.friends, middlewares: [...(this.overrides?.friends?.middlewares || []), ...selectMiddleware('friends', this.middlewares) as DAOMiddleware<FriendsDAOGenerics<MetadataType, OperationMetadataType>>[]], name: 'friends', logger: this.logger }) as unknown as FriendsDAO<MetadataType, OperationMetadataType>) : new FriendsDAO({ daoContext: this, datasource: 'default', metadata: this.metadata, ...this.overrides?.friends, knex: db, tableName: 'friendss', middlewares: [...(this.overrides?.friends?.middlewares || []), ...selectMiddleware('friends', this.middlewares) as DAOMiddleware<FriendsDAOGenerics<MetadataType, OperationMetadataType>>[]], name: 'friends', logger: this.logger })
+      this._friends = db === 'mock' ? (new InMemoryFriendsDAO({ daoContext: this, datasource: null, metadata: this.metadata, ...this.overrides?.friends, middlewares: [...(this.overrides?.friends?.middlewares || []), ...selectMiddleware('friends', this.middlewares) as T.DAOMiddleware<FriendsDAOGenerics<MetadataType, OperationMetadataType>>[]], name: 'friends', logger: this.logger }) as unknown as FriendsDAO<MetadataType, OperationMetadataType>) : new FriendsDAO({ daoContext: this, datasource: 'default', metadata: this.metadata, ...this.overrides?.friends, knex: db, tableName: 'friendss', middlewares: [...(this.overrides?.friends?.middlewares || []), ...selectMiddleware('friends', this.middlewares) as T.DAOMiddleware<FriendsDAOGenerics<MetadataType, OperationMetadataType>>[]], name: 'friends', logger: this.logger })
     }
     return this._friends
   }
   get organization(): OrganizationDAO<MetadataType, OperationMetadataType> {
     if(!this._organization) {
       const db = this.knex.default
-      this._organization = db === 'mock' ? (new InMemoryOrganizationDAO({ daoContext: this, datasource: null, metadata: this.metadata, ...this.overrides?.organization, middlewares: [...(this.overrides?.organization?.middlewares || []), ...selectMiddleware('organization', this.middlewares) as DAOMiddleware<OrganizationDAOGenerics<MetadataType, OperationMetadataType>>[]], name: 'organization', logger: this.logger }) as unknown as OrganizationDAO<MetadataType, OperationMetadataType>) : new OrganizationDAO({ daoContext: this, datasource: 'default', metadata: this.metadata, ...this.overrides?.organization, knex: db, tableName: 'organizations', middlewares: [...(this.overrides?.organization?.middlewares || []), ...selectMiddleware('organization', this.middlewares) as DAOMiddleware<OrganizationDAOGenerics<MetadataType, OperationMetadataType>>[]], name: 'organization', logger: this.logger })
+      this._organization = db === 'mock' ? (new InMemoryOrganizationDAO({ daoContext: this, datasource: null, metadata: this.metadata, ...this.overrides?.organization, middlewares: [...(this.overrides?.organization?.middlewares || []), ...selectMiddleware('organization', this.middlewares) as T.DAOMiddleware<OrganizationDAOGenerics<MetadataType, OperationMetadataType>>[]], name: 'organization', logger: this.logger }) as unknown as OrganizationDAO<MetadataType, OperationMetadataType>) : new OrganizationDAO({ daoContext: this, datasource: 'default', metadata: this.metadata, ...this.overrides?.organization, knex: db, tableName: 'organizations', middlewares: [...(this.overrides?.organization?.middlewares || []), ...selectMiddleware('organization', this.middlewares) as T.DAOMiddleware<OrganizationDAOGenerics<MetadataType, OperationMetadataType>>[]], name: 'organization', logger: this.logger })
     }
     return this._organization
   }
   get user(): UserDAO<MetadataType, OperationMetadataType> {
     if(!this._user) {
       const db = this.knex.default
-      this._user = db === 'mock' ? (new InMemoryUserDAO({ daoContext: this, datasource: null, metadata: this.metadata, ...this.overrides?.user, middlewares: [...(this.overrides?.user?.middlewares || []), ...selectMiddleware('user', this.middlewares) as DAOMiddleware<UserDAOGenerics<MetadataType, OperationMetadataType>>[]], name: 'user', logger: this.logger }) as unknown as UserDAO<MetadataType, OperationMetadataType>) : new UserDAO({ daoContext: this, datasource: 'default', metadata: this.metadata, ...this.overrides?.user, knex: db, tableName: 'users', middlewares: [...(this.overrides?.user?.middlewares || []), ...selectMiddleware('user', this.middlewares) as DAOMiddleware<UserDAOGenerics<MetadataType, OperationMetadataType>>[]], name: 'user', logger: this.logger })
+      this._user = db === 'mock' ? (new InMemoryUserDAO({ daoContext: this, datasource: null, metadata: this.metadata, ...this.overrides?.user, middlewares: [...(this.overrides?.user?.middlewares || []), ...selectMiddleware('user', this.middlewares) as T.DAOMiddleware<UserDAOGenerics<MetadataType, OperationMetadataType>>[]], name: 'user', logger: this.logger }) as unknown as UserDAO<MetadataType, OperationMetadataType>) : new UserDAO({ daoContext: this, datasource: 'default', metadata: this.metadata, ...this.overrides?.user, knex: db, tableName: 'users', middlewares: [...(this.overrides?.user?.middlewares || []), ...selectMiddleware('user', this.middlewares) as T.DAOMiddleware<UserDAOGenerics<MetadataType, OperationMetadataType>>[]], name: 'user', logger: this.logger })
     }
     return this._user
   }
@@ -1551,14 +1550,14 @@ export class DAOContext<MetadataType = never, OperationMetadataType = never, Per
   constructor(params: DAOContextParams<MetadataType, OperationMetadataType, Permissions, SecurityDomain>) {
     super({
       ...params,
-      scalars: params.scalars ? userInputDataTypeAdapterToDataTypeAdapter(params.scalars, ['Coordinates', 'Decimal', 'JSON', 'Live', 'LocalizedString', 'Password', 'ID', 'String', 'Boolean', 'Int', 'Float']) : undefined
+      scalars: params.scalars ? T.userInputDataTypeAdapterToDataTypeAdapter(params.scalars, ['Coordinates', 'Decimal', 'JSON', 'Live', 'LocalizedString', 'Password', 'ID', 'String', 'Boolean', 'Int', 'Float']) : undefined
     })
     this.overrides = params.overrides
     this.knex = params.knex
     this.middlewares = params.middlewares || []
-    this.logger = logInputToLogger(params.log)
+    this.logger = T.logInputToLogger(params.log)
     if(params.security && params.security.applySecurity !== false) {
-      const securityMiddlewares = createSecurityPolicyMiddlewares(params.security)
+      const securityMiddlewares = T.createSecurityPolicyMiddlewares(params.security)
       const defaultMiddleware = securityMiddlewares.others ? [groupMiddleware.excludes(Object.fromEntries(Object.keys(securityMiddlewares.middlewares).map(k => [k, true])) as any, securityMiddlewares.others as any)] : []
       this.middlewares = [...(params.middlewares ?? []), ...defaultMiddleware, ...Object.entries(securityMiddlewares.middlewares).map(([name, middleware]) => groupMiddleware.includes({[name]: true} as any, middleware as any))]
     }
@@ -1614,16 +1613,16 @@ type GroupMiddleware<N extends DAOName, MetadataType, OperationMetadataType> =
   | ExcludeGroupMiddleware<N, MetadataType, OperationMetadataType>
 type IncludeGroupMiddleware<N extends DAOName, MetadataType, OperationMetadataType> = {
   include: { [K in N]: true }
-  middleware: DAOMiddleware<DAOGenericsMap<MetadataType, OperationMetadataType>[N]>
+  middleware: T.DAOMiddleware<DAOGenericsMap<MetadataType, OperationMetadataType>[N]>
 }
 type ExcludeGroupMiddleware<N extends DAOName, MetadataType, OperationMetadataType> = {
   exclude: { [K in N]: true }
-  middleware: DAOMiddleware<DAOGenericsMap<MetadataType, OperationMetadataType>[Exclude<DAOName, N>]>
+  middleware: T.DAOMiddleware<DAOGenericsMap<MetadataType, OperationMetadataType>[Exclude<DAOName, N>]>
 }
 export const groupMiddleware = {
   includes<N extends DAOName, MetadataType, OperationMetadataType>(
     include: { [K in N]: true },
-    middleware: DAOMiddleware<DAOGenericsMap<MetadataType, OperationMetadataType>[N]>,
+    middleware: T.DAOMiddleware<DAOGenericsMap<MetadataType, OperationMetadataType>[N]>,
   ): IncludeGroupMiddleware<N, MetadataType, OperationMetadataType> {
     return { include, middleware }
   },


### PR DESCRIPTION
on the generate file:

before
```typescript
import { DAOMiddleware, Coordinates, UserInputDriverDataTypeAdapterMap, Schema, AbstractDAOContext, LogicalOperators, QuantityOperators, EqualityOperators, StringOperators, ElementOperators, OneKey, SortDirection, overrideRelations, userInputDataTypeAdapterToDataTypeAdapter, LogFunction, LogInput, logInputToLogger, ParamProjection, DAOGenerics, CRUDPermission, DAOContextSecurtyPolicy, createSecurityPolicyMiddlewares, SelectProjection, mergeProjections, AbstractInMemoryDAO, InMemoryDAOGenerics, InMemoryDAOParams } from '@twinlogix/typetta'
import * as types from 'types.generated'
import { MongoDBDAOGenerics, MongoDBDAOParams, AbstractMongoDBDAO } from '@twinlogix/typetta'
import { Knex } from 'knex'
import { Collection, Db, Filter, Sort, UpdateFilter, Document } from 'mongodb'

//...
```

after
```typescript
import * as T from '@twinlogix/typetta'
import * as types from 'types.generated'
import { Knex } from 'knex'
import * as M from 'mongodb'

//...
```