### PR TITLE
Limit now can be 'unlimited'

### DIFF
--- a/src/dal/dao/dao.types.ts
+++ b/src/dal/dao/dao.types.ts
@@ -37,7 +37,7 @@ export type RelationsFindParams<Entity extends string, AST extends AbstractSynta
               filter?: Filter<ASTName, AST, Scalars> | AST[Entity]['driverSpecification']['rawFilter']
               sorts?: SortElement<ASTName, AST>[] | AST[Entity]['driverSpecification']['rawSorts']
               skip?: number
-              limit?: number
+              limit?: number | 'unlimited'
               relations?: RelationsFindParams<ASTName, AST, Scalars>
             }
           : never
@@ -62,7 +62,7 @@ export type FindOneParams<T extends DAOGenerics, P = T['projection']> = Omit<Fil
 }
 
 export type FindParams<T extends DAOGenerics, P = T['projection']> = FindOneParams<T, P> & {
-  limit?: number
+  limit?: number | 'unlimited'
 }
 
 export type InsertParams<T extends DAOGenerics> = {
@@ -92,7 +92,7 @@ export type AggregateParams<T extends DAOGenerics> = {
   filter?: T['filter']
   aggregations: AggregationFields<T>
   skip?: number
-  limit?: number
+  limit?: number | 'unlimited'
 } & OperationParams<T>
 
 export type AggregatePostProcessing<T extends DAOGenerics, A extends AggregateParams<T>> = {
@@ -145,7 +145,9 @@ export type DefaultGenerationStrategy = 'middleware' | 'generator'
 export interface DAO<T extends DAOGenerics> {
   findAll<P extends AnyProjection<T['projection']> | GraphQLResolveInfo>(params?: FindParams<T, P>): Promise<Project<T['entity'], T['ast'], T['scalars'], P, T['types']>[]>
   findOne<P extends AnyProjection<T['projection']> | GraphQLResolveInfo>(params?: FindOneParams<T, P>): Promise<Project<T['entity'], T['ast'], T['scalars'], P, T['types']> | null>
-  findPage<P extends AnyProjection<T['projection']> | GraphQLResolveInfo>(params?: FindParams<T, P>): Promise<{ totalCount: number; records: Project<T['entity'], T['ast'], T['scalars'], P, T['types']>[] }>
+  findPage<P extends AnyProjection<T['projection']> | GraphQLResolveInfo>(
+    params?: FindParams<T, P>,
+  ): Promise<{ totalCount: number; records: Project<T['entity'], T['ast'], T['scalars'], P, T['types']>[] }>
   exists(params: FilterParams<T>): Promise<boolean>
   count(params?: FilterParams<T>): Promise<number>
   aggregate<A extends AggregateParams<T>>(params: A, args?: AggregatePostProcessing<T, A>): Promise<AggregateResults<T, A>>

--- a/src/dal/drivers/in-memory/dao.memory.ts
+++ b/src/dal/drivers/in-memory/dao.memory.ts
@@ -26,7 +26,10 @@ export class AbstractInMemoryDAO<T extends InMemoryDAOGenerics> extends Abstract
 
   protected async _findAll<P extends AnyProjection<T['projection']>>(params: FindParams<T, P>): Promise<PartialDeep<T['model']>[]> {
     const unorderedResults = (await this.entitiesArray(params.filter)).map((v) => v.record)
-    const results = (params.sorts ? sort(unorderedResults, params.sorts) : unorderedResults).slice(params.skip ?? 0, (params.skip ?? 0) + (params.limit ?? unorderedResults.length))
+    const results = (params.sorts ? sort(unorderedResults, params.sorts) : unorderedResults).slice(
+      params.skip ?? 0,
+      (params.skip ?? 0) + (params.limit === 'unlimited' ? unorderedResults.length : params.limit ?? this.pageSize),
+    )
     return results.map((r) => _.cloneDeep(r))
     // projection are ignored since there is no performance advance
   }
@@ -144,7 +147,7 @@ export class AbstractInMemoryDAO<T extends InMemoryDAOGenerics> extends Abstract
       }
     }
     const sorted = args?.sorts ? sort<T['model']>(filteredResult, args.sorts) : filteredResult
-    const result = sorted.slice(params.skip ?? 0, (params.skip ?? 0) + (params.limit ?? sorted.length))
+    const result = sorted.slice(params.skip ?? 0, (params.skip ?? 0) + (params.limit === 'unlimited' ? sorted.length : params.limit ?? this.pageSize))
     return (params.by ? result : result[0]) as AggregateResults<T, A>
   }
 

--- a/src/dal/drivers/no-sql/mongodb/dao.mongodb.ts
+++ b/src/dal/drivers/no-sql/mongodb/dao.mongodb.ts
@@ -63,7 +63,12 @@ export class AbstractMongoDBDAO<T extends MongoDBDAOGenerics> extends AbstractDA
       /*if (sort.length > 0 && !sort.map((v) => v[0]).includes(this.dbIdField)) { // see #288
         sort.push([this.dbIdField, 1])
       }*/
-      const options = { projection, sort, skip: params.skip, limit: params.limit ?? this.pageSize } as FindOptions
+      const options = {
+        projection,
+        sort,
+        skip: params.skip,
+        limit: params.limit === 'unlimited' ? undefined : params.limit ?? this.pageSize,
+      } as FindOptions
       return [
         async () => {
           if (params.limit === 0) {
@@ -137,7 +142,7 @@ export class AbstractMongoDBDAO<T extends MongoDBDAOGenerics> extends AbstractDA
       const filter = params.filter ? [{ $match: await this.buildFilter(params.filter) }] : []
       const having = args?.having ? [{ $match: mapObject(args.having, ([k, v]) => (typeof v === 'object' ? [[k, mapObject(v, ([fk, fv]) => [[`$${fk}`, fv]])]] : [[k, v]])) }] : []
       const skip = params.skip != null ? [{ $skip: params.skip }] : []
-      const limit = params.limit != null ? [{ $limit: params.limit }] : []
+      const limit = params.limit === 'unlimited' ? [] : [{ $limit: params.limit ?? this.pageSize }]
       const options = params.options ?? {}
       const pipeline = [...filter, { $group: { _id: groupId, ...aggregation } }, ...having, ...sort, ...skip, ...limit]
       return [

--- a/tests/in-memory/in-memory.test.ts
+++ b/tests/in-memory/in-memory.test.ts
@@ -90,6 +90,14 @@ test('nulls find', async () => {
   expect(users5.length).toBe(3)
 })
 
+test('unlimited', async () => {
+  for (let i = 0; i < 1000; i++) {
+    await dao.user.insertOne({ record: { live: true, firstName: i.toString() } })
+  }
+  const users = await dao.user.findAll({ limit: 'unlimited' })
+  expect(users.length).toBe(1000)
+})
+
 test('simple findOne', async () => {
   const u = await dao.user.insertOne({ record: { firstName: 'FirstName', lastName: 'LastName', live: true } })
   await dao.user.insertOne({ record: { firstName: 'FirstName1', lastName: 'LastName', live: true } })

--- a/tests/mongodb/dao.mock.ts
+++ b/tests/mongodb/dao.mock.ts
@@ -250,6 +250,17 @@ export type AST = {
       rawSorts: never
     }
   }
+  Test: {
+    fields: {
+      id: { type: 'scalar'; isList: false; astName: 'ID'; isRequired: true; isListElementRequired: false; isExcluded: false; isId: true; generationStrategy: 'db' }
+      name: { type: 'scalar'; isList: false; astName: 'String'; isRequired: false; isListElementRequired: false; isExcluded: false; isId: false; generationStrategy: 'undefined' }
+    }
+    driverSpecification: {
+      rawFilter: () => M.Filter<M.Document>
+      rawUpdate: () => M.UpdateFilter<M.Document>
+      rawSorts: () => M.Sort
+    }
+  }
   User: {
     fields: {
       amount: { type: 'scalar'; isList: false; astName: 'Decimal'; isRequired: false; isListElementRequired: false; isExcluded: false; isId: false; generationStrategy: 'undefined' }
@@ -336,6 +347,7 @@ export const schemas = {
   Organization: organizationSchema,
   Post: postSchema,
   PostMetadata: postMetadataSchema,
+  Test: testSchema,
   User: userSchema,
   UserCollection: userCollectionSchema,
   UsernamePasswordCredentials: usernamePasswordCredentialsSchema,
@@ -1564,6 +1576,85 @@ export function postMetadataSchema(): T.Schema<ScalarsSpecification> {
 
 export interface PostMetadataModel extends types.PostMetadata {}
 export interface PostMetadataPlainModel extends T.GenerateModel<'PostMetadata', AST, ScalarsSpecification, 'relation'> {}
+export function testSchema(): T.Schema<ScalarsSpecification> {
+  return {
+    id: {
+      type: 'scalar',
+      scalar: 'ID',
+      isId: true,
+      generationStrategy: 'db',
+      required: true,
+      alias: '_id',
+      directives: {},
+    },
+    name: {
+      type: 'scalar',
+      scalar: 'String',
+      directives: {},
+    },
+  }
+}
+
+type TestDAOGenerics<MetadataType, OperationMetadataType> = T.MongoDBDAOGenerics<
+  'Test',
+  AST,
+  ScalarsSpecification,
+  TestCachedTypes,
+  MetadataType,
+  OperationMetadataType,
+  EntityManager<MetadataType, OperationMetadataType>
+>
+export type TestDAOParams<MetadataType, OperationMetadataType> = Omit<
+  T.MongoDBDAOParams<TestDAOGenerics<MetadataType, OperationMetadataType>>,
+  'idGenerator' | 'idField' | 'schema' | 'idScalar' | 'idGeneration'
+>
+export type InMemoryTestDAOParams<MetadataType, OperationMetadataType> = Omit<
+  T.InMemoryDAOParams<TestDAOGenerics<MetadataType, OperationMetadataType>>,
+  'idGenerator' | 'idField' | 'schema' | 'idScalar' | 'idGeneration'
+>
+
+export type TestIdFields = T.IdFields<'Test', AST>
+export interface TestModel extends types.Test {}
+export interface TestInsert extends T.Insert<'Test', AST, ScalarsSpecification> {}
+export interface TestPlainModel extends T.GenerateModel<'Test', AST, ScalarsSpecification, 'relation'> {}
+export interface TestProjection extends T.Projection<'Test', AST> {}
+export interface TestUpdate extends T.Update<'Test', AST, ScalarsSpecification> {}
+export interface TestFilter extends T.Filter<'Test', AST, ScalarsSpecification> {}
+export interface TestSortElement extends T.SortElement<'Test', AST> {}
+export interface TestRelationsFindParams extends T.RelationsFindParams<'Test', AST, ScalarsSpecification> {}
+export type TestParams<P extends TestProjection> = T.Params<'Test', AST, ScalarsSpecification, P>
+export type TestProject<P extends TestProjection> = T.Project<'Test', AST, ScalarsSpecification, P>
+export type TestCachedTypes = T.CachedTypes<TestIdFields, TestModel, TestInsert, TestPlainModel, TestProjection, TestUpdate, TestFilter, TestSortElement, TestRelationsFindParams>
+
+export class TestDAO<MetadataType, OperationMetadataType> extends T.AbstractMongoDBDAO<TestDAOGenerics<MetadataType, OperationMetadataType>> {
+  public static projection<P extends T.Projection<'Test', AST>>(p: P) {
+    return p
+  }
+  public static mergeProjection<P1 extends T.Projection<'Test', AST>, P2 extends T.Projection<'Test', AST>>(p1: P1, p2: P2): T.SelectProjection<T.Projection<'Test', AST>, P1, P2> {
+    return T.mergeProjections(p1, p2) as T.SelectProjection<T.Projection<'Test', AST>, P1, P2>
+  }
+  public constructor(params: TestDAOParams<MetadataType, OperationMetadataType>) {
+    super({
+      ...params,
+      schema: testSchema(),
+    })
+  }
+}
+
+export class InMemoryTestDAO<MetadataType, OperationMetadataType> extends T.AbstractInMemoryDAO<TestDAOGenerics<MetadataType, OperationMetadataType>> {
+  public static projection<P extends T.Projection<'Test', AST>>(p: P) {
+    return p
+  }
+  public static mergeProjection<P1 extends T.Projection<'Test', AST>, P2 extends T.Projection<'Test', AST>>(p1: P1, p2: P2): T.SelectProjection<T.Projection<'Test', AST>, P1, P2> {
+    return T.mergeProjections(p1, p2) as T.SelectProjection<T.Projection<'Test', AST>, P1, P2>
+  }
+  public constructor(params: InMemoryTestDAOParams<MetadataType, OperationMetadataType>) {
+    super({
+      ...params,
+      schema: testSchema(),
+    })
+  }
+}
 export function userSchema(): T.Schema<ScalarsSpecification> {
   return {
     amount: {
@@ -1812,11 +1903,12 @@ export type EntityManagerParams<MetadataType, OperationMetadataType, Permissions
     mockedEntity?: Pick<Partial<MockedEntityDAOParams<MetadataType, OperationMetadataType>>, 'middlewares' | 'metadata'>
     organization?: Pick<Partial<OrganizationDAOParams<MetadataType, OperationMetadataType>>, 'idGenerator' | 'middlewares' | 'metadata'>
     post?: Pick<Partial<PostDAOParams<MetadataType, OperationMetadataType>>, 'idGenerator' | 'middlewares' | 'metadata'>
+    test?: Pick<Partial<TestDAOParams<MetadataType, OperationMetadataType>>, 'middlewares' | 'metadata'>
     user?: Pick<Partial<UserDAOParams<MetadataType, OperationMetadataType>>, 'idGenerator' | 'middlewares' | 'metadata'>
   }
   mongodb: Record<'default', M.Db | 'mock'>
   scalars?: T.UserInputDriverDataTypeAdapterMap<ScalarsSpecification, 'mongo'>
-  log?: T.LogInput<'Address' | 'Audit' | 'City' | 'DefaultFieldsEntity' | 'Device' | 'Dog' | 'Hotel' | 'MockedEntity' | 'Organization' | 'Post' | 'User'>
+  log?: T.LogInput<'Address' | 'Audit' | 'City' | 'DefaultFieldsEntity' | 'Device' | 'Dog' | 'Hotel' | 'MockedEntity' | 'Organization' | 'Post' | 'Test' | 'User'>
   awaitLog?: boolean
   security?: T.EntityManagerSecurtyPolicy<DAOGenericsMap<MetadataType, OperationMetadataType>, OperationMetadataType, Permissions, SecurityDomain>
 }
@@ -1837,6 +1929,7 @@ export class EntityManager<
   private _mockedEntity: MockedEntityDAO<MetadataType, OperationMetadataType> | undefined
   private _organization: OrganizationDAO<MetadataType, OperationMetadataType> | undefined
   private _post: PostDAO<MetadataType, OperationMetadataType> | undefined
+  private _test: TestDAO<MetadataType, OperationMetadataType> | undefined
   private _user: UserDAO<MetadataType, OperationMetadataType> | undefined
 
   private params: EntityManagerParams<MetadataType, OperationMetadataType, Permissions, SecurityDomain>
@@ -1846,7 +1939,7 @@ export class EntityManager<
 
   private middlewares: (EntityManagerMiddleware<MetadataType, OperationMetadataType> | GroupMiddleware<any, MetadataType, OperationMetadataType>)[]
 
-  private logger?: T.LogFunction<'Address' | 'Audit' | 'City' | 'DefaultFieldsEntity' | 'Device' | 'Dog' | 'Hotel' | 'MockedEntity' | 'Organization' | 'Post' | 'User'>
+  private logger?: T.LogFunction<'Address' | 'Audit' | 'City' | 'DefaultFieldsEntity' | 'Device' | 'Dog' | 'Hotel' | 'MockedEntity' | 'Organization' | 'Post' | 'Test' | 'User'>
 
   get address(): AddressDAO<MetadataType, OperationMetadataType> {
     if (!this._address) {
@@ -2163,6 +2256,35 @@ export class EntityManager<
     }
     return this._post
   }
+  get test(): TestDAO<MetadataType, OperationMetadataType> {
+    if (!this._test) {
+      const db = this.mongodb.default
+      this._test =
+        db === 'mock'
+          ? (new InMemoryTestDAO({
+              entityManager: this,
+              datasource: null,
+              metadata: this.metadata,
+              ...this.overrides?.test,
+              middlewares: [...(this.overrides?.test?.middlewares || []), ...(selectMiddleware('test', this.middlewares) as T.DAOMiddleware<TestDAOGenerics<MetadataType, OperationMetadataType>>[])],
+              name: 'Test',
+              logger: this.logger,
+              awaitLog: this.params.awaitLog,
+            }) as unknown as TestDAO<MetadataType, OperationMetadataType>)
+          : new TestDAO({
+              entityManager: this,
+              datasource: 'default',
+              metadata: this.metadata,
+              ...this.overrides?.test,
+              collection: db.collection('tests'),
+              middlewares: [...(this.overrides?.test?.middlewares || []), ...(selectMiddleware('test', this.middlewares) as T.DAOMiddleware<TestDAOGenerics<MetadataType, OperationMetadataType>>[])],
+              name: 'Test',
+              logger: this.logger,
+              awaitLog: this.params.awaitLog,
+            })
+    }
+    return this._test
+  }
   get user(): UserDAO<MetadataType, OperationMetadataType> {
     if (!this._user) {
       const db = this.mongodb.default
@@ -2245,6 +2367,7 @@ export class EntityManager<
         hotel: M.Collection<M.Document> | null
         organization: M.Collection<M.Document> | null
         post: M.Collection<M.Document> | null
+        test: M.Collection<M.Document> | null
         user: M.Collection<M.Document> | null
       },
     ) => Promise<T>,
@@ -2261,6 +2384,7 @@ export class EntityManager<
         hotel: this.mongodb.default === 'mock' ? null : this.mongodb.default.collection('hotels'),
         organization: this.mongodb.default === 'mock' ? null : this.mongodb.default.collection('organizations'),
         post: this.mongodb.default === 'mock' ? null : this.mongodb.default.collection('posts'),
+        test: this.mongodb.default === 'mock' ? null : this.mongodb.default.collection('tests'),
         user: this.mongodb.default === 'mock' ? null : this.mongodb.default.collection('users'),
       },
     )
@@ -2283,6 +2407,7 @@ type DAOGenericsMap<MetadataType, OperationMetadataType> = {
   mockedEntity: MockedEntityDAOGenerics<MetadataType, OperationMetadataType>
   organization: OrganizationDAOGenerics<MetadataType, OperationMetadataType>
   post: PostDAOGenerics<MetadataType, OperationMetadataType>
+  test: TestDAOGenerics<MetadataType, OperationMetadataType>
   user: UserDAOGenerics<MetadataType, OperationMetadataType>
 }
 type DAOGenericsUnion<MetadataType, OperationMetadataType> = DAOGenericsMap<MetadataType, OperationMetadataType>[DAOName]
@@ -2345,12 +2470,13 @@ export type EntityManagerTypes<MetadataType = never, OperationMetadataType = nev
       mockedEntity?: Pick<Partial<MockedEntityDAOParams<MetadataType, OperationMetadataType>>, 'middlewares' | 'metadata'>
       organization?: Pick<Partial<OrganizationDAOParams<MetadataType, OperationMetadataType>>, 'idGenerator' | 'middlewares' | 'metadata'>
       post?: Pick<Partial<PostDAOParams<MetadataType, OperationMetadataType>>, 'idGenerator' | 'middlewares' | 'metadata'>
+      test?: Pick<Partial<TestDAOParams<MetadataType, OperationMetadataType>>, 'middlewares' | 'metadata'>
       user?: Pick<Partial<UserDAOParams<MetadataType, OperationMetadataType>>, 'idGenerator' | 'middlewares' | 'metadata'>
     }
     mongodb: Record<'default', M.Db | 'mock'>
 
     scalars: T.UserInputDriverDataTypeAdapterMap<ScalarsSpecification, 'mongo'>
-    log: T.LogInput<'Address' | 'Audit' | 'City' | 'DefaultFieldsEntity' | 'Device' | 'Dog' | 'Hotel' | 'MockedEntity' | 'Organization' | 'Post' | 'User'>
+    log: T.LogInput<'Address' | 'Audit' | 'City' | 'DefaultFieldsEntity' | 'Device' | 'Dog' | 'Hotel' | 'MockedEntity' | 'Organization' | 'Post' | 'Test' | 'User'>
     security: T.EntityManagerSecurtyPolicy<DAOGenericsMap<MetadataType, OperationMetadataType>, OperationMetadataType, Permissions, SecurityDomain>
   }
   security: {

--- a/tests/mongodb/models.mock.ts
+++ b/tests/mongodb/models.mock.ts
@@ -169,6 +169,12 @@ export enum State {
   INACTIVE = 'INACTIVE',
 }
 
+export type Test = {
+  __typename?: 'Test'
+  id: Scalars['ID']
+  name?: Maybe<Scalars['String']>
+}
+
 export type User = {
   __typename?: 'User'
   amount?: Maybe<Scalars['Decimal']>

--- a/tests/mongodb/schema.graphql
+++ b/tests/mongodb/schema.graphql
@@ -164,3 +164,8 @@ type EmbeddedUser4 {
 type EmbeddedUser5 {
   userId: ID
 }
+
+type Test @entity @mongodb {
+  id: ID! @id(from: "db") @alias(value: "_id")
+  name: String
+}

--- a/tests/sql/sql.test.ts
+++ b/tests/sql/sql.test.ts
@@ -253,6 +253,14 @@ test('nulls find', async () => {
   expect(users5.length).toBe(3)
 })
 
+test('unlimited', async () => {
+  for (let i = 0; i < 1000; i++) {
+    await dao.user.insertOne({ record: { live: true, firstName: i.toString() } })
+  }
+  const users = await dao.user.findAll({ limit: 'unlimited' })
+  expect(users.length).toBe(1000)
+})
+
 test('simple findOne multiple filter', async () => {
   await dao.user.insertOne({ record: { firstName: '1', lastName: '2', live: true } })
   await dao.user.insertOne({ record: { firstName: '2', lastName: '2', live: true } })


### PR DESCRIPTION
feat: closes #365

example: 
```typescript
const users = await dao.user.findAll({ limit: 'unlimited' })
```