### PR TITLE
Update type now accept null on required fields

### DIFF
--- a/src/generation/generators/dao-generator.ts
+++ b/src/generation/generators/dao-generator.ts
@@ -671,15 +671,15 @@ function selectMiddleware<MetadataType, OperationMetadataType>(
         if (field.type.kind === 'scalar') {
           const baseType = field.isEnum ? `types.${field.graphqlType}` : `types.Scalars['${field.graphqlType}']`
           const fieldType = field.isList ? `${!field.isListElementRequired ? `(null | ${baseType})` : baseType}[]` : baseType
-          return [`'${fieldName}'?: ${fieldType}${field.isRequired ? '' : ' | null'}`]
+          return [`'${fieldName}'?: ${fieldType} | null`]
         } else if (field.type.kind === 'embedded') {
           const embeddedTypeNode = getNode(field.type.embed, typesMap)
           const embeddedType = `${embeddedTypeNode.name}Insert`
           const fieldType = field.isList ? `${!field.isListElementRequired ? `(null | ${embeddedType})` : embeddedType}[]` : embeddedType
           if (field.isList) {
-            return [`'${fieldName}'?: ${fieldType}${field.isRequired ? '' : ' | null'}`]
+            return [`'${fieldName}'?: ${fieldType} | null`]
           } else {
-            return [`'${fieldName}'?: ${fieldType}${field.isRequired ? '' : ' | null'}`, ...this._generateDAOUpdateFields(embeddedTypeNode, typesMap, path + field.name + '.')]
+            return [`'${fieldName}'?: ${fieldType} | null`, ...this._generateDAOUpdateFields(embeddedTypeNode, typesMap, path + field.name + '.')]
           }
         }
         return []

--- a/tests/id-generator/dao.mock.ts
+++ b/tests/id-generator/dao.mock.ts
@@ -44,8 +44,8 @@ export type ASort = Partial<Record<ASortKeys, T.SortDirection>>
 export type ARawSort = () => M.Sort
 
 export type AUpdate = {
-  id?: types.Scalars['MongoID']
-  value?: types.Scalars['Int']
+  id?: types.Scalars['MongoID'] | null
+  value?: types.Scalars['Int'] | null
 }
 export type ARawUpdate = () => M.UpdateFilter<M.Document>
 
@@ -155,8 +155,8 @@ export type BSort = Partial<Record<BSortKeys, T.SortDirection>>
 export type BRawSort = () => M.Sort
 
 export type BUpdate = {
-  id?: types.Scalars['ID']
-  value?: types.Scalars['Int']
+  id?: types.Scalars['ID'] | null
+  value?: types.Scalars['Int'] | null
 }
 export type BRawUpdate = () => M.UpdateFilter<M.Document>
 
@@ -261,8 +261,8 @@ export type CSort = Partial<Record<CSortKeys, T.SortDirection>>
 export type CRawSort = () => M.Sort
 
 export type CUpdate = {
-  id?: types.Scalars['ID']
-  value?: types.Scalars['Int']
+  id?: types.Scalars['ID'] | null
+  value?: types.Scalars['Int'] | null
 }
 export type CRawUpdate = () => M.UpdateFilter<M.Document>
 
@@ -373,8 +373,8 @@ export type DSort = Partial<Record<DSortKeys, T.SortDirection>>
 export type DRawSort = (builder: Knex.QueryBuilder<any, any>) => Knex.QueryBuilder<any, any>
 
 export type DUpdate = {
-  id?: types.Scalars['IntAutoInc']
-  value?: types.Scalars['Int']
+  id?: types.Scalars['IntAutoInc'] | null
+  value?: types.Scalars['Int'] | null
 }
 export type DRawUpdate = (builder: Knex.QueryBuilder<any, any>) => Knex.QueryBuilder<any, any>
 
@@ -484,8 +484,8 @@ export type ESort = Partial<Record<ESortKeys, T.SortDirection>>
 export type ERawSort = (builder: Knex.QueryBuilder<any, any>) => Knex.QueryBuilder<any, any>
 
 export type EUpdate = {
-  id?: types.Scalars['ID']
-  value?: types.Scalars['Int']
+  id?: types.Scalars['ID'] | null
+  value?: types.Scalars['Int'] | null
 }
 export type ERawUpdate = (builder: Knex.QueryBuilder<any, any>) => Knex.QueryBuilder<any, any>
 
@@ -590,8 +590,8 @@ export type FSort = Partial<Record<FSortKeys, T.SortDirection>>
 export type FRawSort = (builder: Knex.QueryBuilder<any, any>) => Knex.QueryBuilder<any, any>
 
 export type FUpdate = {
-  id?: types.Scalars['ID']
-  value?: types.Scalars['Int']
+  id?: types.Scalars['ID'] | null
+  value?: types.Scalars['Int'] | null
 }
 export type FRawUpdate = (builder: Knex.QueryBuilder<any, any>) => Knex.QueryBuilder<any, any>
 

--- a/tests/in-memory/dao.mock.ts
+++ b/tests/in-memory/dao.mock.ts
@@ -53,7 +53,7 @@ export type AddressSort = Partial<Record<AddressSortKeys, T.SortDirection>>
 export type AddressRawSort = never
 
 export type AddressUpdate = {
-  id?: types.Scalars['ID']
+  id?: types.Scalars['ID'] | null
 }
 export type AddressRawUpdate = never
 
@@ -171,8 +171,8 @@ export type AuditRawSort = never
 
 export type AuditUpdate = {
   changes?: types.Scalars['String'] | null
-  entityId?: types.Scalars['ID']
-  id?: types.Scalars['ID']
+  entityId?: types.Scalars['ID'] | null
+  id?: types.Scalars['ID'] | null
 }
 export type AuditRawUpdate = never
 
@@ -357,9 +357,9 @@ export type CitySort = Partial<Record<CitySortKeys, T.SortDirection>>
 export type CityRawSort = never
 
 export type CityUpdate = {
-  addressId?: types.Scalars['ID']
-  id?: types.Scalars['ID']
-  name?: types.Scalars['String']
+  addressId?: types.Scalars['ID'] | null
+  id?: types.Scalars['ID'] | null
+  name?: types.Scalars['String'] | null
 }
 export type CityRawUpdate = never
 
@@ -498,10 +498,10 @@ export type DefaultFieldsEntitySort = Partial<Record<DefaultFieldsEntitySortKeys
 export type DefaultFieldsEntityRawSort = never
 
 export type DefaultFieldsEntityUpdate = {
-  creationDate?: types.Scalars['Int']
-  id?: types.Scalars['ID']
-  live?: types.Scalars['Live']
-  name?: types.Scalars['String']
+  creationDate?: types.Scalars['Int'] | null
+  id?: types.Scalars['ID'] | null
+  live?: types.Scalars['Live'] | null
+  name?: types.Scalars['String'] | null
   opt1?: types.Scalars['Live'] | null
   opt2?: types.Scalars['Live'] | null
 }
@@ -633,8 +633,8 @@ export type DeviceSort = Partial<Record<DeviceSortKeys, T.SortDirection>>
 export type DeviceRawSort = never
 
 export type DeviceUpdate = {
-  id?: types.Scalars['ID']
-  name?: types.Scalars['String']
+  id?: types.Scalars['ID'] | null
+  name?: types.Scalars['String'] | null
   userId?: types.Scalars['ID'] | null
 }
 export type DeviceRawUpdate = never
@@ -760,9 +760,9 @@ export type DogSort = Partial<Record<DogSortKeys, T.SortDirection>>
 export type DogRawSort = never
 
 export type DogUpdate = {
-  id?: types.Scalars['ID']
-  name?: types.Scalars['String']
-  ownerId?: types.Scalars['ID']
+  id?: types.Scalars['ID'] | null
+  name?: types.Scalars['String'] | null
+  ownerId?: types.Scalars['ID'] | null
 }
 export type DogRawUpdate = never
 
@@ -895,15 +895,15 @@ export type HotelSort = Partial<Record<HotelSortKeys, T.SortDirection>>
 export type HotelRawSort = never
 
 export type HotelUpdate = {
-  audit?: AuditableInsert
-  'audit.createdBy'?: types.Scalars['String']
-  'audit.createdOn'?: types.Scalars['Int']
+  audit?: AuditableInsert | null
+  'audit.createdBy'?: types.Scalars['String'] | null
+  'audit.createdOn'?: types.Scalars['Int'] | null
   'audit.deletedOn'?: types.Scalars['Int'] | null
-  'audit.modifiedBy'?: types.Scalars['String']
-  'audit.modifiedOn'?: types.Scalars['Int']
-  'audit.state'?: types.State
-  id?: types.Scalars['ID']
-  name?: types.Scalars['String']
+  'audit.modifiedBy'?: types.Scalars['String'] | null
+  'audit.modifiedOn'?: types.Scalars['Int'] | null
+  'audit.state'?: types.State | null
+  id?: types.Scalars['ID'] | null
+  name?: types.Scalars['String'] | null
 }
 export type HotelRawUpdate = never
 
@@ -1032,9 +1032,9 @@ export type MockedEntitySort = Partial<Record<MockedEntitySortKeys, T.SortDirect
 export type MockedEntityRawSort = never
 
 export type MockedEntityUpdate = {
-  id?: types.Scalars['ID']
-  name?: types.Scalars['String']
-  userId?: types.Scalars['ID']
+  id?: types.Scalars['ID'] | null
+  name?: types.Scalars['String'] | null
+  userId?: types.Scalars['ID'] | null
 }
 export type MockedEntityRawUpdate = never
 
@@ -1164,9 +1164,9 @@ export type OrganizationRawSort = never
 
 export type OrganizationUpdate = {
   address?: AddressInsert | null
-  'address.id'?: types.Scalars['ID']
-  id?: types.Scalars['ID']
-  name?: types.Scalars['String']
+  'address.id'?: types.Scalars['ID'] | null
+  id?: types.Scalars['ID'] | null
+  name?: types.Scalars['String'] | null
   vatNumber?: types.Scalars['String'] | null
 }
 export type OrganizationRawUpdate = never
@@ -1329,15 +1329,15 @@ export type PostSort = Partial<Record<PostSortKeys, T.SortDirection>>
 export type PostRawSort = never
 
 export type PostUpdate = {
-  authorId?: types.Scalars['ID']
+  authorId?: types.Scalars['ID'] | null
   body?: types.Scalars['String'] | null
   clicks?: types.Scalars['Int'] | null
-  id?: types.Scalars['ID']
+  id?: types.Scalars['ID'] | null
   metadata?: PostMetadataInsert | null
-  'metadata.region'?: types.Scalars['String']
-  'metadata.visible'?: types.Scalars['Boolean']
-  title?: types.Scalars['String']
-  views?: types.Scalars['Int']
+  'metadata.region'?: types.Scalars['String'] | null
+  'metadata.visible'?: types.Scalars['Boolean'] | null
+  title?: types.Scalars['String'] | null
+  views?: types.Scalars['Int'] | null
 }
 export type PostRawUpdate = never
 
@@ -1476,8 +1476,8 @@ export type PostTypeSort = Partial<Record<PostTypeSortKeys, T.SortDirection>>
 export type PostTypeRawSort = never
 
 export type PostTypeUpdate = {
-  id?: types.Scalars['ID']
-  name?: types.Scalars['String']
+  id?: types.Scalars['ID'] | null
+  name?: types.Scalars['String'] | null
 }
 export type PostTypeRawUpdate = never
 
@@ -1755,25 +1755,25 @@ export type UserUpdate = {
   amounts?: types.Scalars['Decimal'][] | null
   credentials?: (null | UsernamePasswordCredentialsInsert)[] | null
   embeddedPost?: PostInsert | null
-  'embeddedPost.authorId'?: types.Scalars['ID']
+  'embeddedPost.authorId'?: types.Scalars['ID'] | null
   'embeddedPost.body'?: types.Scalars['String'] | null
   'embeddedPost.clicks'?: types.Scalars['Int'] | null
-  'embeddedPost.id'?: types.Scalars['ID']
+  'embeddedPost.id'?: types.Scalars['ID'] | null
   'embeddedPost.metadata'?: PostMetadataInsert | null
-  'embeddedPost.metadata.region'?: types.Scalars['String']
-  'embeddedPost.metadata.visible'?: types.Scalars['Boolean']
-  'embeddedPost.title'?: types.Scalars['String']
-  'embeddedPost.views'?: types.Scalars['Int']
+  'embeddedPost.metadata.region'?: types.Scalars['String'] | null
+  'embeddedPost.metadata.visible'?: types.Scalars['Boolean'] | null
+  'embeddedPost.title'?: types.Scalars['String'] | null
+  'embeddedPost.views'?: types.Scalars['Int'] | null
   firstName?: types.Scalars['String'] | null
   friendsId?: types.Scalars['ID'][] | null
-  id?: types.Scalars['ID']
+  id?: types.Scalars['ID'] | null
   lastName?: types.Scalars['String'] | null
-  live?: types.Scalars['Boolean']
+  live?: types.Scalars['Boolean'] | null
   localization?: types.Scalars['Coordinates'] | null
   title?: types.Scalars['LocalizedString'] | null
   usernamePasswordCredentials?: UsernamePasswordCredentialsInsert | null
-  'usernamePasswordCredentials.password'?: types.Scalars['Password']
-  'usernamePasswordCredentials.username'?: types.Scalars['String']
+  'usernamePasswordCredentials.password'?: types.Scalars['Password'] | null
+  'usernamePasswordCredentials.username'?: types.Scalars['String'] | null
 }
 export type UserRawUpdate = never
 

--- a/tests/mongodb/dao.mock.ts
+++ b/tests/mongodb/dao.mock.ts
@@ -54,7 +54,7 @@ export type AddressSort = Partial<Record<AddressSortKeys, T.SortDirection>>
 export type AddressRawSort = () => M.Sort
 
 export type AddressUpdate = {
-  id?: types.Scalars['ID']
+  id?: types.Scalars['ID'] | null
 }
 export type AddressRawUpdate = () => M.UpdateFilter<M.Document>
 
@@ -172,8 +172,8 @@ export type AuditRawSort = () => M.Sort
 
 export type AuditUpdate = {
   changes?: types.Scalars['String'] | null
-  entityId?: types.Scalars['ID']
-  id?: types.Scalars['ID']
+  entityId?: types.Scalars['ID'] | null
+  id?: types.Scalars['ID'] | null
 }
 export type AuditRawUpdate = () => M.UpdateFilter<M.Document>
 
@@ -358,9 +358,9 @@ export type CitySort = Partial<Record<CitySortKeys, T.SortDirection>>
 export type CityRawSort = () => M.Sort
 
 export type CityUpdate = {
-  addressId?: types.Scalars['ID']
-  id?: types.Scalars['ID']
-  name?: types.Scalars['String']
+  addressId?: types.Scalars['ID'] | null
+  id?: types.Scalars['ID'] | null
+  name?: types.Scalars['String'] | null
 }
 export type CityRawUpdate = () => M.UpdateFilter<M.Document>
 
@@ -499,10 +499,10 @@ export type DefaultFieldsEntitySort = Partial<Record<DefaultFieldsEntitySortKeys
 export type DefaultFieldsEntityRawSort = () => M.Sort
 
 export type DefaultFieldsEntityUpdate = {
-  creationDate?: types.Scalars['Int']
-  id?: types.Scalars['ID']
-  live?: types.Scalars['Live']
-  name?: types.Scalars['String']
+  creationDate?: types.Scalars['Int'] | null
+  id?: types.Scalars['ID'] | null
+  live?: types.Scalars['Live'] | null
+  name?: types.Scalars['String'] | null
   opt1?: types.Scalars['Live'] | null
   opt2?: types.Scalars['Live'] | null
 }
@@ -634,8 +634,8 @@ export type DeviceSort = Partial<Record<DeviceSortKeys, T.SortDirection>>
 export type DeviceRawSort = () => M.Sort
 
 export type DeviceUpdate = {
-  id?: types.Scalars['ID']
-  name?: types.Scalars['String']
+  id?: types.Scalars['ID'] | null
+  name?: types.Scalars['String'] | null
   userId?: types.Scalars['ID'] | null
 }
 export type DeviceRawUpdate = () => M.UpdateFilter<M.Document>
@@ -761,9 +761,9 @@ export type DogSort = Partial<Record<DogSortKeys, T.SortDirection>>
 export type DogRawSort = () => M.Sort
 
 export type DogUpdate = {
-  id?: types.Scalars['ID']
-  name?: types.Scalars['String']
-  ownerId?: types.Scalars['ID']
+  id?: types.Scalars['ID'] | null
+  name?: types.Scalars['String'] | null
+  ownerId?: types.Scalars['ID'] | null
 }
 export type DogRawUpdate = () => M.UpdateFilter<M.Document>
 
@@ -1152,13 +1152,13 @@ export type HotelSort = Partial<Record<HotelSortKeys, T.SortDirection>>
 export type HotelRawSort = () => M.Sort
 
 export type HotelUpdate = {
-  audit?: AuditableInsert
-  'audit.createdBy'?: types.Scalars['String']
-  'audit.createdOn'?: types.Scalars['Int']
+  audit?: AuditableInsert | null
+  'audit.createdBy'?: types.Scalars['String'] | null
+  'audit.createdOn'?: types.Scalars['Int'] | null
   'audit.deletedOn'?: types.Scalars['Int'] | null
-  'audit.modifiedBy'?: types.Scalars['String']
-  'audit.modifiedOn'?: types.Scalars['Int']
-  'audit.state'?: types.State
+  'audit.modifiedBy'?: types.Scalars['String'] | null
+  'audit.modifiedOn'?: types.Scalars['Int'] | null
+  'audit.state'?: types.State | null
   embeddedUser3?: EmbeddedUser3Insert | null
   'embeddedUser3.value'?: types.Scalars['Int'] | null
   embeddedUser4?: EmbeddedUser4Insert | null
@@ -1167,11 +1167,11 @@ export type HotelUpdate = {
   embeddedUsers?: EmbeddedUserInsert[] | null
   embeddedUsers3?: EmbeddedUser3Insert[] | null
   embeddedUsers4?: EmbeddedUser4Insert[] | null
-  id?: types.Scalars['ID']
-  name?: types.Scalars['String']
+  id?: types.Scalars['ID'] | null
+  name?: types.Scalars['String'] | null
   userId?: types.Scalars['ID'] | null
   users?: UserCollectionInsert | null
-  'users.usersId'?: types.Scalars['ID'][]
+  'users.usersId'?: types.Scalars['ID'][] | null
 }
 export type HotelRawUpdate = () => M.UpdateFilter<M.Document>
 
@@ -1307,9 +1307,9 @@ export type MockedEntitySort = Partial<Record<MockedEntitySortKeys, T.SortDirect
 export type MockedEntityRawSort = never
 
 export type MockedEntityUpdate = {
-  id?: types.Scalars['MongoID']
-  name?: types.Scalars['String']
-  userId?: types.Scalars['ID']
+  id?: types.Scalars['MongoID'] | null
+  name?: types.Scalars['String'] | null
+  userId?: types.Scalars['ID'] | null
 }
 export type MockedEntityRawUpdate = never
 
@@ -1439,9 +1439,9 @@ export type OrganizationRawSort = () => M.Sort
 
 export type OrganizationUpdate = {
   address?: AddressInsert | null
-  'address.id'?: types.Scalars['ID']
-  id?: types.Scalars['ID']
-  name?: types.Scalars['String']
+  'address.id'?: types.Scalars['ID'] | null
+  id?: types.Scalars['ID'] | null
+  name?: types.Scalars['String'] | null
   vatNumber?: types.Scalars['String'] | null
 }
 export type OrganizationRawUpdate = () => M.UpdateFilter<M.Document>
@@ -1604,15 +1604,15 @@ export type PostSort = Partial<Record<PostSortKeys, T.SortDirection>>
 export type PostRawSort = () => M.Sort
 
 export type PostUpdate = {
-  authorId?: types.Scalars['ID']
+  authorId?: types.Scalars['ID'] | null
   body?: types.Scalars['String'] | null
   clicks?: types.Scalars['Int'] | null
-  id?: types.Scalars['ID']
+  id?: types.Scalars['ID'] | null
   metadata?: PostMetadataInsert | null
-  'metadata.region'?: types.Scalars['String']
-  'metadata.visible'?: types.Scalars['Boolean']
-  title?: types.Scalars['String']
-  views?: types.Scalars['Int']
+  'metadata.region'?: types.Scalars['String'] | null
+  'metadata.visible'?: types.Scalars['Boolean'] | null
+  title?: types.Scalars['String'] | null
+  views?: types.Scalars['Int'] | null
 }
 export type PostRawUpdate = () => M.UpdateFilter<M.Document>
 
@@ -1928,26 +1928,26 @@ export type UserUpdate = {
   amounts?: types.Scalars['Decimal'][] | null
   credentials?: (null | UsernamePasswordCredentialsInsert)[] | null
   embeddedPost?: PostInsert | null
-  'embeddedPost.authorId'?: types.Scalars['ID']
+  'embeddedPost.authorId'?: types.Scalars['ID'] | null
   'embeddedPost.body'?: types.Scalars['String'] | null
   'embeddedPost.clicks'?: types.Scalars['Int'] | null
-  'embeddedPost.id'?: types.Scalars['ID']
+  'embeddedPost.id'?: types.Scalars['ID'] | null
   'embeddedPost.metadata'?: PostMetadataInsert | null
-  'embeddedPost.metadata.region'?: types.Scalars['String']
-  'embeddedPost.metadata.visible'?: types.Scalars['Boolean']
-  'embeddedPost.title'?: types.Scalars['String']
-  'embeddedPost.views'?: types.Scalars['Int']
+  'embeddedPost.metadata.region'?: types.Scalars['String'] | null
+  'embeddedPost.metadata.visible'?: types.Scalars['Boolean'] | null
+  'embeddedPost.title'?: types.Scalars['String'] | null
+  'embeddedPost.views'?: types.Scalars['Int'] | null
   firstName?: types.Scalars['String'] | null
   friendsId?: types.Scalars['ID'][] | null
-  id?: types.Scalars['ID']
+  id?: types.Scalars['ID'] | null
   int?: types.Scalars['Int'] | null
   lastName?: types.Scalars['String'] | null
-  live?: types.Scalars['Boolean']
+  live?: types.Scalars['Boolean'] | null
   localization?: types.Scalars['Coordinates'] | null
   title?: types.Scalars['LocalizedString'] | null
   usernamePasswordCredentials?: UsernamePasswordCredentialsInsert | null
-  'usernamePasswordCredentials.password'?: types.Scalars['Password']
-  'usernamePasswordCredentials.username'?: types.Scalars['String']
+  'usernamePasswordCredentials.password'?: types.Scalars['Password'] | null
+  'usernamePasswordCredentials.username'?: types.Scalars['String'] | null
 }
 export type UserRawUpdate = () => M.UpdateFilter<M.Document>
 

--- a/tests/mongodb/mongodb.test.ts
+++ b/tests/mongodb/mongodb.test.ts
@@ -651,11 +651,16 @@ test('simple update', async () => {
   expect(user2?.firstName).toBe(user.firstName)
   expect(user2?.lastName).toBe('LastName')
 
-  await dao.user.updateOne({ filter: { id: user.id }, changes: { firstName: 'NewFirstName' } })
+  await dao.user.updateOne({ filter: { id: user.id }, changes: { firstName: 'NewFirstName', live: null } })
   const user3 = await dao.user.findOne({ filter: { id: user.id } })
 
   expect(user3?.firstName).toBe('NewFirstName')
-  expect(user3?.lastName).toBe(user3?.lastName)
+  expect(user3?.lastName).toBe(user2?.lastName)
+  expect(user3?.live).toBe(true)
+
+  await dao.user.updateOne({ filter: { id: user.id }, changes: { live: null } })
+  const user4 = await dao.user.findOne({ filter: { id: user.id } })
+  expect(user4?.live).toBe(true)
 })
 
 test('update embedded entity', async () => {

--- a/tests/multitenant/dao.mock.ts
+++ b/tests/multitenant/dao.mock.ts
@@ -65,9 +65,9 @@ export type HotelRawSort = () => M.Sort
 export type HotelUpdate = {
   deletionDate?: types.Scalars['Date'] | null
   description?: types.Scalars['String'] | null
-  id?: types.Scalars['ID']
-  name?: types.Scalars['String']
-  tenantId?: types.Scalars['TenantId']
+  id?: types.Scalars['ID'] | null
+  name?: types.Scalars['String'] | null
+  tenantId?: types.Scalars['TenantId'] | null
 }
 export type HotelRawUpdate = () => M.UpdateFilter<M.Document>
 
@@ -212,10 +212,10 @@ export type ReservationRawSort = () => M.Sort
 
 export type ReservationUpdate = {
   deletionDate?: types.Scalars['Date'] | null
-  id?: types.Scalars['ID']
-  roomId?: types.Scalars['ID']
-  tenantId?: types.Scalars['TenantId']
-  userId?: types.Scalars['ID']
+  id?: types.Scalars['ID'] | null
+  roomId?: types.Scalars['ID'] | null
+  tenantId?: types.Scalars['TenantId'] | null
+  userId?: types.Scalars['ID'] | null
 }
 export type ReservationRawUpdate = () => M.UpdateFilter<M.Document>
 
@@ -361,10 +361,10 @@ export type RoomRawSort = () => M.Sort
 
 export type RoomUpdate = {
   deletionDate?: types.Scalars['Date'] | null
-  hotelId?: types.Scalars['ID']
-  id?: types.Scalars['ID']
-  size?: types.Scalars['String']
-  tenantId?: types.Scalars['TenantId']
+  hotelId?: types.Scalars['ID'] | null
+  id?: types.Scalars['ID'] | null
+  size?: types.Scalars['String'] | null
+  tenantId?: types.Scalars['TenantId'] | null
 }
 export type RoomRawUpdate = () => M.UpdateFilter<M.Document>
 
@@ -477,8 +477,8 @@ export type TenantSort = Partial<Record<TenantSortKeys, T.SortDirection>>
 export type TenantRawSort = () => M.Sort
 
 export type TenantUpdate = {
-  id?: types.Scalars['Int']
-  info?: types.Scalars['String']
+  id?: types.Scalars['Int'] | null
+  info?: types.Scalars['String'] | null
 }
 export type TenantRawUpdate = () => M.UpdateFilter<M.Document>
 
@@ -649,14 +649,14 @@ export type UserRawSort = () => M.Sort
 
 export type UserUpdate = {
   credentials?: UsernamePasswordCredentialsInsert | null
-  'credentials.password'?: types.Scalars['Password']
-  'credentials.username'?: types.Scalars['Username']
+  'credentials.password'?: types.Scalars['Password'] | null
+  'credentials.username'?: types.Scalars['Username'] | null
   deletionDate?: types.Scalars['Date'] | null
-  email?: types.Scalars['Email']
+  email?: types.Scalars['Email'] | null
   firstName?: types.Scalars['String'] | null
-  id?: types.Scalars['ID']
+  id?: types.Scalars['ID'] | null
   lastName?: types.Scalars['String'] | null
-  tenantId?: types.Scalars['TenantId']
+  tenantId?: types.Scalars['TenantId'] | null
 }
 export type UserRawUpdate = () => M.UpdateFilter<M.Document>
 

--- a/tests/resolvers/dao.mock.ts
+++ b/tests/resolvers/dao.mock.ts
@@ -56,10 +56,10 @@ export type LikeSort = Partial<Record<LikeSortKeys, T.SortDirection>>
 export type LikeRawSort = never
 
 export type LikeUpdate = {
-  creationDate?: types.Scalars['Date']
-  id?: types.Scalars['ID']
-  postId?: types.Scalars['ID']
-  userId?: types.Scalars['ID']
+  creationDate?: types.Scalars['Date'] | null
+  id?: types.Scalars['ID'] | null
+  postId?: types.Scalars['ID'] | null
+  userId?: types.Scalars['ID'] | null
 }
 export type LikeRawUpdate = never
 
@@ -249,13 +249,13 @@ export type PostSort = Partial<Record<PostSortKeys, T.SortDirection>>
 export type PostRawSort = never
 
 export type PostUpdate = {
-  content?: types.Scalars['String']
-  creationDate?: types.Scalars['Date']
-  id?: types.Scalars['ID']
+  content?: types.Scalars['String'] | null
+  creationDate?: types.Scalars['Date'] | null
+  id?: types.Scalars['ID'] | null
   metadata?: MetadataInsert | null
   'metadata.tags'?: types.Scalars['String'][] | null
   'metadata.views'?: types.Scalars['Int'] | null
-  userId?: types.Scalars['ID']
+  userId?: types.Scalars['ID'] | null
 }
 export type PostRawUpdate = never
 
@@ -425,9 +425,9 @@ export type UserRawSort = never
 
 export type UserUpdate = {
   birthDate?: types.Scalars['Date'] | null
-  firstName?: types.Scalars['String']
-  id?: types.Scalars['ID']
-  lastName?: types.Scalars['String']
+  firstName?: types.Scalars['String'] | null
+  id?: types.Scalars['ID'] | null
+  lastName?: types.Scalars['String'] | null
 }
 export type UserRawUpdate = never
 

--- a/tests/security/dao.mock.ts
+++ b/tests/security/dao.mock.ts
@@ -63,10 +63,10 @@ export type HotelRawSort = () => M.Sort
 
 export type HotelUpdate = {
   description?: types.Scalars['String'] | null
-  id?: types.Scalars['ID']
-  name?: types.Scalars['String']
-  tenantId?: types.Scalars['Int']
-  totalCustomers?: types.Scalars['Int']
+  id?: types.Scalars['ID'] | null
+  name?: types.Scalars['String'] | null
+  tenantId?: types.Scalars['Int'] | null
+  totalCustomers?: types.Scalars['Int'] | null
 }
 export type HotelRawUpdate = () => M.UpdateFilter<M.Document>
 
@@ -207,11 +207,11 @@ export type ReservationSort = Partial<Record<ReservationSortKeys, T.SortDirectio
 export type ReservationRawSort = () => M.Sort
 
 export type ReservationUpdate = {
-  hotelId?: types.Scalars['ID']
-  id?: types.Scalars['ID']
-  roomId?: types.Scalars['ID']
-  tenantId?: types.Scalars['Int']
-  userId?: types.Scalars['ID']
+  hotelId?: types.Scalars['ID'] | null
+  id?: types.Scalars['ID'] | null
+  roomId?: types.Scalars['ID'] | null
+  tenantId?: types.Scalars['Int'] | null
+  userId?: types.Scalars['ID'] | null
 }
 export type ReservationRawUpdate = () => M.UpdateFilter<M.Document>
 
@@ -328,8 +328,8 @@ export type RoleSort = Partial<Record<RoleSortKeys, T.SortDirection>>
 export type RoleRawSort = () => M.Sort
 
 export type RoleUpdate = {
-  code?: types.RoleCode
-  permissions?: (null | types.Permission)[]
+  code?: types.RoleCode | null
+  permissions?: (null | types.Permission)[] | null
 }
 export type RoleRawUpdate = () => M.UpdateFilter<M.Document>
 
@@ -478,12 +478,12 @@ export type RoomSort = Partial<Record<RoomSortKeys, T.SortDirection>>
 export type RoomRawSort = () => M.Sort
 
 export type RoomUpdate = {
-  description?: types.Scalars['String']
-  from?: types.Scalars['Date']
-  hotelId?: types.Scalars['ID']
-  id?: types.Scalars['ID']
-  tenantId?: types.Scalars['Int']
-  to?: types.Scalars['Date']
+  description?: types.Scalars['String'] | null
+  from?: types.Scalars['Date'] | null
+  hotelId?: types.Scalars['ID'] | null
+  id?: types.Scalars['ID'] | null
+  tenantId?: types.Scalars['Int'] | null
+  to?: types.Scalars['Date'] | null
 }
 export type RoomRawUpdate = () => M.UpdateFilter<M.Document>
 
@@ -651,9 +651,9 @@ export type UserSort = Partial<Record<UserSortKeys, T.SortDirection>>
 export type UserRawSort = () => M.Sort
 
 export type UserUpdate = {
-  email?: types.Scalars['Email']
+  email?: types.Scalars['Email'] | null
   firstName?: types.Scalars['String'] | null
-  id?: types.Scalars['ID']
+  id?: types.Scalars['ID'] | null
   lastName?: types.Scalars['String'] | null
   totalPayments?: types.Scalars['Int'] | null
 }
@@ -804,9 +804,9 @@ export type UserRoleRawSort = () => M.Sort
 
 export type UserRoleUpdate = {
   hotelId?: types.Scalars['ID'] | null
-  id?: types.Scalars['ID']
-  refUserId?: types.Scalars['ID']
-  roleCode?: types.RoleCode
+  id?: types.Scalars['ID'] | null
+  refUserId?: types.Scalars['ID'] | null
+  roleCode?: types.RoleCode | null
   tenantId?: types.Scalars['Int'] | null
   userId?: types.Scalars['ID'] | null
 }

--- a/tests/sql/dao.mock.ts
+++ b/tests/sql/dao.mock.ts
@@ -54,7 +54,7 @@ export type AddressSort = Partial<Record<AddressSortKeys, T.SortDirection>>
 export type AddressRawSort = (builder: Knex.QueryBuilder<any, any>) => Knex.QueryBuilder<any, any>
 
 export type AddressUpdate = {
-  id?: types.Scalars['ID']
+  id?: types.Scalars['ID'] | null
 }
 export type AddressRawUpdate = (builder: Knex.QueryBuilder<any, any>) => Knex.QueryBuilder<any, any>
 
@@ -198,7 +198,7 @@ export type AuthorSort = Partial<Record<AuthorSortKeys, T.SortDirection>>
 export type AuthorRawSort = (builder: Knex.QueryBuilder<any, any>) => Knex.QueryBuilder<any, any>
 
 export type AuthorUpdate = {
-  id?: types.Scalars['ID']
+  id?: types.Scalars['ID'] | null
 }
 export type AuthorRawUpdate = (builder: Knex.QueryBuilder<any, any>) => Knex.QueryBuilder<any, any>
 
@@ -312,9 +312,9 @@ export type AuthorBookSort = Partial<Record<AuthorBookSortKeys, T.SortDirection>
 export type AuthorBookRawSort = (builder: Knex.QueryBuilder<any, any>) => Knex.QueryBuilder<any, any>
 
 export type AuthorBookUpdate = {
-  authorId?: types.Scalars['ID']
-  bookId?: types.Scalars['ID']
-  id?: types.Scalars['ID']
+  authorId?: types.Scalars['ID'] | null
+  bookId?: types.Scalars['ID'] | null
+  id?: types.Scalars['ID'] | null
 }
 export type AuthorBookRawUpdate = (builder: Knex.QueryBuilder<any, any>) => Knex.QueryBuilder<any, any>
 
@@ -444,7 +444,7 @@ export type BookSort = Partial<Record<BookSortKeys, T.SortDirection>>
 export type BookRawSort = (builder: Knex.QueryBuilder<any, any>) => Knex.QueryBuilder<any, any>
 
 export type BookUpdate = {
-  id?: types.Scalars['ID']
+  id?: types.Scalars['ID'] | null
 }
 export type BookRawUpdate = (builder: Knex.QueryBuilder<any, any>) => Knex.QueryBuilder<any, any>
 
@@ -560,9 +560,9 @@ export type CitySort = Partial<Record<CitySortKeys, T.SortDirection>>
 export type CityRawSort = (builder: Knex.QueryBuilder<any, any>) => Knex.QueryBuilder<any, any>
 
 export type CityUpdate = {
-  addressId?: types.Scalars['ID']
-  id?: types.Scalars['ID']
-  name?: types.Scalars['String']
+  addressId?: types.Scalars['ID'] | null
+  id?: types.Scalars['ID'] | null
+  name?: types.Scalars['String'] | null
 }
 export type CityRawUpdate = (builder: Knex.QueryBuilder<any, any>) => Knex.QueryBuilder<any, any>
 
@@ -701,10 +701,10 @@ export type DefaultFieldsEntitySort = Partial<Record<DefaultFieldsEntitySortKeys
 export type DefaultFieldsEntityRawSort = (builder: Knex.QueryBuilder<any, any>) => Knex.QueryBuilder<any, any>
 
 export type DefaultFieldsEntityUpdate = {
-  creationDate?: types.Scalars['Int']
-  id?: types.Scalars['ID']
-  live?: types.Scalars['Live']
-  name?: types.Scalars['String']
+  creationDate?: types.Scalars['Int'] | null
+  id?: types.Scalars['ID'] | null
+  live?: types.Scalars['Live'] | null
+  name?: types.Scalars['String'] | null
   opt1?: types.Scalars['Live'] | null
   opt2?: types.Scalars['Live'] | null
 }
@@ -836,8 +836,8 @@ export type DeviceSort = Partial<Record<DeviceSortKeys, T.SortDirection>>
 export type DeviceRawSort = (builder: Knex.QueryBuilder<any, any>) => Knex.QueryBuilder<any, any>
 
 export type DeviceUpdate = {
-  id?: types.Scalars['ID']
-  name?: types.Scalars['String']
+  id?: types.Scalars['ID'] | null
+  name?: types.Scalars['String'] | null
   userId?: types.Scalars['ID'] | null
 }
 export type DeviceRawUpdate = (builder: Knex.QueryBuilder<any, any>) => Knex.QueryBuilder<any, any>
@@ -963,9 +963,9 @@ export type DogSort = Partial<Record<DogSortKeys, T.SortDirection>>
 export type DogRawSort = (builder: Knex.QueryBuilder<any, any>) => Knex.QueryBuilder<any, any>
 
 export type DogUpdate = {
-  id?: types.Scalars['ID']
-  name?: types.Scalars['String']
-  ownerId?: types.Scalars['ID']
+  id?: types.Scalars['ID'] | null
+  name?: types.Scalars['String'] | null
+  ownerId?: types.Scalars['ID'] | null
 }
 export type DogRawUpdate = (builder: Knex.QueryBuilder<any, any>) => Knex.QueryBuilder<any, any>
 
@@ -1081,9 +1081,9 @@ export type FriendsSort = Partial<Record<FriendsSortKeys, T.SortDirection>>
 export type FriendsRawSort = (builder: Knex.QueryBuilder<any, any>) => Knex.QueryBuilder<any, any>
 
 export type FriendsUpdate = {
-  from?: types.Scalars['ID']
-  id?: types.Scalars['ID']
-  to?: types.Scalars['ID']
+  from?: types.Scalars['ID'] | null
+  id?: types.Scalars['ID'] | null
+  to?: types.Scalars['ID'] | null
 }
 export type FriendsRawUpdate = (builder: Knex.QueryBuilder<any, any>) => Knex.QueryBuilder<any, any>
 
@@ -1211,9 +1211,9 @@ export type OrganizationRawSort = (builder: Knex.QueryBuilder<any, any>) => Knex
 
 export type OrganizationUpdate = {
   address?: AddressInsert | null
-  'address.id'?: types.Scalars['ID']
-  id?: types.Scalars['ID']
-  name?: types.Scalars['String']
+  'address.id'?: types.Scalars['ID'] | null
+  id?: types.Scalars['ID'] | null
+  name?: types.Scalars['String'] | null
   vatNumber?: types.Scalars['String'] | null
 }
 export type OrganizationRawUpdate = (builder: Knex.QueryBuilder<any, any>) => Knex.QueryBuilder<any, any>
@@ -1468,12 +1468,12 @@ export type UserUpdate = {
   credentials?: UsernamePasswordCredentialsInsert | null
   'credentials.another'?: AnotherInsert | null
   'credentials.another.test'?: types.Scalars['String'] | null
-  'credentials.password'?: types.Scalars['Password']
-  'credentials.username'?: types.Scalars['String']
+  'credentials.password'?: types.Scalars['Password'] | null
+  'credentials.username'?: types.Scalars['String'] | null
   firstName?: types.Scalars['String'] | null
-  id?: types.Scalars['ID']
+  id?: types.Scalars['ID'] | null
   lastName?: types.Scalars['String'] | null
-  live?: types.Scalars['Boolean']
+  live?: types.Scalars['Boolean'] | null
   localization?: types.Scalars['Coordinates'] | null
   title?: types.Scalars['LocalizedString'] | null
 }


### PR DESCRIPTION
Update type now accept null on required fields but the null value is ignored at runtime if the field is required.

This is necessary because typescript has 3 states for a field (null, undefined and value) while graphql has only 2 (value, not value). This causes an inconsistency during the update operations that pass through a GraphQL endpoint: the old Typetta update used the 3 states of typescript to obtain 3 different behaviors:
- value: replacement of the value
- undefined: does nothing
- null (where it was possible): deletion of the value

However, it is not possible to express the difference between undefined and null in GraphQL, which actually only supports value or null. To overcome this problem, the user is allowed to specify null (in the update operation) also in the required fields, and a runtime check is performed. This also allows you to resolve the conflicts that are obtained between the type of typetta Update and the type of update generated by the GraphQL inputs.
Now the 3 different behaviors are:
- value: replacement of the value
- undefined: does nothing
- null
  - if the field is required: does nothing
  - if the field is not required: deletion of the value